### PR TITLE
Implement `unsafeEraCastLedgerProtocolParameters`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -54,6 +54,7 @@ library internal
                         Cardano.Api.Convenience.Construction
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
+                        Cardano.Api.Domain.ProtocolParameters
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -55,6 +55,7 @@ library internal
                         Cardano.Api.Convenience.Query
                         Cardano.Api.DeserialiseAnyOf
                         Cardano.Api.Domain.ProtocolParameters
+                        Cardano.Api.Domain.ProtocolParametersUpdate
                         Cardano.Api.DRepMetadata
                         Cardano.Api.EraCast
                         Cardano.Api.Eras

--- a/cardano-api/internal/Cardano/Api/Address.hs
+++ b/cardano-api/internal/Cardano/Api/Address.hs
@@ -473,7 +473,7 @@ instance EraCast (AddressTypeInEra addrtype) where
     ByronAddressInAnyEra -> pure ByronAddressInAnyEra
     ShelleyAddressInEra previousEra ->
       case cardanoEraStyle toEra' of
-        LegacyByronEra -> Left $ EraCastError v (shelleyBasedToCardanoEra previousEra) toEra'
+        LegacyByronEra -> Left $ EraCastError (shelleyBasedToCardanoEra previousEra) toEra'
         ShelleyBasedEra newSbe -> Right $ ShelleyAddressInEra newSbe
 
 byronAddressInEra :: Address ByronAddr -> AddressInEra era

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -273,8 +273,7 @@ instance EraCast Certificate where
           $ inEraFeature targetEra
               ( inEraFeature targetEra
                   ( Left $ EraCastError
-                      { originalValue = cert
-                      , fromEra = shelleyToBabbageEraToCardanoEra sourceWit
+                      { fromEra = shelleyToBabbageEraToCardanoEra sourceWit
                       , toEra = targetEra
                       }
                   )
@@ -284,8 +283,7 @@ instance EraCast Certificate where
                           Just targetLedgerCert -> Right $ ConwayCertificate tgtw targetLedgerCert
                           Nothing ->
                             Left $ EraCastError
-                              { originalValue = cert
-                              , fromEra = shelleyToBabbageEraToCardanoEra sourceWit
+                              { fromEra = shelleyToBabbageEraToCardanoEra sourceWit
                               , toEra = targetEra
                               }
                   )
@@ -302,8 +300,7 @@ instance EraCast Certificate where
           $ inEraFeature targetEra
               ( inEraFeature targetEra
                   ( Left $ EraCastError
-                      { originalValue = cert
-                      , fromEra = conwayEraOnwardsToCardanoEra sourceWit
+                      { fromEra = conwayEraOnwardsToCardanoEra sourceWit
                       , toEra = targetEra
                       }
                   )
@@ -313,8 +310,7 @@ instance EraCast Certificate where
                           Just targetLedgerCert -> Right $ ShelleyRelatedCertificate targetWit targetLedgerCert
                           Nothing ->
                             Left $ EraCastError
-                              { originalValue = cert
-                              , fromEra = conwayEraOnwardsToCardanoEra sourceWit
+                              { fromEra = conwayEraOnwardsToCardanoEra sourceWit
                               , toEra = targetEra
                               }
                   )

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParameters.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Domain.ProtocolParameters
+  ( emptyProtocolParameters
+  , protocolParamProtocolVersionL
+  , protocolParamDecentralizationL
+  , protocolParamExtraPraosEntropyL
+  , protocolParamMaxBlockHeaderSizeL
+  , protocolParamMaxBlockBodySizeL
+  , protocolParamMaxTxSizeL
+  , protocolParamTxFeeFixedL
+  , protocolParamTxFeePerByteL
+  , protocolParamMinUTxOValueL
+  , protocolParamStakeAddressDepositL
+  , protocolParamStakePoolDepositL
+  , protocolParamMinPoolCostL
+  , protocolParamPoolRetireMaxEpochL
+  , protocolParamStakePoolTargetNumL
+  , protocolParamPoolPledgeInfluenceL
+  , protocolParamMonetaryExpansionL
+  , protocolParamTreasuryCutL
+  , protocolParamUTxOCostPerWordL
+  , protocolParamCostModelsL
+  , protocolParamPricesL
+  , protocolParamMaxTxExUnitsL
+  , protocolParamMaxBlockExUnitsL
+  , protocolParamMaxValueSizeL
+  , protocolParamCollateralPercentL
+  , protocolParamMaxCollateralInputsL
+  , protocolParamUTxOCostPerByteL
+  ) where
+
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.AlonzoEraOnly
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
+
+import qualified Cardano.Ledger.Alonzo.Core as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import qualified Cardano.Ledger.Babbage.Core as Ledger
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
+
+import           GHC.Natural (Natural)
+import           Lens.Micro (Lens')
+
+emptyProtocolParameters :: ShelleyBasedEra era -> Ledger.PParams (ShelleyLedgerEra era)
+emptyProtocolParameters w = shelleyBasedEraConstraints w Ledger.emptyPParams
+
+-- | Protocol version, major and minor. Updating the major version is
+-- used to trigger hard forks.
+protocolParamProtocolVersionL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.ProtVer
+protocolParamProtocolVersionL w = shelleyBasedEraConstraints w Ledger.ppProtocolVersionL
+
+-- | The decentralization parameter. This is fraction of slots that
+-- belong to the BFT overlay schedule, rather than the Praos schedule.
+-- So 1 means fully centralised, while 0 means fully decentralised.
+--
+-- This is the \"d\" parameter from the design document.
+protocolParamDecentralizationL :: ShelleyToAlonzoEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.UnitInterval
+protocolParamDecentralizationL w = shelleyToAlonzoEraConstraints w Ledger.ppDL
+
+-- | Extra entropy for the Praos per-epoch nonce.
+--
+-- This can be used to add extra entropy during the decentralisation
+-- process. If the extra entropy can be demonstrated to be generated
+-- randomly then this method can be used to show that the initial
+-- federated operators did not subtly bias the initial schedule so that
+-- they retain undue influence after decentralisation.
+protocolParamExtraPraosEntropyL :: ShelleyToAlonzoEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Nonce
+protocolParamExtraPraosEntropyL w = shelleyToAlonzoEraConstraints w Ledger.ppExtraEntropyL
+
+-- | The maximum permitted size of a block header.
+--
+-- This must be at least as big as the largest legitimate block headers
+-- but should not be too much larger, to help prevent DoS attacks.
+--
+-- Caution: setting this to be smaller than legitimate block headers is
+-- a sure way to brick the system!
+protocolParamMaxBlockHeaderSizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamMaxBlockHeaderSizeL w = shelleyBasedEraConstraints w Ledger.ppMaxBHSizeL
+
+-- | The maximum permitted size of the block body (that is, the block
+-- payload, without the block header).
+--
+-- This should be picked with the Praos network delta security parameter
+-- in mind. Making this too large can severely weaken the Praos
+-- consensus properties.
+--
+-- Caution: setting this to be smaller than a transaction that can
+-- change the protocol parameters is a sure way to brick the system!
+protocolParamMaxBlockBodySizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamMaxBlockBodySizeL w = shelleyBasedEraConstraints w Ledger.ppMaxBBSizeL
+
+-- | The maximum permitted size of a transaction.
+--
+-- Typically this should not be too high a fraction of the block size,
+-- otherwise wastage from block fragmentation becomes a problem, and
+-- the current implementation does not use any sophisticated box packing
+-- algorithm.
+protocolParamMaxTxSizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamMaxTxSizeL w = shelleyBasedEraConstraints w Ledger.ppMaxTxSizeL
+
+-- | The constant factor for the minimum fee calculation.
+protocolParamTxFeeFixedL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamTxFeeFixedL w = shelleyBasedEraConstraints w Ledger.ppMinFeeBL
+
+-- | Per byte linear factor for the minimum fee calculation.
+protocolParamTxFeePerByteL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamTxFeePerByteL w = shelleyBasedEraConstraints w Ledger.ppMinFeeAL
+
+-- | The minimum permitted value for new UTxO entries, ie for
+-- transaction outputs.
+protocolParamMinUTxOValueL :: ShelleyToAllegraEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamMinUTxOValueL w = shelleyToAllegraEraConstraints w Ledger.ppMinUTxOValueL
+
+-- | The deposit required to register a stake address.
+protocolParamStakeAddressDepositL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamStakeAddressDepositL w = shelleyBasedEraConstraints w Ledger.ppKeyDepositL
+
+-- | The deposit required to register a stake pool.
+protocolParamStakePoolDepositL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamStakePoolDepositL w = shelleyBasedEraConstraints w Ledger.ppPoolDepositL
+
+-- | The minimum value that stake pools are permitted to declare for
+-- their cost parameter.
+protocolParamMinPoolCostL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Coin
+protocolParamMinPoolCostL w = shelleyBasedEraConstraints w Ledger.ppMinPoolCostL
+
+-- | The maximum number of epochs into the future that stake pools
+-- are permitted to schedule a retirement.
+protocolParamPoolRetireMaxEpochL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.EpochNo
+protocolParamPoolRetireMaxEpochL w = shelleyBasedEraConstraints w Ledger.ppEMaxL
+
+-- | The equilibrium target number of stake pools.
+-- This is the \"k\" incentives parameter from the design document.
+protocolParamStakePoolTargetNumL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamStakePoolTargetNumL w = shelleyBasedEraConstraints w Ledger.ppNOptL
+
+-- | The influence of the pledge in stake pool rewards.
+-- This is the \"a_0\" incentives parameter from the design document.
+protocolParamPoolPledgeInfluenceL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.NonNegativeInterval
+protocolParamPoolPledgeInfluenceL w = shelleyBasedEraConstraints w Ledger.ppA0L
+
+-- | The monetary expansion rate. This determines the fraction of the
+-- reserves that are added to the fee pot each epoch.
+-- This is the \"rho\" incentives parameter from the design document.
+protocolParamMonetaryExpansionL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.UnitInterval
+protocolParamMonetaryExpansionL w = shelleyBasedEraConstraints w Ledger.ppRhoL
+
+-- | The fraction of the fee pot each epoch that goes to the treasury.
+-- This is the \"tau\" incentives parameter from the design document.
+protocolParamTreasuryCutL :: ShelleyBasedEra era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.UnitInterval
+protocolParamTreasuryCutL w = shelleyBasedEraConstraints w Ledger.ppTauL
+
+-- | Cost in ada per word of UTxO storage.
+protocolParamUTxOCostPerWordL :: AlonzoEraOnly era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.CoinPerWord
+protocolParamUTxOCostPerWordL w = alonzoEraOnlyConstraints w Ledger.ppCoinsPerUTxOWordL
+
+-- | Cost models for script languages that use them.
+protocolParamCostModelsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.CostModels
+protocolParamCostModelsL w = alonzoEraOnwardsConstraints w Ledger.ppCostModelsL
+
+-- | Price of execution units for script languages that use them.
+protocolParamPricesL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.Prices
+protocolParamPricesL w = alonzoEraOnwardsConstraints w Ledger.ppPricesL
+
+-- | Max total script execution resources units allowed per tx
+protocolParamMaxTxExUnitsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.ExUnits
+protocolParamMaxTxExUnitsL w = alonzoEraOnwardsConstraints w Ledger.ppMaxTxExUnitsL
+
+-- | Max total script execution resources units allowed per block
+protocolParamMaxBlockExUnitsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.ExUnits
+protocolParamMaxBlockExUnitsL w = alonzoEraOnwardsConstraints w Ledger.ppMaxBlockExUnitsL
+
+-- | Max size of a Value in a tx output.
+protocolParamMaxValueSizeL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamMaxValueSizeL w = alonzoEraOnwardsConstraints w Ledger.ppMaxValSizeL
+
+-- | The percentage of the script contribution to the txfee that must be
+-- provided as collateral inputs when including Plutus scripts.
+protocolParamCollateralPercentL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamCollateralPercentL w = alonzoEraOnwardsConstraints w Ledger.ppCollateralPercentageL
+
+-- | The maximum number of collateral inputs allowed in a transaction.
+protocolParamMaxCollateralInputsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Natural
+protocolParamMaxCollateralInputsL w = alonzoEraOnwardsConstraints w Ledger.ppMaxCollateralInputsL
+
+-- | Cost in ada per byte of UTxO storage.
+protocolParamUTxOCostPerByteL :: BabbageEraOnwards era -> Lens' (Ledger.PParams (ShelleyLedgerEra era)) Ledger.CoinPerByte
+protocolParamUTxOCostPerByteL w = babbageEraOnwardsConstraints w Ledger.ppCoinsPerUTxOByteL

--- a/cardano-api/internal/Cardano/Api/Domain/ProtocolParametersUpdate.hs
+++ b/cardano-api/internal/Cardano/Api/Domain/ProtocolParametersUpdate.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Domain.ProtocolParametersUpdate
+  ( emptyProtocolParametersUpdate
+  , protocolUpdateProtocolVersionL
+  , protocolUpdateDecentralizationL
+  , protocolUpdateExtraPraosEntropyL
+  , protocolUpdateMaxBlockHeaderSizeL
+  , protocolUpdateMaxBlockBodySizeL
+  , protocolUpdateMaxTxSizeL
+  , protocolUpdateTxFeeFixedL
+  , protocolUpdateTxFeePerByteL
+  , protocolUpdateMinUTxOValueL
+  , protocolUpdateStakeAddressDepositL
+  , protocolUpdateStakePoolDepositL
+  , protocolUpdateMinPoolCostL
+  , protocolUpdatePoolRetireMaxEpochL
+  , protocolUpdateStakePoolTargetNumL
+  , protocolUpdatePoolPledgeInfluenceL
+  , protocolUpdateMonetaryExpansionL
+  , protocolUpdateTreasuryCutL
+  , protocolUpdateUTxOCostPerWordL
+  , protocolUpdateCostModelsL
+  , protocolUpdatePricesL
+  , protocolUpdateMaxTxExUnitsL
+  , protocolUpdateMaxBlockExUnitsL
+  , protocolUpdateMaxValueSizeL
+  , protocolUpdateCollateralPercentL
+  , protocolUpdateMaxCollateralInputsL
+  , protocolUpdateUTxOCostPerByteL
+  ) where
+
+import           Cardano.Api.Eras.Constraints
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Feature.AlonzoEraOnly
+import           Cardano.Api.Feature.AlonzoEraOnwards
+import           Cardano.Api.Feature.BabbageEraOnwards
+import           Cardano.Api.Feature.ShelleyToAllegraEra
+import           Cardano.Api.Feature.ShelleyToAlonzoEra
+
+import qualified Cardano.Ledger.Alonzo.Core as Ledger
+import qualified Cardano.Ledger.Alonzo.Scripts as Ledger
+import qualified Cardano.Ledger.Babbage.Core as Ledger
+import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as Ledger
+
+import           GHC.Natural (Natural)
+import           Lens.Micro (Lens')
+
+emptyProtocolParametersUpdate :: ShelleyBasedEra era -> Ledger.PParamsUpdate (ShelleyLedgerEra era)
+emptyProtocolParametersUpdate w = shelleyBasedEraConstraints w Ledger.emptyPParamsUpdate
+
+-- | Protocol version, major and minor. Updating the major version is used to
+-- trigger hard forks.
+protocolUpdateProtocolVersionL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.ProtVer)
+protocolUpdateProtocolVersionL w = shelleyBasedEraConstraints w Ledger.ppuProtocolVersionL
+
+-- | The decentralization parameter. This is fraction of slots that belong to
+-- the BFT overlay schedule, rather than the Praos schedule. So 1 means fully
+-- centralised, while 0 means fully decentralised.
+--
+-- This is the \"d\" parameter from the design document.
+protocolUpdateDecentralizationL :: ShelleyToAlonzoEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateDecentralizationL w = shelleyToAlonzoEraConstraints w Ledger.ppuDL
+
+-- | Extra entropy for the Praos per-epoch nonce.
+--
+-- This can be used to add extra entropy during the decentralisation process.
+-- If the extra entropy can be demonstrated to be generated randomly then this
+-- method can be used to show that the initial federated operators did not
+-- subtly bias the initial schedule so that they retain undue influence after
+-- decentralisation.
+protocolUpdateExtraPraosEntropyL :: ShelleyToAlonzoEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Nonce)
+protocolUpdateExtraPraosEntropyL w = shelleyToAlonzoEraConstraints w Ledger.ppuExtraEntropyL
+
+-- | The maximum permitted size of a block header.
+--
+-- This must be at least as big as the largest legitimate block headers but
+-- should not be too much larger, to help prevent DoS attacks.
+--
+-- Caution: setting this to be smaller than legitimate block headers is a sure
+-- way to brick the system!
+protocolUpdateMaxBlockHeaderSizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxBlockHeaderSizeL w = shelleyBasedEraConstraints w Ledger.ppuMaxBHSizeL
+
+-- | The maximum permitted size of the block body (that is, the block payload,
+-- without the block header).
+--
+-- This should be picked with the Praos network delta security parameter in
+-- mind. Making this too large can severely weaken the Praos consensus
+-- properties.
+--
+-- Caution: setting this to be smaller than a transaction that can change the
+-- protocol parameters is a sure way to brick the system!
+protocolUpdateMaxBlockBodySizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxBlockBodySizeL w = shelleyBasedEraConstraints w Ledger.ppuMaxBBSizeL
+
+-- | The maximum permitted size of a transaction.
+--
+-- Typically this should not be too high a fraction of the block size,
+-- otherwise wastage from block fragmentation becomes a problem, and the
+-- current implementation does not use any sophisticated box packing
+-- algorithm.
+protocolUpdateMaxTxSizeL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxTxSizeL w = shelleyBasedEraConstraints w Ledger.ppuMaxTxSizeL
+
+-- | The constant factor for the minimum fee calculation.
+protocolUpdateTxFeeFixedL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateTxFeeFixedL w = shelleyBasedEraConstraints w Ledger.ppuMinFeeBL
+
+-- | The linear factor for the minimum fee calculation.
+protocolUpdateTxFeePerByteL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateTxFeePerByteL w = shelleyBasedEraConstraints w Ledger.ppuMinFeeAL
+
+-- | The minimum permitted value for new UTxO entries, ie for transaction
+-- outputs.
+protocolUpdateMinUTxOValueL :: ShelleyToAllegraEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateMinUTxOValueL w = shelleyToAllegraEraConstraints w Ledger.ppuMinUTxOValueL
+
+-- | The deposit required to register a stake address.
+protocolUpdateStakeAddressDepositL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateStakeAddressDepositL w = shelleyBasedEraConstraints w Ledger.ppuKeyDepositL
+
+-- | The deposit required to register a stake pool.
+protocolUpdateStakePoolDepositL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateStakePoolDepositL w = shelleyBasedEraConstraints w Ledger.ppuPoolDepositL
+
+-- | The minimum value that stake pools are permitted to declare for their
+-- cost parameter.
+protocolUpdateMinPoolCostL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Coin)
+protocolUpdateMinPoolCostL w = shelleyBasedEraConstraints w Ledger.ppuMinPoolCostL
+
+-- | The maximum number of epochs into the future that stake pools are
+-- permitted to schedule a retirement.
+protocolUpdatePoolRetireMaxEpochL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.EpochNo)
+protocolUpdatePoolRetireMaxEpochL w = shelleyBasedEraConstraints w Ledger.ppuEMaxL
+
+-- | The equilibrium target number of stake pools.
+--
+-- This is the \"k\" incentives parameter from the design document.
+protocolUpdateStakePoolTargetNumL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateStakePoolTargetNumL w = shelleyBasedEraConstraints w Ledger.ppuNOptL
+
+-- | The influence of the pledge in stake pool rewards.
+--
+-- This is the \"a_0\" incentives parameter from the design document.
+protocolUpdatePoolPledgeInfluenceL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.NonNegativeInterval)
+protocolUpdatePoolPledgeInfluenceL w = shelleyBasedEraConstraints w Ledger.ppuA0L
+
+-- | The monetary expansion rate. This determines the fraction of the reserves
+-- that are added to the fee pot each epoch.
+--
+-- This is the \"rho\" incentives parameter from the design document.
+protocolUpdateMonetaryExpansionL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateMonetaryExpansionL w = shelleyBasedEraConstraints w Ledger.ppuRhoL
+
+-- | The fraction of the fee pot each epoch that goes to the treasury.
+--
+-- This is the \"tau\" incentives parameter from the design document.
+protocolUpdateTreasuryCutL :: ShelleyBasedEra era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.UnitInterval)
+protocolUpdateTreasuryCutL w = shelleyBasedEraConstraints w Ledger.ppuTauL
+
+-- | Cost in ada per word of UTxO storage.
+--
+-- /Obsoleted by 'protocolUpdateUTxOCostPerByte'/
+protocolUpdateUTxOCostPerWordL :: AlonzoEraOnly era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.CoinPerWord)
+protocolUpdateUTxOCostPerWordL w = alonzoEraOnlyConstraints w Ledger.ppuCoinsPerUTxOWordL
+
+-- | Cost models for script languages that use them.
+protocolUpdateCostModelsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.CostModels)
+protocolUpdateCostModelsL w = alonzoEraOnwardsConstraints w Ledger.ppuCostModelsL
+
+-- | Price of execution units for script languages that use them.
+protocolUpdatePricesL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.Prices)
+protocolUpdatePricesL w = alonzoEraOnwardsConstraints w Ledger.ppuPricesL
+
+-- | Max total script execution resources units allowed per tx
+protocolUpdateMaxTxExUnitsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.ExUnits)
+protocolUpdateMaxTxExUnitsL w = alonzoEraOnwardsConstraints w Ledger.ppuMaxTxExUnitsL
+
+-- | Max total script execution resources units allowed per block
+protocolUpdateMaxBlockExUnitsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.ExUnits)
+protocolUpdateMaxBlockExUnitsL w = alonzoEraOnwardsConstraints w Ledger.ppuMaxBlockExUnitsL
+
+-- | Max size of a 'Value' in a tx output.
+protocolUpdateMaxValueSizeL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxValueSizeL w = alonzoEraOnwardsConstraints w Ledger.ppuMaxValSizeL
+
+-- | The percentage of the script contribution to the txfee that must be
+-- provided as collateral inputs when including Plutus scripts.
+protocolUpdateCollateralPercentL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateCollateralPercentL w = alonzoEraOnwardsConstraints w Ledger.ppuCollateralPercentageL
+
+-- | The maximum number of collateral inputs allowed in a transaction.
+protocolUpdateMaxCollateralInputsL :: AlonzoEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Natural)
+protocolUpdateMaxCollateralInputsL w = alonzoEraOnwardsConstraints w Ledger.ppuMaxCollateralInputsL
+
+-- | Cost in ada per byte of UTxO storage.
+--
+-- /Supercedes 'protocolUpdateUTxOCostPerWord'/
+protocolUpdateUTxOCostPerByteL :: BabbageEraOnwards era -> Lens' (Ledger.PParamsUpdate (ShelleyLedgerEra era)) (Ledger.StrictMaybe Ledger.CoinPerByte)
+protocolUpdateUTxOCostPerByteL w = babbageEraOnwardsConstraints w Ledger.ppuCoinsPerUTxOByteL

--- a/cardano-api/internal/Cardano/Api/EraCast.hs
+++ b/cardano-api/internal/Cardano/Api/EraCast.hs
@@ -10,14 +10,12 @@ import           Cardano.Api.Eras (CardanoEra (..), IsCardanoEra)
 
 import           Data.Kind (Type)
 
-data EraCastError = forall fromEra toEra value.
+data EraCastError = forall fromEra toEra.
   ( IsCardanoEra fromEra
   , IsCardanoEra toEra
-  , Show value
   ) =>
     EraCastError
-    { originalValue :: value
-    , fromEra :: CardanoEra fromEra
+    { fromEra :: CardanoEra fromEra
     , toEra :: CardanoEra toEra
     }
 

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -24,6 +24,8 @@ module Cardano.Api.Eras
   , FeatureInEra(..)
   , inEraFeature
   , inEraFeatureMaybe
+  , in2ErasFeature
+
   , maybeFeatureInEra
 
   , featureInShelleyBasedEra

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -35,6 +35,8 @@ module Cardano.Api.Eras.Core
   , inEraFeature
   , inEraFeatureMaybe
   , maybeFeatureInEra
+  , justFeatureInEra
+  , justInEraFeature
   , featureInShelleyBasedEra
   , inShelleyBasedEraFeature
   , inShelleyBasedEraFeatureMaybe
@@ -166,6 +168,20 @@ maybeFeatureInEra :: ()
   -> Maybe (feature era)  -- ^ The feature if supported in the era
 maybeFeatureInEra =
   featureInEra Nothing Just
+
+justFeatureInEra :: ()
+  => FeatureInEra feature
+  => (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> CardanoEra era       -- ^ Era to check
+  -> Maybe a              -- ^ The value to use
+justFeatureInEra f = featureInEra Nothing (Just . f)
+
+justInEraFeature :: ()
+  => FeatureInEra feature
+  => CardanoEra era       -- ^ Era to check
+  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> Maybe a              -- ^ The value to use
+justInEraFeature era f = inEraFeature era Nothing (Just . f)
 
 -- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
 featureInShelleyBasedEra :: ()

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -34,6 +34,8 @@ module Cardano.Api.Eras.Core
   , FeatureInEra(..)
   , inEraFeature
   , inEraFeatureMaybe
+  , in2ErasFeature
+
   , maybeFeatureInEra
   , justFeatureInEra
   , justInEraFeature
@@ -161,6 +163,18 @@ inEraFeatureMaybe :: ()
   -> Maybe a              -- ^ The value to use
 inEraFeatureMaybe era yes =
   inEraFeature era Nothing (Just . yes)
+
+in2ErasFeature :: ()
+  => FeatureInEra feature
+  => CardanoEra era1                      -- ^ Era to check
+  -> CardanoEra era2                      -- ^ Era to check
+  -> a                                    -- ^ Value to use if the feature is not supported in the era
+  -> (feature era1 -> feature era2 -> a)  -- ^ Function to get thealue to use if the feature is supported in the era
+  -> a                                    -- ^ The value to use
+in2ErasFeature era1 era2 no yes =
+  inEraFeature era1 no $ \w1 ->
+    inEraFeature era2 no $ \w2 ->
+      yes w1 w2
 
 maybeFeatureInEra :: ()
   => FeatureInEra feature

--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -143,7 +143,7 @@ class FeatureInEra (feature :: Type -> Type) where
   -- the 'either' function convention.
   featureInEra :: ()
     => a                    -- ^ Value to use if the feature is not supported in the era
-    -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+    -> (feature era -> a)   -- ^ Function to get the value to use if the feature is supported in the era
     -> CardanoEra era       -- ^ Era to check
     -> a                    -- ^ The value to use
 
@@ -151,7 +151,7 @@ inEraFeature :: ()
   => FeatureInEra feature
   => CardanoEra era       -- ^ Era to check
   -> a                    -- ^ Value to use if the feature is not supported in the era
-  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> (feature era -> a)   -- ^ Function to get the value to use if the feature is supported in the era
   -> a                    -- ^ The value to use
 inEraFeature era no yes =
   featureInEra no yes era
@@ -159,7 +159,7 @@ inEraFeature era no yes =
 inEraFeatureMaybe :: ()
   => FeatureInEra feature
   => CardanoEra era       -- ^ Era to check
-  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> (feature era -> a)   -- ^ Function to get the value to use if the feature is supported in the era
   -> Maybe a              -- ^ The value to use
 inEraFeatureMaybe era yes =
   inEraFeature era Nothing (Just . yes)
@@ -169,7 +169,7 @@ in2ErasFeature :: ()
   => CardanoEra era1                      -- ^ Era to check
   -> CardanoEra era2                      -- ^ Era to check
   -> a                                    -- ^ Value to use if the feature is not supported in the era
-  -> (feature era1 -> feature era2 -> a)  -- ^ Function to get thealue to use if the feature is supported in the era
+  -> (feature era1 -> feature era2 -> a)  -- ^ Function to get the value to use if the feature is supported in the era
   -> a                                    -- ^ The value to use
 in2ErasFeature era1 era2 no yes =
   inEraFeature era1 no $ \w1 ->
@@ -185,7 +185,7 @@ maybeFeatureInEra =
 
 justFeatureInEra :: ()
   => FeatureInEra feature
-  => (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  => (feature era -> a)   -- ^ Function to get the value to use if the feature is supported in the era
   -> CardanoEra era       -- ^ Era to check
   -> Maybe a              -- ^ The value to use
 justFeatureInEra f = featureInEra Nothing (Just . f)
@@ -193,7 +193,7 @@ justFeatureInEra f = featureInEra Nothing (Just . f)
 justInEraFeature :: ()
   => FeatureInEra feature
   => CardanoEra era       -- ^ Era to check
-  -> (feature era -> a)   -- ^ Function to get thealue to use if the feature is supported in the era
+  -> (feature era -> a)   -- ^ Function to get the value to use if the feature is supported in the era
   -> Maybe a              -- ^ The value to use
 justInEraFeature era f = inEraFeature era Nothing (Just . f)
 

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -1402,9 +1402,9 @@ instance IsCardanoEra era => FromJSON (ReferenceScript era) where
 instance EraCast ReferenceScript where
   eraCast toEra = \case
     ReferenceScriptNone -> pure ReferenceScriptNone
-    v@(ReferenceScript (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptInAnyLang) ->
+    ReferenceScript (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptInAnyLang ->
       case refInsScriptsAndInlineDatsSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError (cardanoEra @fromEra) toEra
         Just supportedInEra -> Right $ ReferenceScript supportedInEra scriptInAnyLang
 
 data ReferenceTxInsScriptsInlineDatumsSupportedInEra era where

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -1374,7 +1374,7 @@ instance EraCast TxOutValue where
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp $ lovelaceToValue lovelace
     TxOutValue  (_ :: MultiAssetSupportedInEra fromEra) value  ->
       case multiAssetSupportedInEra toEra of
-        Left _adaOnly -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Left _adaOnly -> Left $ EraCastError (cardanoEra @fromEra) toEra
         Right multiAssetSupp -> Right $ TxOutValue multiAssetSupp value
 
 
@@ -1530,17 +1530,17 @@ instance EraCast (TxOutDatum ctx)  where
     TxOutDatumNone -> pure TxOutDatumNone
     TxOutDatumHash (_ :: ScriptDataSupportedInEra fromEra) hash ->
       case scriptDataSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError (cardanoEra @fromEra) toEra
         Just sDatumsSupported ->
           Right $ TxOutDatumHash sDatumsSupported hash
     TxOutDatumInTx' (_ :: ScriptDataSupportedInEra fromEra) scriptData hash ->
       case scriptDataSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError (cardanoEra @fromEra) toEra
         Just sDatumsSupported ->
           Right $ TxOutDatumInTx' sDatumsSupported scriptData hash
     TxOutDatumInline (_ :: ReferenceTxInsScriptsInlineDatumsSupportedInEra fromEra) scriptData ->
       case refInsScriptsAndInlineDatsSupportedInEra toEra of
-        Nothing -> Left $ EraCastError v (cardanoEra @fromEra) toEra
+        Nothing -> Left $ EraCastError (cardanoEra @fromEra) toEra
         Just refInsAndInlineSupported ->
           Right $ TxOutDatumInline refInsAndInlineSupported scriptData
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -31,6 +31,8 @@ module Cardano.Api (
     FeatureInEra(..),
     inEraFeature,
     inEraFeatureMaybe,
+    justFeatureInEra,
+    justInEraFeature,
     maybeFeatureInEra,
 
     featureInShelleyBasedEra,
@@ -1010,6 +1012,7 @@ import           Cardano.Api.DeserialiseAnyOf
 import           Cardano.Api.DRepMetadata
 import           Cardano.Api.EraCast
 import           Cardano.Api.Eras
+import           Cardano.Api.Eras.Core
 import           Cardano.Api.Error
 import           Cardano.Api.Feature
 import           Cardano.Api.Feature.AlonzoEraOnly

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -31,6 +31,8 @@ module Cardano.Api (
     FeatureInEra(..),
     inEraFeature,
     inEraFeatureMaybe,
+    in2ErasFeature,
+
     justFeatureInEra,
     justInEraFeature,
     maybeFeatureInEra,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -1002,6 +1002,8 @@ module Cardano.Api (
     makeDrepUnregistrationCertificate,
 
     ResolvablePointers(..),
+
+    unsafeEraCastLedgerProtocolParameters,
   ) where
 
 import           Cardano.Api.Address


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Implement `unsafeEraCastLedgerProtocolParameters`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`unsafeEraCastLedgerProtocolParameters` will case `LedgerProtocolParameters` from any shelley-based era to any other shelley-based era.

As noted in the comments, the function is unsafe and its use in inadvisable.

However, I would like to merge this PR for two reasons:

* It provides an example of how to use `Applicative` to construct ledger values.  An inclusion of an example in `cardano-api` will be useful for implementing safe functionality for other ledger types.  And since this is the first such example written for `cardano-api` it ought to be included for that purpose.
* I have some ideas on how expose unsafe functionality in `cardano-cli` in a principled manner and would like to use this to try it out.  This doesn't necessarily have any bearing on whether _this_ functionality will be exposed, but there are other technically unsafe operations _we do want to expose_ (era-upgrade of transactions for example) so we want to have the ability to expose unsafe functionality from `cardano-cli` in general.  Doing it for this functionality could prove a useful proof of concept.

To ensure the function is not abused, it has been appropriately prefixed with the word `unsafe`.

We can later decide after more supporting code is written and merged that we definitely do not want this functionality and delete it at that point.

This uses newly defined features in `Cardano.Api.Features.*` to automatically determine if a field can be casted.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
