### PR TITLE
Parameterising `ProtocolParameters` and `ProtocolParametersUpdate`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library internal
                         Cardano.Api.Domain.Common
                         Cardano.Api.Domain.CostModel
                         Cardano.Api.Domain.Errors.ProtocolParametersError
+                        Cardano.Api.Domain.ExecutionUnitPrices
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -58,7 +58,7 @@ library internal
                         Cardano.Api.Domain.CostModel
                         Cardano.Api.Domain.EpochNo
                         Cardano.Api.Domain.Errors.ProtocolParametersError
-                        Cardano.Api.Domain.ExecutionUnitPrices
+                        Cardano.Api.Domain.LegacyExecutionUnitPrices
                         Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.Lovelace
                         Cardano.Api.Domain.PraosNonce

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.AlonzoEraOnwards
+                        Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
+                        Cardano.Api.Feature.ShelleyToMaryEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis
                         Cardano.Api.GenesisParameters

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Domain.Lovelace
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.Domain.ProtocolParameters
+                        Cardano.Api.Domain.ProtocolParametersUpdate
                         Cardano.Api.Domain.ProtVer
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -56,6 +56,7 @@ library internal
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.Domain.Common
                         Cardano.Api.Domain.CostModel
+                        Cardano.Api.Domain.Errors.ProtocolParametersError
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -63,6 +63,7 @@ library internal
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Fees
                         Cardano.Api.Genesis

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -55,6 +55,7 @@ library internal
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.Domain.Common
+                        Cardano.Api.Domain.CostModel
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -54,6 +54,7 @@ library internal
                         Cardano.Api.Convenience.Construction
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
+                        Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
@@ -62,6 +63,7 @@ library internal
                         Cardano.Api.Eras.InAnyEra
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnly
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,7 @@ library internal
                         Cardano.Api.Domain.Errors.ProtocolParametersError
                         Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.ExecutionUnitPrices
+                        Cardano.Api.Domain.Lovelace
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -59,6 +59,7 @@ library internal
                         Cardano.Api.Eras
                         Cardano.Api.Eras.Constraints
                         Cardano.Api.Eras.Core
+                        Cardano.Api.Eras.InAnyEra
                         Cardano.Api.Error
                         Cardano.Api.Feature
                         Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library internal
                         Cardano.Api.Domain.ExecutionUnitPrices
                         Cardano.Api.Domain.Lovelace
                         Cardano.Api.Domain.PraosNonce
+                        Cardano.Api.Domain.ProtVer
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras
@@ -166,6 +167,7 @@ library internal
                       , deepseq
                       , directory
                       , either
+                      , FailT
                       , filepath
                       , formatting
                       , iproute

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -57,6 +57,7 @@ library internal
                         Cardano.Api.Domain.Common
                         Cardano.Api.Domain.CostModel
                         Cardano.Api.Domain.Errors.ProtocolParametersError
+                        Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.ExecutionUnitPrices
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -58,10 +58,11 @@ library internal
                         Cardano.Api.Domain.CostModel
                         Cardano.Api.Domain.EpochNo
                         Cardano.Api.Domain.Errors.ProtocolParametersError
-                        Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.ExecutionUnitPrices
+                        Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.Lovelace
                         Cardano.Api.Domain.PraosNonce
+                        Cardano.Api.Domain.ProtocolParameters
                         Cardano.Api.Domain.ProtVer
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -56,6 +56,7 @@ library internal
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.Domain.Common
                         Cardano.Api.Domain.CostModel
+                        Cardano.Api.Domain.EpochNo
                         Cardano.Api.Domain.Errors.ProtocolParametersError
                         Cardano.Api.Domain.ExecutionUnits
                         Cardano.Api.Domain.ExecutionUnitPrices

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -62,6 +62,7 @@ library internal
                         Cardano.Api.Eras.InAnyEra
                         Cardano.Api.Error
                         Cardano.Api.Feature
+                        Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -65,6 +65,7 @@ library internal
                         Cardano.Api.Feature.AlonzoEraOnwards
                         Cardano.Api.Feature.BabbageEraOnwards
                         Cardano.Api.Feature.ConwayEraOnwards
+                        Cardano.Api.Feature.ShelleyToAllegraEra
                         Cardano.Api.Feature.ShelleyToAlonzoEra
                         Cardano.Api.Feature.ShelleyToBabbageEra
                         Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -54,6 +54,7 @@ library internal
                         Cardano.Api.Convenience.Construction
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
+                        Cardano.Api.Domain.Common
                         Cardano.Api.Domain.PraosNonce
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -52,7 +52,7 @@ module Test.Gen.Cardano.Api.Typed
   , genAssetName
   , genAssetId
   , genEpochNo
-  , genExecutionUnitPrices
+  , genLegacyExecutionUnitPrices
   , genExecutionUnits
   , genHashScriptData
   , genKESPeriod
@@ -922,7 +922,7 @@ genProtocolParameters era = do
   protocolParamCostModels <- pure mempty
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
-  protocolParamPrices <- Gen.maybe genExecutionUnitPrices
+  protocolParamPrices <- Gen.maybe genLegacyExecutionUnitPrices
   protocolParamMaxTxExUnits <- Gen.maybe genExecutionUnits
   protocolParamMaxBlockExUnits <- Gen.maybe genExecutionUnits
   protocolParamMaxValueSize <- Gen.maybe genNat
@@ -959,7 +959,7 @@ genValidProtocolParameters era =
     --TODO: Babbage figure out how to deal with
     -- asymmetric cost model JSON instances
     -- 'Just' is required by checks in Cardano.Api.ProtocolParameters
-    <*> fmap Just genExecutionUnitPrices
+    <*> fmap Just genLegacyExecutionUnitPrices
     <*> fmap Just genExecutionUnits
     <*> fmap Just genExecutionUnits
     <*> fmap Just genNat
@@ -990,7 +990,7 @@ genProtocolParametersUpdate era = do
   let protocolUpdateCostModels = mempty -- genCostModels
   --TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
-  protocolUpdatePrices              <- Gen.maybe genExecutionUnitPrices
+  protocolUpdatePrices              <- Gen.maybe genLegacyExecutionUnitPrices
   protocolUpdateMaxTxExUnits        <- Gen.maybe genExecutionUnits
   protocolUpdateMaxBlockExUnits     <- Gen.maybe genExecutionUnits
   protocolUpdateMaxValueSize        <- Gen.maybe genNat
@@ -1036,8 +1036,8 @@ genExecutionUnits :: Gen ExecutionUnits
 genExecutionUnits = ExecutionUnits <$> Gen.integral (Range.constant 0 1000)
                                    <*> Gen.integral (Range.constant 0 1000)
 
-genExecutionUnitPrices :: Gen ExecutionUnitPrices
-genExecutionUnitPrices = ExecutionUnitPrices <$> genRational <*> genRational
+genLegacyExecutionUnitPrices :: Gen LegacyExecutionUnitPrices
+genLegacyExecutionUnitPrices = LegacyExecutionUnitPrices <$> genRational <*> genRational
 
 genTxOutDatumHashTxContext :: CardanoEra era -> Gen (TxOutDatum CtxTx era)
 genTxOutDatumHashTxContext era = case era of

--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -78,7 +78,7 @@ module Cardano.Api.Address (
   ) where
 
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron

--- a/cardano-api/internal/Cardano/Api/Block.hs
+++ b/cardano-api/internal/Cardano/Api/Block.hs
@@ -51,7 +51,8 @@ module Cardano.Api.Block (
     makeChainTip,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImpredicativeTypes #-}
@@ -74,7 +73,8 @@ module Cardano.Api.Certificate (
 import           Cardano.Api.Address
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Governance.Actions.VotingProcedure

--- a/cardano-api/internal/Cardano/Api/Convenience/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Constraints.hs
@@ -8,7 +8,7 @@ module Cardano.Api.Convenience.Constraints (
   ) where
 
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 getIsCardanoEraConstraint :: CardanoEra era -> (IsCardanoEra era => a) -> a
 getIsCardanoEraConstraint ByronEra f = f

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -15,7 +15,7 @@ module Cardano.Api.Convenience.Construction (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Fees
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Convenience.Query (
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Constraints
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.IO
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad

--- a/cardano-api/internal/Cardano/Api/DRepMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/DRepMetadata.hs
@@ -15,7 +15,7 @@ module Cardano.Api.DRepMetadata (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Domain/Common.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/Common.hs
@@ -1,0 +1,9 @@
+module Cardano.Api.Domain.Common
+  ( ProtocolParameterName
+  , ProtocolParameterVersion
+  ) where
+
+import           Numeric.Natural
+
+type ProtocolParameterName = String
+type ProtocolParameterVersion = Natural

--- a/cardano-api/internal/Cardano/Api/Domain/CostModel.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/CostModel.hs
@@ -16,6 +16,7 @@ module Cardano.Api.Domain.CostModel
   , fromAlonzoScriptLanguage
   , toAlonzoCostModel
   , fromAlonzoCostModel
+  , boundRationalEither
   ) where
 
 import           Cardano.Api.Domain.Common
@@ -26,10 +27,12 @@ import           Cardano.Api.SerialiseCBOR
 
 import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.BaseTypes as Ledger
 
 import           Data.Aeson (FromJSON (..), ToJSON (..))
 import           Data.Bifunctor (bimap, first)
 import           Data.Data (Data)
+import           Data.Either.Combinators (maybeToRight)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Text.PrettyBy.Default (display)
@@ -100,3 +103,9 @@ toAlonzoCostModel (CostModel m) l = first (PpceInvalidCostModel (CostModel m)) $
 
 fromAlonzoCostModel :: Alonzo.CostModel -> CostModel
 fromAlonzoCostModel m = CostModel $ Alonzo.getCostModelParams m
+
+boundRationalEither :: Ledger.BoundedRational b
+                    => String
+                    -> Rational
+                    -> Either ProtocolParametersConversionError b
+boundRationalEither name r = maybeToRight (PpceOutOfBounds name r) $ Ledger.boundRational r

--- a/cardano-api/internal/Cardano/Api/Domain/CostModel.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/CostModel.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Domain.CostModel
+  ( CostModel(..)
+  , CostModels(..)
+  , ProtocolParametersConversionError(..)
+  , toAlonzoCostModels
+  , fromAlonzoCostModels
+  , toAlonzoScriptLanguage
+  , fromAlonzoScriptLanguage
+  , toAlonzoCostModel
+  , fromAlonzoCostModel
+  ) where
+
+import           Cardano.Api.Domain.Common
+import           Cardano.Api.Error
+import           Cardano.Api.Orphans ()
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseCBOR
+
+import qualified Cardano.Ledger.Alonzo.Language as Alonzo
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+
+import           Data.Aeson (FromJSON (..), ToJSON (..))
+import           Data.Bifunctor (bimap, first)
+import           Data.Data (Data)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Text.PrettyBy.Default (display)
+
+-- | Script cost models
+newtype CostModel = CostModel [Integer]
+  deriving (Eq, Show, Data)
+  deriving newtype (ToCBOR, FromCBOR)
+
+newtype CostModels = CostModels { unCostModels :: Map AnyPlutusScriptVersion CostModel }
+  deriving (Eq, Show)
+
+instance FromJSON CostModels where
+  parseJSON v = CostModels . fromAlonzoCostModels <$> parseJSON v
+
+instance ToJSON CostModels where
+  toJSON (CostModels costModels) =
+    case toAlonzoCostModels costModels of
+      Left err -> error $ displayError err
+      Right ledgerCostModels -> toJSON ledgerCostModels
+
+data ProtocolParametersConversionError
+  = PpceOutOfBounds !ProtocolParameterName !Rational
+  | PpceVersionInvalid !ProtocolParameterVersion
+  | PpceInvalidCostModel !CostModel !Alonzo.CostModelApplyError
+  | PpceMissingParameter !ProtocolParameterName
+  deriving (Eq, Show, Data)
+
+instance Error ProtocolParametersConversionError where
+  displayError = \case
+    PpceOutOfBounds name r -> "Value for '" <> name <> "' is outside of bounds: " <> show (fromRational r :: Double)
+    PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
+    PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
+    PpceMissingParameter name -> "Missing parameter: " <> name
+
+toAlonzoCostModels
+  :: Map AnyPlutusScriptVersion CostModel
+  -> Either ProtocolParametersConversionError Alonzo.CostModels
+toAlonzoCostModels m = do
+  f <- mapM conv $ Map.toList m
+  Right (Alonzo.emptyCostModels { Alonzo.costModelsValid = Map.fromList f })
+ where
+  conv :: (AnyPlutusScriptVersion, CostModel) -> Either ProtocolParametersConversionError (Alonzo.Language, Alonzo.CostModel)
+  conv (anySVer, cModel) = do
+    alonzoCostModel <- toAlonzoCostModel cModel (toAlonzoScriptLanguage anySVer)
+    Right (toAlonzoScriptLanguage anySVer, alonzoCostModel)
+
+fromAlonzoCostModels
+  :: Alonzo.CostModels
+  -> Map AnyPlutusScriptVersion CostModel
+fromAlonzoCostModels (Alonzo.CostModels m _ _) =
+    Map.fromList
+  . map (bimap fromAlonzoScriptLanguage fromAlonzoCostModel)
+  $ Map.toList m
+
+toAlonzoScriptLanguage :: AnyPlutusScriptVersion -> Alonzo.Language
+toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV1) = Alonzo.PlutusV1
+toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV2) = Alonzo.PlutusV2
+toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV3) = Alonzo.PlutusV3
+
+fromAlonzoScriptLanguage :: Alonzo.Language -> AnyPlutusScriptVersion
+fromAlonzoScriptLanguage Alonzo.PlutusV1 = AnyPlutusScriptVersion PlutusScriptV1
+fromAlonzoScriptLanguage Alonzo.PlutusV2 = AnyPlutusScriptVersion PlutusScriptV2
+fromAlonzoScriptLanguage Alonzo.PlutusV3 = AnyPlutusScriptVersion PlutusScriptV3
+
+toAlonzoCostModel :: CostModel -> Alonzo.Language -> Either ProtocolParametersConversionError Alonzo.CostModel
+toAlonzoCostModel (CostModel m) l = first (PpceInvalidCostModel (CostModel m)) $ Alonzo.mkCostModel l m
+
+fromAlonzoCostModel :: Alonzo.CostModel -> CostModel
+fromAlonzoCostModel m = CostModel $ Alonzo.getCostModelParams m

--- a/cardano-api/internal/Cardano/Api/Domain/EpochNo.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/EpochNo.hs
@@ -1,0 +1,5 @@
+module Cardano.Api.Domain.EpochNo
+  ( EpochNo(..)
+  ) where
+
+import           Cardano.Slotting.Slot (EpochNo (..))

--- a/cardano-api/internal/Cardano/Api/Domain/Errors/ProtocolParametersError.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/Errors/ProtocolParametersError.hs
@@ -1,0 +1,24 @@
+module Cardano.Api.Domain.Errors.ProtocolParametersError
+  ( ProtocolParametersError(..)
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Error
+
+data ProtocolParametersError
+  = PParamsErrorMissingMinUTxoValue !AnyCardanoEra
+  | PParamsErrorMissingAlonzoProtocolParameter
+  deriving (Show)
+
+instance Error ProtocolParametersError where
+  displayError (PParamsErrorMissingMinUTxoValue (AnyCardanoEra era)) = mconcat
+    [ "The " <> show era <> " protocol parameters value is missing the following "
+    , "field: MinUTxoValue. Did you intend to use a " <> show era <> " protocol "
+    , "parameters value?"
+    ]
+  displayError PParamsErrorMissingAlonzoProtocolParameter = mconcat
+    [ "The Alonzo era protocol parameters in use is missing one or more of the "
+    , "following fields: UTxOCostPerWord, CostModels, Prices, MaxTxExUnits, "
+    , "MaxBlockExUnits, MaxValueSize, CollateralPercent, MaxCollateralInputs. Did "
+    , "you intend to use an Alonzo era protocol parameters value?"
+    ]

--- a/cardano-api/internal/Cardano/Api/Domain/ExecutionUnitPrices.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ExecutionUnitPrices.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Script execution unit prices and cost models
+module Cardano.Api.Domain.ExecutionUnitPrices
+  ( ExecutionUnitPrices(..)
+  , toAlonzoPrices
+  , fromAlonzoPrices
+  ) where
+
+import           Cardano.Api.Domain.CostModel
+import           Cardano.Api.Json (toRationalJSON)
+import           Cardano.Api.Orphans ()
+import           Cardano.Api.SerialiseCBOR
+
+import qualified Cardano.Binary as CBOR
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+import qualified Cardano.Ledger.BaseTypes as Ledger
+
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+
+
+-- | The prices for 'ExecutionUnits' as a fraction of a 'Lovelace'.
+--
+-- These are used to determine the fee for the use of a script within a
+-- transaction, based on the 'ExecutionUnits' needed by the use of the script.
+data ExecutionUnitPrices = ExecutionUnitPrices
+  { priceExecutionSteps  :: Rational
+  , priceExecutionMemory :: Rational
+  }
+  deriving (Eq, Show)
+
+instance ToCBOR ExecutionUnitPrices where
+  toCBOR ExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
+      CBOR.encodeListLen 2
+   <> toCBOR priceExecutionSteps
+   <> toCBOR priceExecutionMemory
+
+instance FromCBOR ExecutionUnitPrices where
+  fromCBOR = do
+    CBOR.enforceSize "ExecutionUnitPrices" 2
+    ExecutionUnitPrices
+      <$> fromCBOR
+      <*> fromCBOR
+
+instance ToJSON ExecutionUnitPrices where
+  toJSON ExecutionUnitPrices{priceExecutionSteps, priceExecutionMemory} =
+    object
+      [ "priceSteps"  .= toRationalJSON priceExecutionSteps
+      , "priceMemory" .= toRationalJSON priceExecutionMemory
+      ]
+
+instance FromJSON ExecutionUnitPrices where
+  parseJSON =
+    withObject "ExecutionUnitPrices" $ \o ->
+      ExecutionUnitPrices
+        <$> o .: "priceSteps"
+        <*> o .: "priceMemory"
+
+toAlonzoPrices :: ExecutionUnitPrices -> Either ProtocolParametersConversionError Alonzo.Prices
+toAlonzoPrices
+    ExecutionUnitPrices
+    { priceExecutionSteps
+    , priceExecutionMemory
+    } = do
+  prSteps <- boundRationalEither "Steps" priceExecutionSteps
+  prMem   <- boundRationalEither "Mem" priceExecutionMemory
+
+  return Alonzo.Prices
+    { Alonzo.prSteps
+    , Alonzo.prMem
+    }
+
+fromAlonzoPrices :: Alonzo.Prices -> ExecutionUnitPrices
+fromAlonzoPrices Alonzo.Prices{Alonzo.prSteps, Alonzo.prMem} =
+  ExecutionUnitPrices
+  { priceExecutionSteps  = Ledger.unboundRational prSteps
+  , priceExecutionMemory = Ledger.unboundRational prMem
+  }

--- a/cardano-api/internal/Cardano/Api/Domain/ExecutionUnits.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ExecutionUnits.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Domain.ExecutionUnits
+  ( ExecutionUnits (..)
+  , toAlonzoExUnits
+  , fromAlonzoExUnits
+  ) where
+
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseJSON
+
+import qualified Cardano.Binary as CBOR
+import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
+
+import           Data.Aeson (object, (.:), (.=))
+import qualified Data.Aeson as Aeson
+import           Numeric.Natural (Natural)
+
+-- | Script execution units.
+--
+-- The units for how long a script executes for and how much memory it uses.
+-- This is used to declare the resources used by a particular use of a script.
+--
+-- This type is also used to describe the limits for the maximum overall
+-- execution units per transaction or per block.
+--
+data ExecutionUnits = ExecutionUnits
+  { -- | This corresponds roughly to the time to execute a script.
+    executionSteps  :: Natural
+  , -- | This corresponds roughly to the peak memory used during script
+    -- execution.
+    executionMemory :: Natural
+  }
+  deriving (Eq, Show)
+
+instance ToCBOR ExecutionUnits where
+  toCBOR ExecutionUnits {executionSteps, executionMemory} =
+      CBOR.encodeListLen 2
+   <> toCBOR executionSteps
+   <> toCBOR executionMemory
+
+instance FromCBOR ExecutionUnits where
+  fromCBOR = do
+    CBOR.enforceSize "ExecutionUnits" 2
+    ExecutionUnits
+      <$> fromCBOR
+      <*> fromCBOR
+
+instance ToJSON ExecutionUnits where
+  toJSON ExecutionUnits{executionSteps, executionMemory} =
+    object [ "steps"  .= executionSteps
+           , "memory" .= executionMemory ]
+
+instance FromJSON ExecutionUnits where
+  parseJSON =
+    Aeson.withObject "ExecutionUnits" $ \o ->
+      ExecutionUnits
+        <$> o .: "steps"
+        <*> o .: "memory"
+
+toAlonzoExUnits :: ExecutionUnits -> Alonzo.ExUnits
+toAlonzoExUnits ExecutionUnits{executionSteps, executionMemory} =
+  Alonzo.ExUnits
+  { Alonzo.exUnitsSteps = executionSteps
+  , Alonzo.exUnitsMem   = executionMemory
+  }
+
+fromAlonzoExUnits :: Alonzo.ExUnits -> ExecutionUnits
+fromAlonzoExUnits Alonzo.ExUnits{Alonzo.exUnitsSteps, Alonzo.exUnitsMem} =
+  ExecutionUnits
+  { executionSteps  = exUnitsSteps
+  , executionMemory = exUnitsMem
+  }

--- a/cardano-api/internal/Cardano/Api/Domain/Lovelace.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/Lovelace.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module Cardano.Api.Domain.Lovelace
+  ( Lovelace(..)
+  , toByronLovelace
+  , fromByronLovelace
+  , toShelleyLovelace
+  , fromShelleyLovelace
+  , fromShelleyDeltaLovelace
+  , reLedgerCoinL
+  , unLedgerCoinL
+  ) where
+
+import           Cardano.Api.SerialiseCBOR
+
+import qualified Cardano.Chain.Common as Byron
+import qualified Cardano.Ledger.Coin as Shelley
+
+import           Data.Aeson (FromJSON, ToJSON)
+import           Lens.Micro (Lens', lens)
+
+newtype Lovelace = Lovelace Integer
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (Enum, Real, Integral, Num, ToJSON, FromJSON, ToCBOR, FromCBOR)
+
+instance Semigroup Lovelace where
+  Lovelace a <> Lovelace b = Lovelace (a + b)
+
+instance Monoid Lovelace where
+  mempty = Lovelace 0
+
+toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
+toByronLovelace (Lovelace x) =
+    case Byron.integerToLovelace x of
+      Left  _  -> Nothing
+      Right x' -> Just x'
+
+fromByronLovelace :: Byron.Lovelace -> Lovelace
+fromByronLovelace = Lovelace . Byron.lovelaceToInteger
+
+toShelleyLovelace :: Lovelace -> Shelley.Coin
+toShelleyLovelace (Lovelace l) = Shelley.Coin l
+--TODO: validate bounds
+
+fromShelleyLovelace :: Shelley.Coin -> Lovelace
+fromShelleyLovelace (Shelley.Coin l) = Lovelace l
+
+fromShelleyDeltaLovelace :: Shelley.DeltaCoin -> Lovelace
+fromShelleyDeltaLovelace (Shelley.DeltaCoin d) = Lovelace d
+
+reLedgerCoinL :: Lens' Lovelace Shelley.Coin
+reLedgerCoinL = lens toShelleyLovelace (const fromShelleyLovelace)
+
+unLedgerCoinL :: Lens' Shelley.Coin Lovelace
+unLedgerCoinL = lens fromShelleyLovelace (const toShelleyLovelace)

--- a/cardano-api/internal/Cardano/Api/Domain/PraosNonce.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/PraosNonce.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Domain.PraosNonce
+  ( PraosNonce (..)
+  , makePraosNonce
+  , toLedgerNonce
+  , fromLedgerNonce
+
+  , reLedgerNonceL
+  , unLedgerNonceL
+  , rePraosNonceHashL
+  , unPraosNonceHashL
+  ) where
+
+import           Cardano.Api.Address
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Orphans ()
+import           Cardano.Api.SerialiseCBOR
+import           Cardano.Api.SerialiseRaw
+import           Cardano.Api.SerialiseUsing
+
+import qualified Cardano.Crypto.Hash.Class as Crypto
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Keys as Ledger
+
+import           Data.Aeson (FromJSON (..), ToJSON (..))
+import           Data.ByteString (ByteString)
+import           Data.Either.Combinators (maybeToRight)
+import           Data.String (IsString)
+import           GHC.Generics
+import           Lens.Micro (Lens', lens)
+
+newtype PraosNonce = PraosNonce
+  { praosNonceHash :: Ledger.Hash StandardCrypto ByteString
+  }
+  deriving stock (Eq, Ord, Generic)
+  deriving (Show, IsString)   via UsingRawBytesHex PraosNonce
+  deriving (ToJSON, FromJSON) via UsingRawBytesHex PraosNonce
+  deriving (ToCBOR, FromCBOR) via UsingRawBytes    PraosNonce
+
+instance HasTypeProxy PraosNonce where
+    data AsType PraosNonce = AsPraosNonce
+    proxyToAsType _ = AsPraosNonce
+
+instance SerialiseAsRawBytes PraosNonce where
+    serialiseToRawBytes (PraosNonce h) =
+      Crypto.hashToBytes h
+
+    deserialiseFromRawBytes AsPraosNonce bs =
+      maybeToRight (SerialiseAsRawBytesError "Unable to deserialise PraosNonce") $
+        PraosNonce <$> Crypto.hashFromBytes bs
+
+makePraosNonce :: ByteString -> PraosNonce
+makePraosNonce = PraosNonce . Crypto.hashWith id
+
+toLedgerNonce :: Maybe PraosNonce -> Ledger.Nonce
+toLedgerNonce Nothing               = Ledger.NeutralNonce
+toLedgerNonce (Just (PraosNonce h)) = Ledger.Nonce (Crypto.castHash h)
+
+fromLedgerNonce :: Ledger.Nonce -> Maybe PraosNonce
+fromLedgerNonce Ledger.NeutralNonce = Nothing
+fromLedgerNonce (Ledger.Nonce h)    = Just (PraosNonce (Crypto.castHash h))
+
+reLedgerNonceL :: Lens' (Maybe PraosNonce) Ledger.Nonce
+reLedgerNonceL = lens toLedgerNonce (const fromLedgerNonce)
+
+unLedgerNonceL :: Lens' Ledger.Nonce (Maybe PraosNonce)
+unLedgerNonceL = lens fromLedgerNonce (const toLedgerNonce)
+
+rePraosNonceHashL :: Lens' PraosNonce (Ledger.Hash StandardCrypto ByteString)
+rePraosNonceHashL = lens praosNonceHash (const PraosNonce)
+
+unPraosNonceHashL :: Lens' (Ledger.Hash StandardCrypto ByteString) PraosNonce
+unPraosNonceHashL = lens PraosNonce (const praosNonceHash)

--- a/cardano-api/internal/Cardano/Api/Domain/ProtVer.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtVer.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Api.Domain.ProtVer
+  ( ProtVer(..)
+  , reLedgerProtVerL
+  , unLedgerProtVerL
+  ) where
+
+import qualified Cardano.Ledger.BaseTypes as Ledger
+
+import           Control.Monad.Trans.Fail.String (runFail)
+import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
+import           Lens.Micro (Lens', lens)
+import           Numeric.Natural (Natural)
+
+newtype ProtVer = ProtVer
+  { unProtVer :: Ledger.ProtVer
+  }
+
+instance FromJSON ProtVer where
+  parseJSON v =
+    flip (withObject "ProtocolParameters") v $ \o -> do
+      major :: Natural <- o .: "major"
+      minor :: Natural <- o .: "minor"
+      let result = runFail $ (`Ledger.ProtVer` minor) <$> Ledger.mkVersion major
+      case result of
+        Right protVer -> pure $ ProtVer protVer
+        Left msg -> fail $ "Invalid protocol version: " <> show v <> " (" <> msg <> ")"
+
+instance ToJSON ProtVer where
+  toJSON (ProtVer (Ledger.ProtVer a b)) =
+    object
+      [ "major" .= (Ledger.getVersion a :: Natural)
+      , "minor" .= (b :: Natural)
+      ]
+
+reLedgerProtVerL :: Lens' ProtVer Ledger.ProtVer
+reLedgerProtVerL = lens unProtVer (const ProtVer)
+
+unLedgerProtVerL :: Lens' Ledger.ProtVer ProtVer
+unLedgerProtVerL = lens ProtVer (const unProtVer)

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Domain.ProtocolParameters
+  ( ProtocolParameters(..)
+  , emptyProtocolParameters
+  , protocolParametersL
+  , protocolParamProtocolVersionL
+  , protocolParamDecentralizationL
+  , protocolParamExtraPraosEntropyL
+  , protocolParamMaxBlockHeaderSizeL
+  , protocolParamMaxBlockBodySizeL
+  , protocolParamMaxTxSizeL
+  , protocolParamTxFeeFixedL
+  , protocolParamTxFeePerByteL
+  , protocolParamMinUTxOValueL
+  , protocolParamStakeAddressDepositL
+  , protocolParamStakePoolDepositL
+  , protocolParamMinPoolCostL
+  , protocolParamPoolRetireMaxEpochL
+  , protocolParamStakePoolTargetNumL
+  , protocolParamPoolPledgeInfluenceL
+  , protocolParamMonetaryExpansionL
+  , protocolParamTreasuryCutL
+  , protocolParamUTxOCostPerWordL
+  , protocolParamCostModelsL
+  , protocolParamPricesL
+  , protocolParamMaxTxExUnitsL
+  , protocolParamMaxBlockExUnitsL
+  , protocolParamMaxValueSizeL
+  , protocolParamCollateralPercentL
+  , protocolParamMaxCollateralInputsL
+  , protocolParamUTxOCostPerByteL
+  ) where
+
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.AlonzoEraOnly
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
+
+import qualified Cardano.Ledger.Alonzo.Core as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import qualified Cardano.Ledger.Babbage.Core as Ledger
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
+
+import           GHC.Natural (Natural)
+import           Lens.Micro (Lens', lens)
+
+newtype ProtocolParameters era = ProtocolParameters
+  { unProtocolParameters :: Ledger.PParams (ShelleyLedgerEra era)
+  }
+
+protocolParametersL :: Lens' (ProtocolParameters era) (Ledger.PParams (ShelleyLedgerEra era))
+protocolParametersL = lens unProtocolParameters (\_ pp -> ProtocolParameters pp)
+
+emptyProtocolParameters :: ShelleyBasedEra era -> ProtocolParameters era
+emptyProtocolParameters w = shelleyBasedEraConstraints w $ ProtocolParameters Ledger.emptyPParams
+
+-- | Protocol version, major and minor. Updating the major version is
+-- used to trigger hard forks.
+protocolParamProtocolVersionL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.ProtVer
+protocolParamProtocolVersionL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppProtocolVersionL
+
+-- | The decentralization parameter. This is fraction of slots that
+-- belong to the BFT overlay schedule, rather than the Praos schedule.
+-- So 1 means fully centralised, while 0 means fully decentralised.
+--
+-- This is the \"d\" parameter from the design document.
+protocolParamDecentralizationL :: ShelleyToAlonzoEra era -> Lens' (ProtocolParameters era) Ledger.UnitInterval
+protocolParamDecentralizationL w = shelleyToAlonzoEraConstraints w $ protocolParametersL . Ledger.ppDL
+
+-- | Extra entropy for the Praos per-epoch nonce.
+--
+-- This can be used to add extra entropy during the decentralisation
+-- process. If the extra entropy can be demonstrated to be generated
+-- randomly then this method can be used to show that the initial
+-- federated operators did not subtly bias the initial schedule so that
+-- they retain undue influence after decentralisation.
+protocolParamExtraPraosEntropyL :: ShelleyToAlonzoEra era -> Lens' (ProtocolParameters era) Ledger.Nonce
+protocolParamExtraPraosEntropyL w = shelleyToAlonzoEraConstraints w $ protocolParametersL . Ledger.ppExtraEntropyL
+
+-- | The maximum permitted size of a block header.
+--
+-- This must be at least as big as the largest legitimate block headers
+-- but should not be too much larger, to help prevent DoS attacks.
+--
+-- Caution: setting this to be smaller than legitimate block headers is
+-- a sure way to brick the system!
+protocolParamMaxBlockHeaderSizeL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Natural
+protocolParamMaxBlockHeaderSizeL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMaxBHSizeL
+
+-- | The maximum permitted size of the block body (that is, the block
+-- payload, without the block header).
+--
+-- This should be picked with the Praos network delta security parameter
+-- in mind. Making this too large can severely weaken the Praos
+-- consensus properties.
+--
+-- Caution: setting this to be smaller than a transaction that can
+-- change the protocol parameters is a sure way to brick the system!
+protocolParamMaxBlockBodySizeL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Natural
+protocolParamMaxBlockBodySizeL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMaxBBSizeL
+
+-- | The maximum permitted size of a transaction.
+--
+-- Typically this should not be too high a fraction of the block size,
+-- otherwise wastage from block fragmentation becomes a problem, and
+-- the current implementation does not use any sophisticated box packing
+-- algorithm.
+protocolParamMaxTxSizeL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Natural
+protocolParamMaxTxSizeL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMaxTxSizeL
+
+-- | The constant factor for the minimum fee calculation.
+protocolParamTxFeeFixedL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamTxFeeFixedL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMinFeeBL
+
+-- | Per byte linear factor for the minimum fee calculation.
+protocolParamTxFeePerByteL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamTxFeePerByteL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMinFeeAL
+
+-- | The minimum permitted value for new UTxO entries, ie for
+-- transaction outputs.
+protocolParamMinUTxOValueL :: ShelleyToAllegraEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamMinUTxOValueL w = shelleyToAllegraEraConstraints w $ protocolParametersL . Ledger.ppMinUTxOValueL
+
+-- | The deposit required to register a stake address.
+protocolParamStakeAddressDepositL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamStakeAddressDepositL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppKeyDepositL
+
+-- | The deposit required to register a stake pool.
+protocolParamStakePoolDepositL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamStakePoolDepositL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppPoolDepositL
+
+-- | The minimum value that stake pools are permitted to declare for
+-- their cost parameter.
+protocolParamMinPoolCostL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.Coin
+protocolParamMinPoolCostL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppMinPoolCostL
+
+-- | The maximum number of epochs into the future that stake pools
+-- are permitted to schedule a retirement.
+protocolParamPoolRetireMaxEpochL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.EpochNo
+protocolParamPoolRetireMaxEpochL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppEMaxL
+
+-- | The equilibrium target number of stake pools.
+-- This is the \"k\" incentives parameter from the design document.
+protocolParamStakePoolTargetNumL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Natural
+protocolParamStakePoolTargetNumL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppNOptL
+
+-- | The influence of the pledge in stake pool rewards.
+-- This is the \"a_0\" incentives parameter from the design document.
+protocolParamPoolPledgeInfluenceL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.NonNegativeInterval
+protocolParamPoolPledgeInfluenceL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppA0L
+
+-- | The monetary expansion rate. This determines the fraction of the
+-- reserves that are added to the fee pot each epoch.
+-- This is the \"rho\" incentives parameter from the design document.
+protocolParamMonetaryExpansionL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.UnitInterval
+protocolParamMonetaryExpansionL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppRhoL
+
+-- | The fraction of the fee pot each epoch that goes to the treasury.
+-- This is the \"tau\" incentives parameter from the design document.
+protocolParamTreasuryCutL :: ShelleyBasedEra era -> Lens' (ProtocolParameters era) Ledger.UnitInterval
+protocolParamTreasuryCutL w = shelleyBasedEraConstraints w $ protocolParametersL . Ledger.ppTauL
+
+-- | Cost in ada per word of UTxO storage.
+protocolParamUTxOCostPerWordL :: AlonzoEraOnly era -> Lens' (ProtocolParameters era) Ledger.CoinPerWord
+protocolParamUTxOCostPerWordL w = alonzoEraOnlyConstraints w $ protocolParametersL . Ledger.ppCoinsPerUTxOWordL
+
+-- | Cost models for script languages that use them.
+protocolParamCostModelsL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Ledger.CostModels
+protocolParamCostModelsL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppCostModelsL
+
+-- | Price of execution units for script languages that use them.
+protocolParamPricesL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Ledger.Prices
+protocolParamPricesL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppPricesL
+
+-- | Max total script execution resources units allowed per tx
+protocolParamMaxTxExUnitsL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Ledger.ExUnits
+protocolParamMaxTxExUnitsL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppMaxTxExUnitsL
+
+-- | Max total script execution resources units allowed per block
+protocolParamMaxBlockExUnitsL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Ledger.ExUnits
+protocolParamMaxBlockExUnitsL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppMaxBlockExUnitsL
+
+-- | Max size of a Value in a tx output.
+protocolParamMaxValueSizeL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Natural
+protocolParamMaxValueSizeL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppMaxValSizeL
+
+-- | The percentage of the script contribution to the txfee that must be
+-- provided as collateral inputs when including Plutus scripts.
+protocolParamCollateralPercentL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Natural
+protocolParamCollateralPercentL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppCollateralPercentageL
+
+-- | The maximum number of collateral inputs allowed in a transaction.
+protocolParamMaxCollateralInputsL :: AlonzoEraOnwards era -> Lens' (ProtocolParameters era) Natural
+protocolParamMaxCollateralInputsL w = alonzoEraOnwardsConstraints w $ protocolParametersL . Ledger.ppMaxCollateralInputsL
+
+-- | Cost in ada per byte of UTxO storage.
+protocolParamUTxOCostPerByteL :: BabbageEraOnwards era -> Lens' (ProtocolParameters era) Ledger.CoinPerByte
+protocolParamUTxOCostPerByteL w = babbageEraOnwardsConstraints w $ protocolParametersL . Ledger.ppCoinsPerUTxOByteL

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 {- HLINT ignore "Redundant pure" -}
+{- HLINT ignore "Move brackets to avoid $" -}
 
 module Cardano.Api.Domain.ProtocolParameters
   ( ProtocolParameters(..)
@@ -57,7 +58,6 @@ import qualified Cardano.Ledger.BaseTypes as Ledger
 
 import           Control.Applicative
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
-import           Data.Function ((&))
 import           GHC.Natural (Natural)
 import           Lens.Micro (Lens', lens, (.~), (^.))
 
@@ -110,34 +110,54 @@ instance IsCardanoEra era => FromJSON (ProtocolParameters era) where
               pure (emptyProtocolParameters sbe)
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "protocolVersion"
-                          pure (& protocolParamProtocolVersionL w .~ v)
+                          pure (protocolParamProtocolVersionL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "extraPraosEntropy"
-                          pure (& protocolParamExtraPraosEntropyL w .~ v)
+                          pure (protocolParamExtraPraosEntropyL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "maxBlockHeaderSize"
-                          pure (& protocolParamMaxBlockHeaderSizeL w .~ v)
+                          pure (protocolParamMaxBlockHeaderSizeL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "maxBlockBodySize"
-                          pure (& protocolParamMaxBlockBodySizeL w .~ v)
+                          pure (protocolParamMaxBlockBodySizeL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "maxTxSize"
-                          pure (& protocolParamMaxTxSizeL w .~ v)
+                          pure (protocolParamMaxTxSizeL w .~ v)
                       )
-                --     -- txFeeFixed <- o .: "txFeeFixed"
-                --     -- txFeePerByte <- o .: "txFeePerByte"
-                --     -- minUTxOValue <- o .: "minUTxOValue"
-                --     -- stakeAddressDeposit <- o .: "stakeAddressDeposit"
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "txFeeFixed"
+                          pure (protocolParamTxFeeFixedL w .~ v)
+                      )
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "txFeePerByte"
+                          pure (protocolParamTxFeePerByteL w .~ v)
+                      )
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "minUTxOValue"
+                          pure (protocolParamMinUTxOValueL w .~ v)
+                      )
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "stakeAddressDeposit"
+                          pure (protocolParamStakeAddressDepositL w .~ v)
+                      )
                 --     -- stakePoolDeposit <- o .: "stakePoolDeposit"
-                --     -- minPoolCost <- o .: "minPoolCost"
-                --     -- poolRetireMaxEpoch <- o .: "poolRetireMaxEpoch"
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "minPoolCost"
+                          pure (protocolParamMinPoolCostL w .~ v)
+                      )
+                <**>  ( inEraFeature era (pure id) $ \w -> do
+                          v <- o .: "poolRetireMaxEpoch"
+                          pure (protocolParamPoolRetireMaxEpochL w .~ v)
+                      )
+
+
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "stakePoolTargetNum"
-                          pure (& protocolParamStakePoolTargetNumL w .~ v)
+                          pure (protocolParamStakePoolTargetNumL w .~ v)
                       )
                 --     -- poolPledgeInfluence <- o .: "poolPledgeInfluence"
                 --     -- monetaryExpansion <- o .: "monetaryExpansion"
@@ -149,15 +169,15 @@ instance IsCardanoEra era => FromJSON (ProtocolParameters era) where
                 --     -- maxBlockExecutionUnits <- o .:? "maxBlockExecutionUnits"
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "maxValueSize"
-                          pure (& protocolParamMaxValueSizeL w .~ v)
+                          pure (protocolParamMaxValueSizeL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "collateralPercentage"
-                          pure (& protocolParamCollateralPercentL w .~ v)
+                          pure (protocolParamCollateralPercentL w .~ v)
                       )
                 <**>  ( inEraFeature era (pure id) $ \w -> do
                           v <- o .: "maxCollateralInputs"
-                          pure (& protocolParamMaxCollateralInputsL w .~ v)
+                          pure (protocolParamMaxCollateralInputsL w .~ v)
                       )
                 --     -- utxoCostPerByte <- o .:? "utxoCostPerByte"\
             )

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
@@ -33,6 +33,7 @@ module Cardano.Api.Domain.ProtocolParameters
   , protocolParamUTxOCostPerByteL
   ) where
 
+import           Cardano.Api.Domain.PraosNonce
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.AlonzoEraOnly
@@ -80,8 +81,8 @@ protocolParamDecentralizationL w = shelleyToAlonzoEraConstraints w $ protocolPar
 -- randomly then this method can be used to show that the initial
 -- federated operators did not subtly bias the initial schedule so that
 -- they retain undue influence after decentralisation.
-protocolParamExtraPraosEntropyL :: ShelleyToAlonzoEra era -> Lens' (ProtocolParameters era) Ledger.Nonce
-protocolParamExtraPraosEntropyL w = shelleyToAlonzoEraConstraints w $ protocolParametersL . Ledger.ppExtraEntropyL
+protocolParamExtraPraosEntropyL :: ShelleyToAlonzoEra era -> Lens' (ProtocolParameters era) (Maybe PraosNonce)
+protocolParamExtraPraosEntropyL w = shelleyToAlonzoEraConstraints w $ protocolParametersL . Ledger.ppExtraEntropyL . unLedgerNonceL
 
 -- | The maximum permitted size of a block header.
 --

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParametersUpdate.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParametersUpdate.hs
@@ -1,0 +1,212 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Domain.ProtocolParametersUpdate
+  ( ProtocolParametersUpdate(..)
+  , emptyProtocolParametersUpdate
+  , protocolParametersUpdateL
+  , protocolUpdateProtocolVersion
+  , protocolUpdateDecentralization
+  , protocolUpdateExtraPraosEntropy
+  , protocolUpdateMaxBlockHeaderSize
+  , protocolUpdateMaxBlockBodySize
+  , protocolUpdateMaxTxSize
+  , protocolUpdateTxFeeFixed
+  , protocolUpdateTxFeePerByte
+  , protocolUpdateMinUTxOValue
+  , protocolUpdateStakeAddressDeposit
+  , protocolUpdateStakePoolDeposit
+  , protocolUpdateMinPoolCost
+  , protocolUpdatePoolRetireMaxEpoch
+  , protocolUpdateStakePoolTargetNum
+  , protocolUpdatePoolPledgeInfluence
+  , protocolUpdateMonetaryExpansion
+  , protocolUpdateTreasuryCut
+  , protocolUpdateUTxOCostPerWord
+  , protocolUpdateCostModels
+  , protocolUpdatePrices
+  , protocolUpdateMaxTxExUnits
+  , protocolUpdateMaxBlockExUnits
+  , protocolUpdateMaxValueSize
+  , protocolUpdateCollateralPercent
+  , protocolUpdateMaxCollateralInputs
+  , protocolUpdateUTxOCostPerByte
+  ) where
+
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.AlonzoEraOnly
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
+
+import qualified Cardano.Ledger.Alonzo.Core as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import qualified Cardano.Ledger.Babbage.Core as Ledger
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
+
+import           GHC.Natural (Natural)
+import           Lens.Micro (Lens', lens)
+
+newtype ProtocolParametersUpdate era = ProtocolParametersUpdate
+  { unProtocolParametersUpdate :: Ledger.PParamsUpdate (ShelleyLedgerEra era)
+  }
+
+emptyProtocolParametersUpdate :: ShelleyBasedEra era -> ProtocolParametersUpdate era
+emptyProtocolParametersUpdate w = shelleyBasedEraConstraints w $ ProtocolParametersUpdate Ledger.emptyPParamsUpdate
+
+protocolParametersUpdateL :: Lens' (ProtocolParametersUpdate era) (Ledger.PParamsUpdate (ShelleyLedgerEra era))
+protocolParametersUpdateL = lens unProtocolParametersUpdate (\_ pp -> ProtocolParametersUpdate pp)
+
+-- | Protocol version, major and minor. Updating the major version is used to
+-- trigger hard forks.
+protocolUpdateProtocolVersion :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.ProtVer)
+protocolUpdateProtocolVersion w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuProtocolVersionL
+
+-- | The decentralization parameter. This is fraction of slots that belong to
+-- the BFT overlay schedule, rather than the Praos schedule. So 1 means fully
+-- centralised, while 0 means fully decentralised.
+--
+-- This is the \"d\" parameter from the design document.
+protocolUpdateDecentralization :: ShelleyToAlonzoEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateDecentralization w = shelleyToAlonzoEraConstraints w $ protocolParametersUpdateL . Ledger.ppuDL
+
+-- | Extra entropy for the Praos per-epoch nonce.
+--
+-- This can be used to add extra entropy during the decentralisation process.
+-- If the extra entropy can be demonstrated to be generated randomly then this
+-- method can be used to show that the initial federated operators did not
+-- subtly bias the initial schedule so that they retain undue influence after
+-- decentralisation.
+protocolUpdateExtraPraosEntropy :: ShelleyToAlonzoEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Nonce)
+protocolUpdateExtraPraosEntropy w = shelleyToAlonzoEraConstraints w $ protocolParametersUpdateL . Ledger.ppuExtraEntropyL
+
+-- | The maximum permitted size of a block header.
+--
+-- This must be at least as big as the largest legitimate block headers but
+-- should not be too much larger, to help prevent DoS attacks.
+--
+-- Caution: setting this to be smaller than legitimate block headers is a sure
+-- way to brick the system!
+protocolUpdateMaxBlockHeaderSize :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxBlockHeaderSize w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxBHSizeL
+
+-- | The maximum permitted size of the block body (that is, the block payload,
+-- without the block header).
+--
+-- This should be picked with the Praos network delta security parameter in
+-- mind. Making this too large can severely weaken the Praos consensus
+-- properties.
+--
+-- Caution: setting this to be smaller than a transaction that can change the
+-- protocol parameters is a sure way to brick the system!
+protocolUpdateMaxBlockBodySize :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxBlockBodySize w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxBBSizeL
+
+-- | The maximum permitted size of a transaction.
+--
+-- Typically this should not be too high a fraction of the block size,
+-- otherwise wastage from block fragmentation becomes a problem, and the
+-- current implementation does not use any sophisticated box packing
+-- algorithm.
+protocolUpdateMaxTxSize :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxTxSize w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxTxSizeL
+
+-- | The constant factor for the minimum fee calculation.
+protocolUpdateTxFeeFixed :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateTxFeeFixed w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMinFeeBL
+
+-- | The linear factor for the minimum fee calculation.
+protocolUpdateTxFeePerByte :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateTxFeePerByte w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMinFeeAL
+
+-- | The minimum permitted value for new UTxO entries, ie for transaction
+-- outputs.
+protocolUpdateMinUTxOValue :: ShelleyToAllegraEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateMinUTxOValue w = shelleyToAllegraEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMinUTxOValueL
+
+-- | The deposit required to register a stake address.
+protocolUpdateStakeAddressDeposit :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateStakeAddressDeposit w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuKeyDepositL
+
+-- | The deposit required to register a stake pool.
+protocolUpdateStakePoolDeposit :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateStakePoolDeposit w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuPoolDepositL
+
+-- | The minimum value that stake pools are permitted to declare for their
+-- cost parameter.
+protocolUpdateMinPoolCost :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateMinPoolCost w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuMinPoolCostL
+
+-- | The maximum number of epochs into the future that stake pools are
+-- permitted to schedule a retirement.
+protocolUpdatePoolRetireMaxEpoch :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.EpochNo)
+protocolUpdatePoolRetireMaxEpoch w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuEMaxL
+
+-- | The equilibrium target number of stake pools.
+--
+-- This is the \"k\" incentives parameter from the design document.
+protocolUpdateStakePoolTargetNum :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateStakePoolTargetNum w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuNOptL
+
+-- | The influence of the pledge in stake pool rewards.
+--
+-- This is the \"a_0\" incentives parameter from the design document.
+protocolUpdatePoolPledgeInfluence :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.NonNegativeInterval)
+protocolUpdatePoolPledgeInfluence w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuA0L
+
+-- | The monetary expansion rate. This determines the fraction of the reserves
+-- that are added to the fee pot each epoch.
+--
+-- This is the \"rho\" incentives parameter from the design document.
+protocolUpdateMonetaryExpansion :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateMonetaryExpansion w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuRhoL
+
+-- | The fraction of the fee pot each epoch that goes to the treasury.
+--
+-- This is the \"tau\" incentives parameter from the design document.
+protocolUpdateTreasuryCut :: ShelleyBasedEra era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateTreasuryCut w = shelleyBasedEraConstraints w $ protocolParametersUpdateL . Ledger.ppuTauL
+
+-- | Cost in ada per word of UTxO storage.
+--
+-- /Obsoleted by 'protocolUpdateUTxOCostPerByte'/
+protocolUpdateUTxOCostPerWord :: AlonzoEraOnly era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.CoinPerWord)
+protocolUpdateUTxOCostPerWord w = alonzoEraOnlyConstraints w $ protocolParametersUpdateL . Ledger.ppuCoinsPerUTxOWordL
+
+-- | Cost models for script languages that use them.
+protocolUpdateCostModels :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.CostModels)
+protocolUpdateCostModels w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuCostModelsL
+
+-- | Price of execution units for script languages that use them.
+protocolUpdatePrices :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.Prices)
+protocolUpdatePrices w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuPricesL
+
+-- | Max total script execution resources units allowed per tx
+protocolUpdateMaxTxExUnits :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.ExUnits)
+protocolUpdateMaxTxExUnits w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxTxExUnitsL
+
+-- | Max total script execution resources units allowed per block
+protocolUpdateMaxBlockExUnits :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.ExUnits)
+protocolUpdateMaxBlockExUnits w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxBlockExUnitsL
+
+-- | Max size of a 'Value' in a tx output.
+protocolUpdateMaxValueSize :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxValueSize w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxValSizeL
+
+-- | The percentage of the script contribution to the txfee that must be
+-- provided as collateral inputs when including Plutus scripts.
+protocolUpdateCollateralPercent :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateCollateralPercent w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuCollateralPercentageL
+
+-- | The maximum number of collateral inputs allowed in a transaction.
+protocolUpdateMaxCollateralInputs :: AlonzoEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxCollateralInputs w = alonzoEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuMaxCollateralInputsL
+
+-- | Cost in ada per byte of UTxO storage.
+--
+-- /Supercedes 'protocolUpdateUTxOCostPerWord'/
+protocolUpdateUTxOCostPerByte :: BabbageEraOnwards era -> Lens' (ProtocolParametersUpdate era) (Ledger.StrictMaybe Ledger.CoinPerByte)
+protocolUpdateUTxOCostPerByte w = babbageEraOnwardsConstraints w $ protocolParametersUpdateL . Ledger.ppuCoinsPerUTxOByteL

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -1,15 +1,3 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
-{-# LANGUAGE TypeOperators #-}
-
 
 -- | Cardano eras, sometimes we have to distinguish them.
 --

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -22,6 +22,8 @@ module Cardano.Api.Eras
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
@@ -29,6 +31,7 @@ module Cardano.Api.Eras
   , cardanoEraConstraints
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -39,6 +39,7 @@ module Cardano.Api.Eras
   , maybeFeatureInEra
   , featureInShelleyBasedEra
   , inShelleyBasedEraFeature
+  , InAnyEra(..)
 
     -- * Deprecated aliases
   , Byron
@@ -74,3 +75,4 @@ module Cardano.Api.Eras
 
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
+import           Cardano.Api.Eras.InAnyEra

--- a/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Constraints.hs
@@ -52,20 +52,20 @@ cardanoEraConstraints = \case
   BabbageEra -> id
   ConwayEra  -> id
 
-type ShelleyBasedEraConstraints era ledgerera =
-  ( C.HashAlgorithm (L.HASH (L.EraCrypto ledgerera))
-  , C.Signable (L.VRF (L.EraCrypto ledgerera)) L.Seed
+type ShelleyBasedEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-  , Consensus.ShelleyCompatible (ConsensusProtocol era) ledgerera
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
   , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-  , L.Crypto (L.EraCrypto ledgerera)
-  , L.Era ledgerera
-  , L.EraCrypto ledgerera ~ L.StandardCrypto
-  , L.EraPParams ledgerera
-  , L.EraTx ledgerera
-  , L.EraTxBody ledgerera
-  , L.HashAnnotated (L.TxBody ledgerera) L.EraIndependentTxBody L.StandardCrypto
-  , L.ShelleyEraTxBody ledgerera
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -76,9 +76,8 @@ type ShelleyBasedEraConstraints era ledgerera =
   )
 
 shelleyBasedEraConstraints :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 shelleyBasedEraConstraints = \case
   ShelleyBasedEraShelley -> id
@@ -90,8 +89,7 @@ shelleyBasedEraConstraints = \case
 
 -- Deprecated: Use shelleyBasedEraConstraints instead.
 withShelleyBasedEraConstraintsForLedger :: ()
-  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
-  -> (ShelleyBasedEraConstraints era ledgerera => a)
+  -> (ShelleyBasedEraConstraints era => a)
   -> a
 withShelleyBasedEraConstraintsForLedger = shelleyBasedEraConstraints

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -20,12 +20,15 @@ module Cardano.Api.Eras.Core
   , AlonzoEra
   , BabbageEra
   , ConwayEra
+
+    -- * CardanoEra
   , CardanoEra(..)
   , IsCardanoEra(..)
   , AnyCardanoEra(..)
   , anyCardanoEra
   , InAnyCardanoEra(..)
   , CardanoLedgerEra
+  , ToCardanoEra(..)
 
     -- * FeatureInEra
   , FeatureInEra(..)
@@ -180,6 +183,14 @@ inShelleyBasedEraFeature era no yes =
   featureInShelleyBasedEra no yes era
 
 -- ----------------------------------------------------------------------------
+-- ToCardanoEra
+
+class ToCardanoEra (feature :: Type -> Type) where
+  toCardanoEra :: ()
+    => feature era
+    -> CardanoEra era
+
+-- ----------------------------------------------------------------------------
 -- Deprecated aliases
 --
 
@@ -267,6 +278,8 @@ instance TestEquality CardanoEra where
     testEquality ConwayEra  ConwayEra  = Just Refl
     testEquality _          _          = Nothing
 
+instance ToCardanoEra CardanoEra where
+  toCardanoEra = id
 
 -- | The class of Cardano eras. This allows uniform handling of all Cardano
 -- eras, but also non-uniform by making case distinctions on the 'CardanoEra'
@@ -378,7 +391,6 @@ data InAnyCardanoEra thing where
                      -> thing era
                      -> InAnyCardanoEra thing
 
-
 -- ----------------------------------------------------------------------------
 -- Shelley-based eras
 --
@@ -423,6 +435,15 @@ instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
     testEquality ShelleyBasedEraConway  ShelleyBasedEraConway  = Just Refl
     testEquality _                      _                      = Nothing
+
+instance ToCardanoEra ShelleyBasedEra where
+  toCardanoEra = \case
+    ShelleyBasedEraShelley -> ShelleyEra
+    ShelleyBasedEraAllegra -> AllegraEra
+    ShelleyBasedEraMary    -> MaryEra
+    ShelleyBasedEraAlonzo  -> AlonzoEra
+    ShelleyBasedEraBabbage -> BabbageEra
+    ShelleyBasedEraConway  -> ConwayEra
 
 -- | The class of eras that are based on Shelley. This allows uniform handling
 -- of Shelley-based eras, but also non-uniform by making case distinctions on

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -1,13 +1,9 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Cardano eras, sometimes we have to distinguish them.
 --

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -274,6 +274,9 @@ instance TestEquality CardanoEra where
     testEquality ConwayEra  ConwayEra  = Just Refl
     testEquality _          _          = Nothing
 
+instance FeatureInEra CardanoEra where
+  featureInEra _ yes = yes
+
 instance ToCardanoEra CardanoEra where
   toCardanoEra = id
 
@@ -431,6 +434,16 @@ instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
     testEquality ShelleyBasedEraConway  ShelleyBasedEraConway  = Just Refl
     testEquality _                      _                      = Nothing
+
+instance FeatureInEra ShelleyBasedEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyBasedEraShelley
+    AllegraEra  -> yes ShelleyBasedEraAllegra
+    MaryEra     -> yes ShelleyBasedEraMary
+    AlonzoEra   -> yes ShelleyBasedEraAlonzo
+    BabbageEra  -> yes ShelleyBasedEraBabbage
+    ConwayEra   -> yes ShelleyBasedEraConway
 
 instance ToCardanoEra ShelleyBasedEra where
   toCardanoEra = \case

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -30,6 +30,8 @@ module Cardano.Api.Eras.Core
   , FeatureInEra(..)
   , inEraFeature
   , maybeFeatureInEra
+  , justFeatureInEra
+  , justInEraFeature
   , featureInShelleyBasedEra
   , inShelleyBasedEraFeature
 
@@ -158,6 +160,20 @@ maybeFeatureInEra :: ()
   -> Maybe (feature era)  -- ^ The feature if supported in the era
 maybeFeatureInEra =
   featureInEra Nothing Just
+
+justFeatureInEra :: ()
+  => FeatureInEra feature
+  => (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> CardanoEra era       -- ^ Era to check
+  -> Maybe a              -- ^ The value to use
+justFeatureInEra f = featureInEra Nothing (Just . f)
+
+justInEraFeature :: ()
+  => FeatureInEra feature
+  => CardanoEra era       -- ^ Era to check
+  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> Maybe a              -- ^ The value to use
+justInEraFeature era f = inEraFeature era Nothing (Just . f)
 
 -- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
 featureInShelleyBasedEra :: ()

--- a/cardano-api/internal/Cardano/Api/Eras/InAnyEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/InAnyEra.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+
+module Cardano.Api.Eras.InAnyEra
+  ( InAnyEra(..)
+  ) where
+
+import           Data.Kind
+
+-- | This pairs up some era-dependent type with a 'feature' value that tells
+-- us what feature involves, but hides the era type.
+data InAnyEra (feature :: Type -> Type) (t :: Type -> Type) where
+  InAnyEra :: feature era -> t era -> InAnyEra feature t

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -11,7 +11,7 @@ module Cardano.Api.Feature
   , asFeaturedInShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 
 -- | A value only if the feature is supported in this era
 data Featured feature era a where

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnly.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnly
+  ( AlonzoEraOnly(..)
+  , IsAlonzoEraOnly(..)
+  , AnyAlonzoEraOnly(..)
+  , alonzoEraOnlyConstraints
+  , alonzoEraOnlyToCardanoEra
+  , alonzoEraOnlyToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnly era where
+  alonzoEraOnly :: AlonzoEraOnly era
+
+data AlonzoEraOnly era where
+  AlonzoEraOnlyAlonzo  :: AlonzoEraOnly AlonzoEra
+
+deriving instance Show (AlonzoEraOnly era)
+deriving instance Eq (AlonzoEraOnly era)
+
+instance IsAlonzoEraOnly AlonzoEra where
+  alonzoEraOnly = AlonzoEraOnlyAlonzo
+
+instance FeatureInEra AlonzoEraOnly where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnlyAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra AlonzoEraOnly where
+  toCardanoEra = \case
+    AlonzoEraOnlyAlonzo  -> AlonzoEra
+
+data AnyAlonzoEraOnly where
+  AnyAlonzoEraOnly :: AlonzoEraOnly era -> AnyAlonzoEraOnly
+
+deriving instance Show AnyAlonzoEraOnly
+
+type AlonzoEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.ExactEra L.AlonzoEra (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnly era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnlyConstraints :: ()
+  => AlonzoEraOnly era
+  -> (AlonzoEraOnlyConstraints era => a)
+  -> a
+alonzoEraOnlyConstraints = \case
+  AlonzoEraOnlyAlonzo  -> id
+
+alonzoEraOnlyToCardanoEra :: AlonzoEraOnly era -> CardanoEra era
+alonzoEraOnlyToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnlyToShelleyBasedEra
+
+alonzoEraOnlyToShelleyBasedEra :: AlonzoEraOnly era -> ShelleyBasedEra era
+alonzoEraOnlyToShelleyBasedEra = \case
+  AlonzoEraOnlyAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/AlonzoEraOnwards.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.AlonzoEraOnwards
+  ( AlonzoEraOnwards(..)
+  , IsAlonzoEraOnwards(..)
+  , AnyAlonzoEraOnwards(..)
+  , alonzoEraOnwardsConstraints
+  , alonzoEraOnwardsToCardanoEra
+  , alonzoEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsAlonzoEraOnwards era where
+  alonzoEraOnwards :: AlonzoEraOnwards era
+
+data AlonzoEraOnwards era where
+  AlonzoEraOnwardsAlonzo  :: AlonzoEraOnwards AlonzoEra
+  AlonzoEraOnwardsBabbage :: AlonzoEraOnwards BabbageEra
+  AlonzoEraOnwardsConway  :: AlonzoEraOnwards ConwayEra
+
+deriving instance Show (AlonzoEraOnwards era)
+deriving instance Eq (AlonzoEraOnwards era)
+
+instance IsAlonzoEraOnwards AlonzoEra where
+  alonzoEraOnwards = AlonzoEraOnwardsAlonzo
+
+instance IsAlonzoEraOnwards BabbageEra where
+  alonzoEraOnwards = AlonzoEraOnwardsBabbage
+
+instance IsAlonzoEraOnwards ConwayEra where
+  alonzoEraOnwards = AlonzoEraOnwardsConway
+
+instance FeatureInEra AlonzoEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> yes AlonzoEraOnwardsAlonzo
+    BabbageEra  -> yes AlonzoEraOnwardsBabbage
+    ConwayEra   -> yes AlonzoEraOnwardsConway
+
+instance ToCardanoEra AlonzoEraOnwards where
+  toCardanoEra = \case
+    AlonzoEraOnwardsAlonzo  -> AlonzoEra
+    AlonzoEraOnwardsBabbage -> BabbageEra
+    AlonzoEraOnwardsConway  -> ConwayEra
+
+data AnyAlonzoEraOnwards where
+  AnyAlonzoEraOnwards :: AlonzoEraOnwards era -> AnyAlonzoEraOnwards
+
+deriving instance Show AnyAlonzoEraOnwards
+
+type AlonzoEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.AlonzoEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsAlonzoEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+alonzoEraOnwardsConstraints :: ()
+  => AlonzoEraOnwards era
+  -> (AlonzoEraOnwardsConstraints era => a)
+  -> a
+alonzoEraOnwardsConstraints = \case
+  AlonzoEraOnwardsAlonzo  -> id
+  AlonzoEraOnwardsBabbage -> id
+  AlonzoEraOnwardsConway  -> id
+
+alonzoEraOnwardsToCardanoEra :: AlonzoEraOnwards era -> CardanoEra era
+alonzoEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnwardsToShelleyBasedEra
+
+alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
+alonzoEraOnwardsToShelleyBasedEra = \case
+  AlonzoEraOnwardsAlonzo  -> ShelleyBasedEraAlonzo
+  AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  AlonzoEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/BabbageEraOnwards.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.BabbageEraOnwards
+  ( BabbageEraOnwards(..)
+  , IsBabbageEraOnwards(..)
+  , AnyBabbageEraOnwards(..)
+  , babbageEraOnwardsConstraints
+  , babbageEraOnwardsToCardanoEra
+  , babbageEraOnwardsToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsBabbageEraOnwards era where
+  babbageEraOnwards :: BabbageEraOnwards era
+
+data BabbageEraOnwards era where
+  BabbageEraOnwardsBabbage :: BabbageEraOnwards BabbageEra
+  BabbageEraOnwardsConway  :: BabbageEraOnwards ConwayEra
+
+deriving instance Show (BabbageEraOnwards era)
+deriving instance Eq (BabbageEraOnwards era)
+
+instance IsBabbageEraOnwards BabbageEra where
+  babbageEraOnwards = BabbageEraOnwardsBabbage
+
+instance IsBabbageEraOnwards ConwayEra where
+  babbageEraOnwards = BabbageEraOnwardsConway
+
+instance FeatureInEra BabbageEraOnwards where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> yes BabbageEraOnwardsBabbage
+    ConwayEra   -> yes BabbageEraOnwardsConway
+
+instance ToCardanoEra BabbageEraOnwards where
+  toCardanoEra = \case
+    BabbageEraOnwardsBabbage -> BabbageEra
+    BabbageEraOnwardsConway  -> ConwayEra
+
+data AnyBabbageEraOnwards where
+  AnyBabbageEraOnwards :: BabbageEraOnwards era -> AnyBabbageEraOnwards
+
+deriving instance Show AnyBabbageEraOnwards
+
+type BabbageEraOnwardsConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.BabbageEraPParams (ShelleyLedgerEra era)
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsBabbageEraOnwards era
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+babbageEraOnwardsConstraints :: ()
+  => BabbageEraOnwards era
+  -> (BabbageEraOnwardsConstraints era => a)
+  -> a
+babbageEraOnwardsConstraints = \case
+  BabbageEraOnwardsBabbage -> id
+  BabbageEraOnwardsConway  -> id
+
+babbageEraOnwardsToCardanoEra :: BabbageEraOnwards era -> CardanoEra era
+babbageEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . babbageEraOnwardsToShelleyBasedEra
+
+babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
+babbageEraOnwardsToShelleyBasedEra = \case
+  BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
+  BabbageEraOnwardsConway  -> ShelleyBasedEraConway

--- a/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ConwayEraOnwards.hs
@@ -16,7 +16,7 @@ module Cardano.Api.Feature.ConwayEraOnwards
   , conwayEraOnwardsToShelleyBasedEra
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Query.Types
 
@@ -57,6 +57,10 @@ instance FeatureInEra ConwayEraOnwards where
     AlonzoEra   -> no
     BabbageEra  -> no
     ConwayEra   -> yes ConwayEraOnwardsConway
+
+instance ToCardanoEra ConwayEraOnwards where
+  toCardanoEra = \case
+    ConwayEraOnwardsConway -> ConwayEra
 
 data AnyConwayEraOnwards where
   AnyConwayEraOnwards :: ConwayEraOnwards era -> AnyConwayEraOnwards

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAllegraEra.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAllegraEra
+  ( ShelleyToAllegraEra(..)
+  , IsShelleyToAllegraEra(..)
+  , AnyShelleyToAllegraEra(..)
+  , shelleyToAllegraEraConstraints
+  , shelleyToAllegraEraToCardanoEra
+  , shelleyToAllegraEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAllegraEra era where
+  shelleyToAllegraEra :: ShelleyToAllegraEra era
+
+data ShelleyToAllegraEra era where
+  ShelleyToAllegraEraShelley :: ShelleyToAllegraEra ShelleyEra
+  ShelleyToAllegraEraAllegra :: ShelleyToAllegraEra AllegraEra
+
+deriving instance Show (ShelleyToAllegraEra era)
+deriving instance Eq (ShelleyToAllegraEra era)
+
+instance IsShelleyToAllegraEra ShelleyEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraShelley
+
+instance IsShelleyToAllegraEra AllegraEra where
+  shelleyToAllegraEra = ShelleyToAllegraEraAllegra
+
+instance FeatureInEra ShelleyToAllegraEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAllegraEraShelley
+    AllegraEra  -> yes ShelleyToAllegraEraAllegra
+    MaryEra     -> no
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAllegraEra where
+  toCardanoEra = \case
+    ShelleyToAllegraEraShelley  -> ShelleyEra
+    ShelleyToAllegraEraAllegra  -> AllegraEra
+
+type ShelleyToAllegraEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 4
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAllegraEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAllegraEra where
+  AnyShelleyToAllegraEra :: ShelleyToAllegraEra era -> AnyShelleyToAllegraEra
+
+deriving instance Show AnyShelleyToAllegraEra
+
+shelleyToAllegraEraConstraints :: ()
+  => ShelleyToAllegraEra era
+  -> (ShelleyToAllegraEraConstraints era => a)
+  -> a
+shelleyToAllegraEraConstraints = \case
+  ShelleyToAllegraEraShelley -> id
+  ShelleyToAllegraEraAllegra -> id
+
+shelleyToAllegraEraToCardanoEra :: ShelleyToAllegraEra era -> CardanoEra era
+shelleyToAllegraEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAllegraEraToShelleyBasedEra
+
+shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
+shelleyToAllegraEraToShelleyBasedEra = \case
+  ShelleyToAllegraEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAllegraEraAllegra -> ShelleyBasedEraAllegra

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToAlonzoEra.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToAlonzoEra
+  ( ShelleyToAlonzoEra(..)
+  , IsShelleyToAlonzoEra(..)
+  , AnyShelleyToAlonzoEra(..)
+  , shelleyToAlonzoEraConstraints
+  , shelleyToAlonzoEraToCardanoEra
+  , shelleyToAlonzoEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToAlonzoEra era where
+  shelleyToAlonzoEra :: ShelleyToAlonzoEra era
+
+data ShelleyToAlonzoEra era where
+  ShelleyToAlonzoEraShelley :: ShelleyToAlonzoEra ShelleyEra
+  ShelleyToAlonzoEraAllegra :: ShelleyToAlonzoEra AllegraEra
+  ShelleyToAlonzoEraMary :: ShelleyToAlonzoEra MaryEra
+  ShelleyToAlonzoEraAlonzo :: ShelleyToAlonzoEra AlonzoEra
+
+deriving instance Show (ShelleyToAlonzoEra era)
+deriving instance Eq (ShelleyToAlonzoEra era)
+
+instance IsShelleyToAlonzoEra ShelleyEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraShelley
+
+instance IsShelleyToAlonzoEra AllegraEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAllegra
+
+instance IsShelleyToAlonzoEra MaryEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraMary
+
+instance IsShelleyToAlonzoEra AlonzoEra where
+  shelleyToAlonzoEra = ShelleyToAlonzoEraAlonzo
+
+instance FeatureInEra ShelleyToAlonzoEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToAlonzoEraShelley
+    AllegraEra  -> yes ShelleyToAlonzoEraAllegra
+    MaryEra     -> yes ShelleyToAlonzoEraMary
+    AlonzoEra   -> yes ShelleyToAlonzoEraAlonzo
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToAlonzoEra where
+  toCardanoEra = \case
+    ShelleyToAlonzoEraShelley  -> ShelleyEra
+    ShelleyToAlonzoEraAllegra  -> AllegraEra
+    ShelleyToAlonzoEraMary     -> MaryEra
+    ShelleyToAlonzoEraAlonzo   -> AlonzoEra
+
+type ShelleyToAlonzoEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 6
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToAlonzoEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToAlonzoEra where
+  AnyShelleyToAlonzoEra :: ShelleyToAlonzoEra era -> AnyShelleyToAlonzoEra
+
+deriving instance Show AnyShelleyToAlonzoEra
+
+shelleyToAlonzoEraConstraints :: ()
+  => ShelleyToAlonzoEra era
+  -> (ShelleyToAlonzoEraConstraints era => a)
+  -> a
+shelleyToAlonzoEraConstraints = \case
+  ShelleyToAlonzoEraShelley -> id
+  ShelleyToAlonzoEraAllegra -> id
+  ShelleyToAlonzoEraMary    -> id
+  ShelleyToAlonzoEraAlonzo  -> id
+
+shelleyToAlonzoEraToCardanoEra :: ShelleyToAlonzoEra era -> CardanoEra era
+shelleyToAlonzoEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAlonzoEraToShelleyBasedEra
+
+shelleyToAlonzoEraToShelleyBasedEra :: ShelleyToAlonzoEra era -> ShelleyBasedEra era
+shelleyToAlonzoEraToShelleyBasedEra = \case
+  ShelleyToAlonzoEraShelley -> ShelleyBasedEraShelley
+  ShelleyToAlonzoEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToAlonzoEraMary    -> ShelleyBasedEraMary
+  ShelleyToAlonzoEraAlonzo  -> ShelleyBasedEraAlonzo

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -95,6 +96,7 @@ type ShelleyToBabbageEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 7
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToBabbageEra.hs
@@ -74,6 +74,14 @@ instance FeatureInEra ShelleyToBabbageEra where
     BabbageEra  -> yes ShelleyToBabbageEraBabbage
     ConwayEra   -> no
 
+instance ToCardanoEra ShelleyToBabbageEra where
+  toCardanoEra = \case
+    ShelleyToBabbageEraShelley  -> ShelleyEra
+    ShelleyToBabbageEraAllegra  -> AllegraEra
+    ShelleyToBabbageEraMary     -> MaryEra
+    ShelleyToBabbageEraAlonzo   -> AlonzoEra
+    ShelleyToBabbageEraBabbage  -> BabbageEra
+
 type ShelleyToBabbageEraConstraints era =
   ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
   , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -85,6 +86,7 @@ type ShelleyToMaryEraConstraints era =
   , L.EraTx (ShelleyLedgerEra era)
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ProtVerAtMost (ShelleyLedgerEra era) 5
   , L.ShelleyEraTxBody (ShelleyLedgerEra era)
   , L.ShelleyEraTxCert (ShelleyLedgerEra era)
   , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Feature/ShelleyToMaryEra.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Feature.ShelleyToMaryEra
+  ( ShelleyToMaryEra(..)
+  , IsShelleyToMaryEra(..)
+  , AnyShelleyToMaryEra(..)
+  , shelleyToMaryEraConstraints
+  , shelleyToMaryEraToCardanoEra
+  , shelleyToMaryEraToShelleyBasedEra
+  ) where
+
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.Shelley.TxCert as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+class IsShelleyBasedEra era => IsShelleyToMaryEra era where
+  shelleyToMaryEra :: ShelleyToMaryEra era
+
+data ShelleyToMaryEra era where
+  ShelleyToMaryEraShelley :: ShelleyToMaryEra ShelleyEra
+  ShelleyToMaryEraAllegra :: ShelleyToMaryEra AllegraEra
+  ShelleyToMaryEraMary    :: ShelleyToMaryEra MaryEra
+
+deriving instance Show (ShelleyToMaryEra era)
+deriving instance Eq (ShelleyToMaryEra era)
+
+instance IsShelleyToMaryEra ShelleyEra where
+  shelleyToMaryEra = ShelleyToMaryEraShelley
+
+instance IsShelleyToMaryEra AllegraEra where
+  shelleyToMaryEra = ShelleyToMaryEraAllegra
+
+instance IsShelleyToMaryEra MaryEra where
+  shelleyToMaryEra = ShelleyToMaryEraMary
+
+instance FeatureInEra ShelleyToMaryEra where
+  featureInEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> yes ShelleyToMaryEraShelley
+    AllegraEra  -> yes ShelleyToMaryEraAllegra
+    MaryEra     -> yes ShelleyToMaryEraMary
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra ShelleyToMaryEra where
+  toCardanoEra = \case
+    ShelleyToMaryEraShelley  -> ShelleyEra
+    ShelleyToMaryEraAllegra  -> AllegraEra
+    ShelleyToMaryEraMary     -> MaryEra
+
+type ShelleyToMaryEraConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.TxCert (ShelleyLedgerEra era) ~ L.ShelleyTxCert (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , IsShelleyToMaryEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+data AnyShelleyToMaryEra where
+  AnyShelleyToMaryEra :: ShelleyToMaryEra era -> AnyShelleyToMaryEra
+
+deriving instance Show AnyShelleyToMaryEra
+
+shelleyToMaryEraConstraints :: ()
+  => ShelleyToMaryEra era
+  -> (ShelleyToMaryEraConstraints era => a)
+  -> a
+shelleyToMaryEraConstraints = \case
+  ShelleyToMaryEraShelley -> id
+  ShelleyToMaryEraAllegra -> id
+  ShelleyToMaryEraMary    -> id
+
+shelleyToMaryEraToCardanoEra :: ShelleyToMaryEra era -> CardanoEra era
+shelleyToMaryEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToMaryEraToShelleyBasedEra
+
+shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
+shelleyToMaryEraToShelleyBasedEra = \case
+  ShelleyToMaryEraShelley -> ShelleyBasedEraShelley
+  ShelleyToMaryEraAllegra -> ShelleyBasedEraAllegra
+  ShelleyToMaryEraMary    -> ShelleyBasedEraMary

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -46,7 +46,8 @@ module Cardano.Api.Fees (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -16,7 +16,7 @@ module Cardano.Api.GenesisParameters (
 
   ) where
 
-import           Cardano.Api.Eras (ShelleyBasedEra (ShelleyBasedEraShelley))
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Value

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -13,7 +13,8 @@
 module Cardano.Api.Governance.Actions.ProposalProcedure where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/VotingProcedure.hs
@@ -16,7 +16,8 @@
 module Cardano.Api.Governance.Actions.VotingProcedure where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Governance/Poll.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Poll.hs
@@ -36,7 +36,7 @@ module Cardano.Api.Governance.Poll(
     verifyPollAnswer,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -25,7 +25,7 @@ module Cardano.Api.InMode (
     fromConsensusApplyTxErr,
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -83,7 +83,8 @@ module Cardano.Api.LedgerState
 
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Genesis
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
+++ b/cardano-api/internal/Cardano/Api/OperationalCertificate.hs
@@ -26,7 +26,6 @@ import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Class
 import           Cardano.Api.Keys.Praos
 import           Cardano.Api.Keys.Shelley
-import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseTextEnvelope
 import           Cardano.Api.Tx

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -96,6 +96,7 @@ module Cardano.Api.ProtocolParameters (
   ) where
 
 import           Cardano.Api.Address
+import           Cardano.Api.Domain.Common
 import           Cardano.Api.Domain.PraosNonce
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
@@ -1913,10 +1914,6 @@ data ProtocolParametersConversionError
   | PpceInvalidCostModel !CostModel !Alonzo.CostModelApplyError
   | PpceMissingParameter !ProtocolParameterName
   deriving (Eq, Show, Data)
-
-
-type ProtocolParameterName = String
-type ProtocolParameterVersion = Natural
 
 instance Error ProtocolParametersConversionError where
   displayError = \case

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -18,6 +18,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {- HLINT ignore "Redundant ==" -}
+{- HLINT ignore "Use mapM" -}
 
 -- | The various Cardano protocol parameters, including:
 --
@@ -978,6 +979,11 @@ instance FeatureInEra ProtocolUTxOCostPerByteFeature where
     BabbageEra  -> yes ProtocolUTxOCostPerByteInBabbageEra
     ConwayEra   -> yes ProtocolUTxOCostPerByteInConwayEra
 
+instance ToCardanoEra ProtocolUTxOCostPerByteFeature where
+  toCardanoEra = \case
+    ProtocolUTxOCostPerByteInBabbageEra -> BabbageEra
+    ProtocolUTxOCostPerByteInConwayEra  -> ConwayEra
+
 -- | A representation of whether the era supports the 'UTxO Cost Per Word'
 -- protocol parameter.
 --
@@ -998,6 +1004,10 @@ instance FeatureInEra ProtocolUTxOCostPerWordFeature where
     AlonzoEra   -> yes ProtocolUpdateUTxOCostPerWordInAlonzoEra
     BabbageEra  -> no
     ConwayEra   -> no
+
+instance ToCardanoEra ProtocolUTxOCostPerWordFeature where
+  toCardanoEra = \case
+    ProtocolUpdateUTxOCostPerWordInAlonzoEra -> AlonzoEra
 
 -- ----------------------------------------------------------------------------
 -- Praos nonce
@@ -1954,4 +1964,3 @@ instance Error ProtocolParametersConversionError where
     PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
     PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
     PpceMissingParameter name -> "Missing parameter: " <> name
-

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -95,9 +95,9 @@ module Cardano.Api.ProtocolParameters (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Domain.CostModel
+import           Cardano.Api.Domain.Errors.ProtocolParametersError
 import           Cardano.Api.Domain.PraosNonce
 import           Cardano.Api.Eras.Core
-import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Json (toRationalJSON)
@@ -1825,22 +1825,3 @@ checkProtocolParameters sbe ProtocolParameters{..} =
      then return ()
      else Left . PParamsErrorMissingMinUTxoValue
                $ AnyCardanoEra era
-
-
-data ProtocolParametersError
-  = PParamsErrorMissingMinUTxoValue !AnyCardanoEra
-  | PParamsErrorMissingAlonzoProtocolParameter
-  deriving (Show)
-
-instance Error ProtocolParametersError where
-  displayError (PParamsErrorMissingMinUTxoValue (AnyCardanoEra era)) = mconcat
-    [ "The " <> show era <> " protocol parameters value is missing the following "
-    , "field: MinUTxoValue. Did you intend to use a " <> show era <> " protocol "
-    , "parameters value?"
-    ]
-  displayError PParamsErrorMissingAlonzoProtocolParameter = mconcat
-    [ "The Alonzo era protocol parameters in use is missing one or more of the "
-    , "following fields: UTxOCostPerWord, CostModels, Prices, MaxTxExUnits, "
-    , "MaxBlockExUnits, MaxValueSize, CollateralPercent, MaxCollateralInputs. Did "
-    , "you intend to use an Alonzo era protocol parameters value?"
-    ]

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -96,7 +96,7 @@ module Cardano.Api.ProtocolParameters (
   ) where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -58,7 +58,7 @@ module Cardano.Api.ProtocolParameters (
 
     -- * Execution units, prices and cost models,
     ExecutionUnits(..),
-    ExecutionUnitPrices(..),
+    LegacyExecutionUnitPrices(..),
     CostModel(..),
     fromAlonzoCostModels,
 
@@ -96,7 +96,7 @@ module Cardano.Api.ProtocolParameters (
 import           Cardano.Api.Address
 import           Cardano.Api.Domain.CostModel
 import           Cardano.Api.Domain.Errors.ProtocolParametersError
-import           Cardano.Api.Domain.ExecutionUnitPrices
+import           Cardano.Api.Domain.LegacyExecutionUnitPrices
 import           Cardano.Api.Domain.PraosNonce
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Hash
@@ -537,7 +537,7 @@ data ProtocolParameters =
        -- | Price of execution units for script languages that use them.
        --
        -- /Introduced in Alonzo/
-       protocolParamPrices :: Maybe ExecutionUnitPrices,
+       protocolParamPrices :: Maybe LegacyExecutionUnitPrices,
 
        -- | Max total script execution resources units allowed per tx
        --
@@ -776,7 +776,7 @@ data ProtocolParametersUpdate =
        -- | Price of execution units for script languages that use them.
        --
        -- /Introduced in Alonzo/
-       protocolUpdatePrices :: Maybe ExecutionUnitPrices,
+       protocolUpdatePrices :: Maybe LegacyExecutionUnitPrices,
 
        -- | Max total script execution resources units allowed per tx
        --

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -1,12 +1,10 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -96,7 +94,7 @@ module Cardano.Api.ProtocolParameters (
   ) where
 
 import           Cardano.Api.Address
-import           Cardano.Api.Domain.Common
+import           Cardano.Api.Domain.CostModel
 import           Cardano.Api.Domain.PraosNonce
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
@@ -115,7 +113,6 @@ import           Cardano.Api.Utils
 import           Cardano.Api.Value
 
 import qualified Cardano.Binary as CBOR
-import qualified Cardano.Ledger.Alonzo.Language as Alonzo
 import qualified Cardano.Ledger.Alonzo.PParams as Ledger
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.Api.Era as Ledger
@@ -130,8 +127,6 @@ import           Cardano.Slotting.Slot (EpochNo)
 import           Control.Monad
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.!=), (.:), (.:?),
                    (.=))
-import           Data.Bifunctor (bimap, first)
-import           Data.Data (Data)
 import           Data.Either.Combinators (maybeToRight)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -140,7 +135,6 @@ import           Data.Maybe.Strict (StrictMaybe (..))
 import           GHC.Generics
 import           Lens.Micro
 import           Numeric.Natural
-import           Text.PrettyBy.Default (display)
 
 
 -- -----------------------------------------------------------------------------
@@ -1068,62 +1062,6 @@ fromAlonzoPrices Alonzo.Prices{Alonzo.prSteps, Alonzo.prMem} =
   }
 
 
--- ----------------------------------------------------------------------------
--- Script cost models
---
-
-newtype CostModel = CostModel [Integer]
-  deriving (Eq, Show, Data)
-  deriving newtype (ToCBOR, FromCBOR)
-
-newtype CostModels = CostModels { unCostModels :: Map AnyPlutusScriptVersion CostModel }
-  deriving (Eq, Show)
-
-instance FromJSON CostModels where
-  parseJSON v = CostModels . fromAlonzoCostModels <$> parseJSON v
-
-instance ToJSON CostModels where
-  toJSON (CostModels costModels) =
-    case toAlonzoCostModels costModels of
-      Left err -> error $ displayError err
-      Right ledgerCostModels -> toJSON ledgerCostModels
-
-toAlonzoCostModels
-  :: Map AnyPlutusScriptVersion CostModel
-  -> Either ProtocolParametersConversionError Alonzo.CostModels
-toAlonzoCostModels m = do
-  f <- mapM conv $ Map.toList m
-  Right (Alonzo.emptyCostModels { Alonzo.costModelsValid = Map.fromList f })
- where
-  conv :: (AnyPlutusScriptVersion, CostModel) -> Either ProtocolParametersConversionError (Alonzo.Language, Alonzo.CostModel)
-  conv (anySVer, cModel) = do
-    alonzoCostModel <- toAlonzoCostModel cModel (toAlonzoScriptLanguage anySVer)
-    Right (toAlonzoScriptLanguage anySVer, alonzoCostModel)
-
-fromAlonzoCostModels
-  :: Alonzo.CostModels
-  -> Map AnyPlutusScriptVersion CostModel
-fromAlonzoCostModels (Alonzo.CostModels m _ _) =
-    Map.fromList
-  . map (bimap fromAlonzoScriptLanguage fromAlonzoCostModel)
-  $ Map.toList m
-
-toAlonzoScriptLanguage :: AnyPlutusScriptVersion -> Alonzo.Language
-toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV1) = Alonzo.PlutusV1
-toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV2) = Alonzo.PlutusV2
-toAlonzoScriptLanguage (AnyPlutusScriptVersion PlutusScriptV3) = Alonzo.PlutusV3
-
-fromAlonzoScriptLanguage :: Alonzo.Language -> AnyPlutusScriptVersion
-fromAlonzoScriptLanguage Alonzo.PlutusV1 = AnyPlutusScriptVersion PlutusScriptV1
-fromAlonzoScriptLanguage Alonzo.PlutusV2 = AnyPlutusScriptVersion PlutusScriptV2
-fromAlonzoScriptLanguage Alonzo.PlutusV3 = AnyPlutusScriptVersion PlutusScriptV3
-
-toAlonzoCostModel :: CostModel -> Alonzo.Language -> Either ProtocolParametersConversionError Alonzo.CostModel
-toAlonzoCostModel (CostModel m) l = first (PpceInvalidCostModel (CostModel m)) $ Alonzo.mkCostModel l m
-
-fromAlonzoCostModel :: Alonzo.CostModel -> CostModel
-fromAlonzoCostModel m = CostModel $ Alonzo.getCostModelParams m
-
 
 -- ----------------------------------------------------------------------------
 -- Proposals embedded in transactions to update protocol parameters
@@ -1906,18 +1844,3 @@ instance Error ProtocolParametersError where
     , "MaxBlockExUnits, MaxValueSize, CollateralPercent, MaxCollateralInputs. Did "
     , "you intend to use an Alonzo era protocol parameters value?"
     ]
-
-
-data ProtocolParametersConversionError
-  = PpceOutOfBounds !ProtocolParameterName !Rational
-  | PpceVersionInvalid !ProtocolParameterVersion
-  | PpceInvalidCostModel !CostModel !Alonzo.CostModelApplyError
-  | PpceMissingParameter !ProtocolParameterName
-  deriving (Eq, Show, Data)
-
-instance Error ProtocolParametersConversionError where
-  displayError = \case
-    PpceOutOfBounds name r -> "Value for '" <> name <> "' is outside of bounds: " <> show (fromRational r :: Double)
-    PpceVersionInvalid majorProtVer -> "Major protocol version is invalid: " <> show majorProtVer
-    PpceInvalidCostModel cm err -> "Invalid cost model: " <> display err <> " Cost model: " <> show cm
-    PpceMissingParameter name -> "Missing parameter: " <> name

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -82,7 +82,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.IPC.Version
 import           Cardano.Api.Keys.Shelley

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -30,7 +30,7 @@ module Cardano.Api.Query.Expr
 import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.GenesisParameters
 import           Cardano.Api.IPC
 import           Cardano.Api.IPC.Monad

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -109,7 +109,7 @@ module Cardano.Api.Script (
   ) where
 
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -108,6 +107,7 @@ module Cardano.Api.Script (
     Hash(..),
   ) where
 
+import           Cardano.Api.Domain.ExecutionUnits
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
@@ -854,67 +854,6 @@ instance IsScriptWitnessInCtx WitCtxStake where
   scriptWitnessInCtx = ScriptWitnessForStakeAddr
 
 -- ----------------------------------------------------------------------------
--- Script execution units
---
-
--- | The units for how long a script executes for and how much memory it uses.
--- This is used to declare the resources used by a particular use of a script.
---
--- This type is also used to describe the limits for the maximum overall
--- execution units per transaction or per block.
---
-data ExecutionUnits =
-     ExecutionUnits {
-        -- | This corresponds roughly to the time to execute a script.
-        executionSteps  :: Natural,
-
-        -- | This corresponds roughly to the peak memory used during script
-        -- execution.
-        executionMemory :: Natural
-     }
-  deriving (Eq, Show)
-
-instance ToCBOR ExecutionUnits where
-  toCBOR ExecutionUnits{executionSteps, executionMemory} =
-      CBOR.encodeListLen 2
-   <> toCBOR executionSteps
-   <> toCBOR executionMemory
-
-instance FromCBOR ExecutionUnits where
-  fromCBOR = do
-    CBOR.enforceSize "ExecutionUnits" 2
-    ExecutionUnits
-      <$> fromCBOR
-      <*> fromCBOR
-
-instance ToJSON ExecutionUnits where
-  toJSON ExecutionUnits{executionSteps, executionMemory} =
-    object [ "steps"  .= executionSteps
-           , "memory" .= executionMemory ]
-
-instance FromJSON ExecutionUnits where
-  parseJSON =
-    Aeson.withObject "ExecutionUnits" $ \o ->
-      ExecutionUnits
-        <$> o .: "steps"
-        <*> o .: "memory"
-
-toAlonzoExUnits :: ExecutionUnits -> Alonzo.ExUnits
-toAlonzoExUnits ExecutionUnits{executionSteps, executionMemory} =
-  Alonzo.ExUnits {
-    Alonzo.exUnitsSteps = executionSteps,
-    Alonzo.exUnitsMem   = executionMemory
-  }
-
-fromAlonzoExUnits :: Alonzo.ExUnits -> ExecutionUnits
-fromAlonzoExUnits Alonzo.ExUnits{Alonzo.exUnitsSteps, Alonzo.exUnitsMem} =
-  ExecutionUnits {
-    executionSteps  = exUnitsSteps,
-    executionMemory = exUnitsMem
-  }
-
-
--- ----------------------------------------------------------------------------
 -- Script Hash
 --
 
@@ -1376,11 +1315,11 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
         ReferenceScript refSupInEra <$> o .: "referenceScript"
 
 instance EraCast ReferenceScript where
-  eraCast toEra = \case
+  eraCast era = \case
     ReferenceScriptNone -> pure ReferenceScriptNone
     v@(ReferenceScript (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptInAnyLang) ->
-      case refInsScriptsAndInlineDatsSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+      case refInsScriptsAndInlineDatsSupportedInEra era of
+        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) era
         Just supportedInEra -> Right $ ReferenceScript supportedInEra scriptInAnyLang
 
 data ReferenceTxInsScriptsInlineDatumsSupportedInEra era where

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -45,7 +45,7 @@ module Cardano.Api.ScriptData (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -30,7 +30,7 @@ module Cardano.Api.SerialiseLedgerCddl
   )
   where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseTextEnvelope.hs
@@ -34,7 +34,7 @@ module Cardano.Api.SerialiseTextEnvelope
   , AsType(..)
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.IO

--- a/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/StakePoolMetadata.hs
@@ -15,7 +15,7 @@ module Cardano.Api.StakePoolMetadata (
     Hash(..),
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Hash
 import           Cardano.Api.HasTypeProxy

--- a/cardano-api/internal/Cardano/Api/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Tx.hs
@@ -50,7 +50,8 @@ module Cardano.Api.Tx (
 
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.Keys.Class

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -4327,7 +4327,7 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
              (Shelley.KeyHashObj kh)
              Shelley.StakeRefNull
 
-calculateExecutionUnitsLovelace :: ExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
+calculateExecutionUnitsLovelace :: LegacyExecutionUnitPrices -> ExecutionUnits -> Maybe Lovelace
 calculateExecutionUnitsLovelace euPrices eUnits =
   case toAlonzoPrices euPrices of
     Left _ -> Nothing

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -188,7 +188,8 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Convenience.Constraints
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Governance.Actions.ProposalProcedure

--- a/cardano-api/internal/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/TxMetadata.hs
@@ -47,7 +47,7 @@ module Cardano.Api.TxMetadata (
     AsType(..)
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.SerialiseCBOR (SerialiseAsCBOR (..))

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -31,7 +31,8 @@ module Cardano.Api.Utils
   , bounded
   ) where
 
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 
 import           Cardano.Ledger.Shelley ()
 

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 
 #if !defined(mingw32_HOST_OS)
 #define UNIX
@@ -31,7 +30,6 @@ module Cardano.Api.Utils
   , bounded
   ) where
 
-import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
 
 import           Cardano.Ledger.Shelley ()

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -56,16 +56,14 @@ module Cardano.Api.Value
   , AsType(..)
   ) where
 
+import           Cardano.Api.Domain.Lovelace
 import           Cardano.Api.Error (displayError)
 import           Cardano.Api.HasTypeProxy
 import           Cardano.Api.Script
-import           Cardano.Api.SerialiseCBOR
 import           Cardano.Api.SerialiseRaw
 import           Cardano.Api.SerialiseUsing
 import           Cardano.Api.Utils (failEitherWith)
 
-import qualified Cardano.Chain.Common as Byron
-import qualified Cardano.Ledger.Coin as Shelley
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Mary.TxOut as Mary (scaledMinDeposit)
 import           Cardano.Ledger.Mary.Value (MaryValue (..))
@@ -88,41 +86,6 @@ import           Data.String (IsString (..))
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-
--- ----------------------------------------------------------------------------
--- Lovelace
---
-
-newtype Lovelace = Lovelace Integer
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (Enum, Real, Integral, Num, ToJSON, FromJSON, ToCBOR, FromCBOR)
-
-instance Semigroup Lovelace where
-  Lovelace a <> Lovelace b = Lovelace (a + b)
-
-instance Monoid Lovelace where
-  mempty = Lovelace 0
-
-
-toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
-toByronLovelace (Lovelace x) =
-    case Byron.integerToLovelace x of
-      Left  _  -> Nothing
-      Right x' -> Just x'
-
-fromByronLovelace :: Byron.Lovelace -> Lovelace
-fromByronLovelace = Lovelace . Byron.lovelaceToInteger
-
-toShelleyLovelace :: Lovelace -> Shelley.Coin
-toShelleyLovelace (Lovelace l) = Shelley.Coin l
---TODO: validate bounds
-
-fromShelleyLovelace :: Shelley.Coin -> Lovelace
-fromShelleyLovelace (Shelley.Coin l) = Lovelace l
-
-fromShelleyDeltaLovelace :: Shelley.DeltaCoin -> Lovelace
-fromShelleyDeltaLovelace (Shelley.DeltaCoin d) = Lovelace d
-
 
 -- ----------------------------------------------------------------------------
 -- Multi asset Value

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -953,7 +953,8 @@ import           Cardano.Api.Convenience.Query
 import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -46,6 +46,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAllegraEra(..),
+    IsShelleyToAllegraEra(..),
+    AnyShelleyToAllegraEra(..),
+    shelleyToAllegraEraConstraints,
+    shelleyToAllegraEraToCardanoEra,
+    shelleyToAllegraEraToShelleyBasedEra,
+
     ShelleyToAlonzoEra(..),
     IsShelleyToAlonzoEra(..),
     AnyShelleyToAlonzoEra(..),
@@ -990,6 +997,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Feature.ShelleyToMaryEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -30,6 +30,8 @@ module Cardano.Api (
     -- * Feature support
     FeatureInEra(..),
     inEraFeature,
+    justFeatureInEra,
+    justInEraFeature,
     maybeFeatureInEra,
     featureInShelleyBasedEra,
     inShelleyBasedEraFeature,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -25,6 +25,7 @@ module Cardano.Api (
     anyCardanoEra,
     cardanoEraConstraints,
     InAnyCardanoEra(..),
+    ToCardanoEra(..),
 
     -- * Feature support
     FeatureInEra(..),

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -564,7 +564,7 @@ module Cardano.Api (
 
     -- ** Script execution units
     ExecutionUnits(..),
-    ExecutionUnitPrices(..),
+    LegacyExecutionUnitPrices(..),
     CostModel(..),
     toAlonzoCostModel,
     fromAlonzoCostModel,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -53,6 +53,13 @@ module Cardano.Api (
     shelleyToAlonzoEraToCardanoEra,
     shelleyToAlonzoEraToShelleyBasedEra,
 
+    ShelleyToMaryEra(..),
+    IsShelleyToMaryEra(..),
+    AnyShelleyToMaryEra(..),
+    shelleyToMaryEraConstraints,
+    shelleyToMaryEraToCardanoEra,
+    shelleyToMaryEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -969,6 +976,7 @@ import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
+import           Cardano.Api.Feature.ShelleyToMaryEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis
 import           Cardano.Api.GenesisParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -46,6 +46,13 @@ module Cardano.Api (
     shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
+    ShelleyToAlonzoEra(..),
+    IsShelleyToAlonzoEra(..),
+    AnyShelleyToAlonzoEra(..),
+    shelleyToAlonzoEraConstraints,
+    shelleyToAlonzoEraToCardanoEra,
+    shelleyToAlonzoEraToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -960,6 +967,7 @@ import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra
 import           Cardano.Api.Fees
 import           Cardano.Api.Genesis

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -36,6 +36,7 @@ module Cardano.Api (
     Featured(..),
     asFeaturedInEra,
     asFeaturedInShelleyBasedEra,
+    InAnyEra(..),
 
     -- * Features
     ShelleyToBabbageEra(..),
@@ -955,6 +956,7 @@ import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras.Constraints
 import           Cardano.Api.Eras.Core
+import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -60,6 +60,13 @@ module Cardano.Api (
     shelleyToMaryEraToCardanoEra,
     shelleyToMaryEraToShelleyBasedEra,
 
+    AlonzoEraOnwards(..),
+    IsAlonzoEraOnwards(..),
+    AnyAlonzoEraOnwards(..),
+    alonzoEraOnwardsConstraints,
+    alonzoEraOnwardsToCardanoEra,
+    alonzoEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -973,6 +980,7 @@ import           Cardano.Api.Eras.Core
 import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -74,6 +74,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    AlonzoEraOnly(..),
+    IsAlonzoEraOnly(..),
+    AnyAlonzoEraOnly(..),
+    alonzoEraOnlyConstraints,
+    alonzoEraOnlyToCardanoEra,
+    alonzoEraOnlyToShelleyBasedEra,
+
     BabbageEraOnwards(..),
     IsBabbageEraOnwards(..),
     AnyBabbageEraOnwards(..),
@@ -994,6 +1001,7 @@ import           Cardano.Api.Eras.Core
 import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
+import           Cardano.Api.Feature.AlonzoEraOnly
 import           Cardano.Api.Feature.AlonzoEraOnwards
 import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -67,6 +67,13 @@ module Cardano.Api (
     alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
+    BabbageEraOnwards(..),
+    IsBabbageEraOnwards(..),
+    AnyBabbageEraOnwards(..),
+    babbageEraOnwardsConstraints,
+    babbageEraOnwardsToCardanoEra,
+    babbageEraOnwardsToShelleyBasedEra,
+
     ConwayEraOnwards(..),
     IsConwayEraOnwards(..),
     AnyConwayEraOnwards(..),
@@ -981,6 +988,7 @@ import           Cardano.Api.Eras.InAnyEra
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
 import           Cardano.Api.Feature.ConwayEraOnwards
 import           Cardano.Api.Feature.ShelleyToAlonzoEra
 import           Cardano.Api.Feature.ShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -289,7 +289,7 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.DRepMetadata
-import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Genesis
 import           Cardano.Api.Governance.Actions.ProposalProcedure
 import           Cardano.Api.Governance.Actions.VotingProcedure

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceInvalidCostModel.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceInvalidCostModel.txt
@@ -1,0 +1,1 @@
+Invalid cost model: applyParams error: Internal problem occurred upon generating the applied cost model parameters with JSON error: <string> Cost model: CostModel [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42]

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceMissingParameter.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceMissingParameter.txt
@@ -1,0 +1,1 @@
+Missing parameter: pparam

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceOutOfBounds.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceOutOfBounds.txt
@@ -1,0 +1,1 @@
+Value for 'pparam' is outside of bounds: 0.1

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceVersionInvalid.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Domain.CostModel.ProtocolParametersConversionError/PpceVersionInvalid.txt
@@ -1,0 +1,1 @@
+Major protocol version is invalid: 99999

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -4,7 +4,7 @@ module Test.Cardano.Api.Eras
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Orphans ()
 
 import           Data.Aeson (ToJSON (..), decode, encode)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -4,7 +4,7 @@ module Test.Cardano.Api.IO
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.Error
 import           Cardano.Api.IO
 
 import           Control.Monad.Except (runExceptT)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -6,8 +6,10 @@ module Test.Cardano.Api.Json
   ( tests
   ) where
 
+import           Cardano.Api.Eras
+import           Cardano.Api.Modes
 import           Cardano.Api.Orphans ()
-import           Cardano.Api.Shelley
+import           Cardano.Api.ScriptData
 
 import           Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), eitherDecode, encode)
 import           Data.Aeson.Types (Parser, parseEither)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/KeysByron.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/KeysByron.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.KeysByron
   ( tests
   ) where
 
-import           Cardano.Api (AsType (AsByronKey, AsSigningKey), Key (deterministicSigningKey))
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
 
 import           Test.Cardano.Api.Typed.Orphans ()
 import qualified Test.Gen.Cardano.Crypto.Seed as Gen
@@ -14,8 +17,6 @@ import qualified Hedgehog as H
 import           Test.Hedgehog.Roundtrip.CBOR (trippingCbor)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 prop_roundtrip_byron_key_CBOR :: Property
 prop_roundtrip_byron_key_CBOR = H.property $ do

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
@@ -5,8 +5,7 @@ module Test.Cardano.Api.Ledger
   ( tests
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import           Cardano.Api.ScriptData
 
 import           Cardano.Ledger.Address (deserialiseAddr, serialiseAddr)
 import qualified Cardano.Ledger.Api as L

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
@@ -7,7 +7,7 @@ module Test.Cardano.Api.Metadata
   , genTxMetadataValue
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.TxMetadata
 
 import qualified Data.Aeson as Aeson
 import           Data.ByteString (ByteString)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Address.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Address.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE FlexibleContexts #-}
 
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.Typed.Address
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.Address
 
 import qualified Data.Aeson as Aeson
 
@@ -16,8 +18,6 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 -- Address CBOR round trips
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Bech32.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Bech32.hs
@@ -2,7 +2,7 @@ module Test.Cardano.Api.Typed.Bech32
   ( tests
   ) where
 
-import           Cardano.Api (AsType (AsShelleyAddress, AsStakeAddress))
+import           Cardano.Api.Address
 
 import           Test.Gen.Cardano.Api.Typed (genAddressShelley, genStakeAddress)
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/CBOR.hs
@@ -2,14 +2,22 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.Typed.CBOR
   ( tests
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley (AsType (..))
-
-import           Data.Proxy (Proxy (..))
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Governance.Poll
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Praos
+import           Cardano.Api.OperationalCertificate
+import           Cardano.Api.ProtocolParameters
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseLedgerCddl
+import           Cardano.Api.Tx
 
 import           Test.Gen.Cardano.Api.Typed
 
@@ -22,8 +30,6 @@ import qualified Test.Hedgehog.Roundtrip.CBOR as H
 import           Test.Hedgehog.Roundtrip.CBOR
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 -- TODO: Need to add PaymentExtendedKey roundtrip tests however
 -- we can't derive an Eq instance for Crypto.HD.XPrv

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Envelope.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.Typed.Envelope
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.HasTypeProxy
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
+import           Cardano.Api.Keys.Praos
+import           Cardano.Api.SerialiseTextEnvelope
 
 import           Test.Gen.Cardano.Api.Typed
 
@@ -15,8 +21,6 @@ import           Hedgehog (Property)
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 prop_roundtrip_ByronVerificationKey_envelope :: Property
 prop_roundtrip_ByronVerificationKey_envelope =

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/JSON.hs
@@ -4,11 +4,13 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.Typed.JSON
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.Eras
 
 import           Data.Aeson (eitherDecode, encode)
 
@@ -21,8 +23,6 @@ import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 prop_roundtrip_praos_nonce_JSON :: Property
 prop_roundtrip_praos_nonce_JSON = H.property $ do

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Ord.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Ord.hs
@@ -1,9 +1,14 @@
+{- HLINT ignore "Use camelCase" -}
+
 module Test.Cardano.Api.Typed.Ord
   ( tests
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import           Cardano.Api.Address
+import           Cardano.Api.Eras
+import           Cardano.Api.ScriptData
+import           Cardano.Api.TxIn
+import           Cardano.Api.TxMetadata
 
 import           Test.Gen.Cardano.Api.Typed
 
@@ -13,8 +18,6 @@ import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
-
-{- HLINT ignore "Use camelCase" -}
 
 ord_distributive :: (Show a, Ord a, Ord b)
                       => H.Gen a -> (a -> b) -> Property

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Orphans.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Orphans.hs
@@ -8,7 +8,9 @@
 
 module Test.Cardano.Api.Typed.Orphans () where
 
-import           Cardano.Api.Shelley
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Praos
+import           Cardano.Api.Keys.Shelley
 
 import           Cardano.Crypto.Hash hiding (Hash)
 import           Cardano.Crypto.KES

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/RawBytes.hs
@@ -5,7 +5,12 @@ module Test.Cardano.Api.Typed.RawBytes
   ( tests
   ) where
 
-import           Cardano.Api
+import           Cardano.Api.Address
+import           Cardano.Api.Keys.Byron
+import           Cardano.Api.Keys.Class
+import           Cardano.Api.Keys.Praos
+import           Cardano.Api.Script
+import           Cardano.Api.SerialiseRaw
 
 import           Test.Gen.Cardano.Api.Typed
 
@@ -23,7 +28,6 @@ import           Test.Tasty.Hedgehog (testProperty)
 prop_roundtrip_shelley_address_raw :: Property
 prop_roundtrip_shelley_address_raw =
   roundtrip_raw_bytes AsShelleyAddress genAddressShelley
-
 
 prop_roundtrip_byron_address_raw :: Property
 prop_roundtrip_byron_address_raw =

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -4,8 +4,10 @@ module Test.Cardano.Api.Typed.TxBody
   ( tests
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley (ReferenceScript (..), refScriptToShelleyScript)
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Script
+import           Cardano.Api.ScriptData
+import           Cardano.Api.TxBody
 
 import           Data.Maybe (isJust)
 import           Data.Type.Equality (TestEquality (testEquality))

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Value.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/Value.hs
@@ -2,8 +2,7 @@ module Test.Cardano.Api.Typed.Value
   ( tests
   ) where
 
-import           Cardano.Api (ValueNestedBundle (..), ValueNestedRep (..), valueFromNestedRep,
-                   valueToNestedRep)
+import           Cardano.Api.Value
 
 import           Prelude
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Features for protocol parameters and protocol parameter updates
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The substantive commits in this PR are the last five commits.   The earlier commits are quality of life commits that are included in https://github.com/input-output-hk/cardano-api/pull/184.  For those earlier commits, please review them in that PR.

This PR introduces a brand new parameterised `ProtocolParameters era` data type that lives in `Cardano.Api.Domain.ProtocolParameters`.

The switch over to use this type has not happened yet.  Rather this PR is meant to demonstrate are particular approach to the parameterisation of `ProtocolParameters` for consideration as it provides a number of advantages.

## Quality of Life changes
It uses the quality of life changes from the earlier PR which provides new features that are useful but not specific to the parameterisation of `ProtocolParameters`.  This encourages code re-use.

## Newtype
It is a `newtype` wrapper around the `Ledger` type.  This means the type as simple as it can be whilst still being a distinct API type.  But offering no new structure, it relies completely on the `Ledger` for type cues.

The main motivation for the `newtype` is to allow for the `cardano-api` to control JSON and perhaps CBOR serialisation, but the `newtype` is not a necessary design aspect of the PR.

## Lenses
It uses lenses.  If the intent is to minimise and eventually get rid of `cardano-api`, the use of lenses in unavoidable going forward.  The introduction of lens provides a nice succinct way to both get and set fields in protocol parameters.  

Furthermore instead of have just plain lenses, we have functions that return a lens in return for a feature witness.  This is what bridges the GADT based `cardano-api` way of era type-check with Ledger style type family type class constraints.

## `ToJSON` and `FromJSON` intances
There is an incomplete, `ToJSON` and `FromJSON` instance.  These instances are currently for illustration only.

It shows that it is possible with a combination of `featurInEra`, feature witnesses and lenses that is possible to write a `ToJSON` and `FromJSON` instance.

Moreover, the implementation of those instances are highly regular.  The type class instance can be extended with copy-past code.

Finally, the implementation of the `FromJSON` instance use the applicative style which demonstrates that it is possible to use this approach with `optparse-applicative`.

I can provide an in-person meeting to walk through this code.

## No breaking changes
This PR offers no breaking changes only because the rest of `cardano-api` does not yet integrate with it.  This will be in a future PR.  This shows the PR can demonstrate its advantages whilst being self contained.

Depends on: https://github.com/input-output-hk/cardano-api/pull/184

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
