### PR TITLE
Use fewer constraints. New `MaryEraOnly` eon

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library internal
                         Cardano.Api.Eon.ByronToAlonzoEra
                         Cardano.Api.Eon.ByronToMaryEra
                         Cardano.Api.Eon.ConwayEraOnwards
+                        Cardano.Api.Eon.MaryEraOnly
                         Cardano.Api.Eon.MaryEraOnwards
                         Cardano.Api.Eon.ShelleyBasedEra
                         Cardano.Api.Eon.ShelleyEraOnly

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnly.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Cardano.Api.Eon.MaryEraOnly
+  ( MaryEraOnly(..)
+  , maryEraOnlyConstraints
+  , maryEraOnlyToCardanoEra
+  , maryEraOnlyToShelleyBasedEra
+
+  , MaryEraOnlyConstraints
+  ) where
+
+import           Cardano.Api.Eon.ShelleyBasedEra
+import           Cardano.Api.Eras.Core
+import           Cardano.Api.Modes
+import           Cardano.Api.Query.Types
+
+import           Cardano.Binary
+import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Crypto.Hash.Class as C
+import qualified Cardano.Crypto.VRF as C
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Core as L
+import qualified Cardano.Ledger.Mary.Value as L
+import qualified Cardano.Ledger.SafeHash as L
+import qualified Cardano.Ledger.UTxO as L
+import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
+import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import qualified Ouroboros.Consensus.Shelley.Ledger as Consensus
+
+import           Data.Aeson
+import           Data.Typeable (Typeable)
+
+data MaryEraOnly era where
+  MaryEraOnlyMary  :: MaryEraOnly MaryEra
+
+deriving instance Show (MaryEraOnly era)
+deriving instance Eq (MaryEraOnly era)
+
+instance Eon MaryEraOnly where
+  inEonForEra no yes = \case
+    ByronEra    -> no
+    ShelleyEra  -> no
+    AllegraEra  -> no
+    MaryEra     -> yes MaryEraOnlyMary
+    AlonzoEra   -> no
+    BabbageEra  -> no
+    ConwayEra   -> no
+
+instance ToCardanoEra MaryEraOnly where
+  toCardanoEra = \case
+    MaryEraOnlyMary    -> MaryEra
+
+type MaryEraOnlyConstraints era =
+  ( C.HashAlgorithm (L.HASH (L.EraCrypto (ShelleyLedgerEra era)))
+  , C.Signable (L.VRF (L.EraCrypto (ShelleyLedgerEra era))) L.Seed
+  , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
+  , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , L.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
+  , L.Crypto (L.EraCrypto (ShelleyLedgerEra era))
+  , L.Era (ShelleyLedgerEra era)
+  , L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
+  , L.EraPParams (ShelleyLedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
+  , L.EraTxBody (ShelleyLedgerEra era)
+  , L.EraUTxO (ShelleyLedgerEra era)
+  , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
+  , L.MaryEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxBody (ShelleyLedgerEra era)
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue L.StandardCrypto
+
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (DebugLedgerState era)
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
+  , ToJSON (DebugLedgerState era)
+  , Typeable era
+  )
+
+maryEraOnlyConstraints :: ()
+  => MaryEraOnly era
+  -> (MaryEraOnlyConstraints era => a)
+  -> a
+maryEraOnlyConstraints = \case
+  MaryEraOnlyMary    -> id
+
+maryEraOnlyToCardanoEra :: MaryEraOnly era -> CardanoEra era
+maryEraOnlyToCardanoEra = shelleyBasedToCardanoEra . maryEraOnlyToShelleyBasedEra
+
+maryEraOnlyToShelleyBasedEra :: MaryEraOnly era -> ShelleyBasedEra era
+maryEraOnlyToShelleyBasedEra = \case
+  MaryEraOnlyMary    -> ShelleyBasedEraMary

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -19,6 +19,9 @@ module Cardano.Api.Eras.Case
   , caseShelleyToAlonzoOrBabbageEraOnwards
   , caseShelleyToBabbageOrConwayEraOnwards
 
+    -- Case on MaryEraOnwards
+  , caseMaryEraOnlyOrAlonzoEraOnwards
+
     -- Case on AlonzoEraOnwards
   , caseAlonzoOnlyOrBabbageEraOnwards
 
@@ -45,6 +48,7 @@ import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra
 import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
+import           Cardano.Api.Eon.MaryEraOnly
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyEraOnly
@@ -189,6 +193,17 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraAlonzo  -> l ShelleyToBabbageEraAlonzo
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway  -> r ConwayEraOnwardsConway
+
+caseMaryEraOnlyOrAlonzoEraOnwards :: ()
+  => (MaryEraOnly era -> a)
+  -> (AlonzoEraOnwards era -> a)
+  -> MaryEraOnwards era
+  -> a
+caseMaryEraOnlyOrAlonzoEraOnwards l r = \case
+  MaryEraOnwardsMary    -> l MaryEraOnlyMary
+  MaryEraOnwardsAlonzo  -> r AlonzoEraOnwardsAlonzo
+  MaryEraOnwardsBabbage -> r AlonzoEraOnwardsBabbage
+  MaryEraOnwardsConway  -> r AlonzoEraOnwardsConway
 
 caseAlonzoOnlyOrBabbageEraOnwards :: ()
   => (AlonzoEraOnly era -> a)

--- a/cardano-api/internal/Cardano/Api/Eras/Case.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Case.hs
@@ -24,6 +24,8 @@ module Cardano.Api.Eras.Case
 
     -- Proofs
   , noByronEraInShelleyBasedEra
+  , disjointAlonzoEraOnlyAndBabbageEraOnwards
+  , disjointByronEraOnlyAndShelleyBasedEra
 
     -- Conversions
   , shelleyToAllegraEraToByronToAllegraEra
@@ -198,8 +200,17 @@ caseAlonzoOnlyOrBabbageEraOnwards l r = \case
   AlonzoEraOnwardsBabbage -> r BabbageEraOnwardsBabbage
   AlonzoEraOnwardsConway  -> r BabbageEraOnwardsConway
 
+{-# DEPRECATED noByronEraInShelleyBasedEra "Use disjointByronEraOnlyAndShelleyBasedEra instead" #-}
 noByronEraInShelleyBasedEra :: ShelleyBasedEra era -> ByronEraOnly era -> a
-noByronEraInShelleyBasedEra sbe ByronEraOnlyByron = case sbe of {}
+noByronEraInShelleyBasedEra = flip disjointByronEraOnlyAndShelleyBasedEra
+
+disjointByronEraOnlyAndShelleyBasedEra :: ByronEraOnly era -> ShelleyBasedEra era -> a
+disjointByronEraOnlyAndShelleyBasedEra ByronEraOnlyByron sbe = case sbe of {}
+
+disjointAlonzoEraOnlyAndBabbageEraOnwards :: AlonzoEraOnly era -> BabbageEraOnwards era -> a
+disjointAlonzoEraOnlyAndBabbageEraOnwards eonL eonR =
+  case eonL of
+    AlonzoEraOnlyAlonzo -> case eonR of {}
 
 shelleyToAllegraEraToByronToAllegraEra :: ShelleyToAllegraEra era -> ByronToAllegraEra era
 shelleyToAllegraEraToByronToAllegraEra = \case

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -762,10 +762,7 @@ fromShelleyTxOut sbe ledgerTxOut = do
     ShelleyBasedEraBabbage ->
        TxOut addressInEra
              txOutValue
-             (fromBabbageTxOutDatum
-               AlonzoEraOnwardsBabbage
-               BabbageEraOnwardsBabbage
-               datum)
+             (fromBabbageTxOutDatum BabbageEraOnwardsBabbage datum)
              (case mRefScript of
                 SNothing -> ReferenceScriptNone
                 SJust refScript ->
@@ -777,10 +774,7 @@ fromShelleyTxOut sbe ledgerTxOut = do
     ShelleyBasedEraConway ->
        TxOut addressInEra
              txOutValue
-             (fromBabbageTxOutDatum
-               AlonzoEraOnwardsConway
-               BabbageEraOnwardsConway
-               datum)
+             (fromBabbageTxOutDatum BabbageEraOnwardsConway datum)
              (case mRefScript of
                 SNothing -> ReferenceScriptNone
                 SJust refScript ->
@@ -820,15 +814,12 @@ toBabbageTxOutDatum eon =
 
 fromBabbageTxOutDatum
   :: (L.Era ledgerera, Ledger.EraCrypto ledgerera ~ StandardCrypto)
-  => AlonzoEraOnwards era
-  -> BabbageEraOnwards era
+  => BabbageEraOnwards era
   -> Babbage.Datum ledgerera
   -> TxOutDatum ctx era
-fromBabbageTxOutDatum _ _ Babbage.NoDatum = TxOutDatumNone
-fromBabbageTxOutDatum w _ (Babbage.DatumHash dh) =
-  TxOutDatumHash w $ ScriptDataHash dh
-fromBabbageTxOutDatum _ w (Babbage.Datum binData) =
-  TxOutDatumInline w $ fromAlonzoData $ L.binaryDataToData binData
+fromBabbageTxOutDatum _ Babbage.NoDatum = TxOutDatumNone
+fromBabbageTxOutDatum w (Babbage.DatumHash dh) = TxOutDatumHash (babbageEraOnwardsToAlonzoEraOnwards w) $ ScriptDataHash dh
+fromBabbageTxOutDatum w (Babbage.Datum binData) = TxOutDatumInline w $ fromAlonzoData $ L.binaryDataToData binData
 
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -812,15 +812,18 @@ toBabbageTxOutDatum eon =
     TxOutDatumHash _ (ScriptDataHash dh) -> Babbage.DatumHash dh
     TxOutDatumInline _ sd -> scriptDataToInlineDatum sd
 
-fromBabbageTxOutDatum
-  :: (L.Era ledgerera, Ledger.EraCrypto ledgerera ~ StandardCrypto)
+fromBabbageTxOutDatum :: ()
   => BabbageEraOnwards era
-  -> Babbage.Datum ledgerera
+  -> Babbage.Datum (ShelleyLedgerEra era)
   -> TxOutDatum ctx era
-fromBabbageTxOutDatum _ Babbage.NoDatum = TxOutDatumNone
-fromBabbageTxOutDatum w (Babbage.DatumHash dh) = TxOutDatumHash (babbageEraOnwardsToAlonzoEraOnwards w) $ ScriptDataHash dh
-fromBabbageTxOutDatum w (Babbage.Datum binData) = TxOutDatumInline w $ fromAlonzoData $ L.binaryDataToData binData
-
+fromBabbageTxOutDatum eon =
+  babbageEraOnwardsConstraints eon $ \case
+    Babbage.NoDatum ->
+      TxOutDatumNone
+    Babbage.DatumHash dh ->
+      TxOutDatumHash (babbageEraOnwardsToAlonzoEraOnwards eon) $ ScriptDataHash dh
+    Babbage.Datum binData ->
+      TxOutDatumInline eon $ fromAlonzoData $ L.binaryDataToData binData
 
 -- ----------------------------------------------------------------------------
 -- Building vs viewing transactions

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -825,7 +825,7 @@ fromBabbageTxOutDatum _ _ Babbage.NoDatum = TxOutDatumNone
 fromBabbageTxOutDatum w _ (Babbage.DatumHash dh) =
   TxOutDatumHash w $ ScriptDataHash dh
 fromBabbageTxOutDatum _ w (Babbage.Datum binData) =
-  TxOutDatumInline w $ binaryDataToScriptData w binData
+  TxOutDatumInline w $ fromAlonzoData $ L.binaryDataToData binData
 
 
 -- ----------------------------------------------------------------------------
@@ -2306,7 +2306,7 @@ fromBabbageTxOut w txdatums txout =
         case txout ^. L.datumTxOutL of
           L.NoDatum -> TxOutDatumNone
           L.DatumHash dh -> resolveDatumInTx dh
-          L.Datum d -> TxOutDatumInline w $ binaryDataToScriptData w d
+          L.Datum d -> TxOutDatumInline w $ fromAlonzoData $ L.binaryDataToData d
 
     resolveDatumInTx :: L.DataHash StandardCrypto -> TxOutDatum CtxTx era
     resolveDatumInTx dh
@@ -3501,12 +3501,3 @@ calculateExecutionUnitsLovelace prices eUnits =
 scriptDataToInlineDatum :: L.Era ledgerera => HashableScriptData -> L.Datum ledgerera
 scriptDataToInlineDatum d =
   L.Datum . L.dataToBinaryData $ toAlonzoData d
-
-binaryDataToScriptData
-  :: L.Era ledgerera
-  => BabbageEraOnwards era
-  -> L.BinaryData ledgerera -> HashableScriptData
-binaryDataToScriptData BabbageEraOnwardsBabbage d =
-  fromAlonzoData $ L.binaryDataToData d
-binaryDataToScriptData BabbageEraOnwardsConway  d =
-  fromAlonzoData $ L.binaryDataToData d

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -3202,34 +3202,34 @@ makeShelleyTransactionBody sbe@ShelleyBasedEraConway
 -- that works with a 'TxOut' in any context (including CtxTx) by ignoring
 -- embedded datums (taking only their hash).
 --
-toShelleyTxOutAny :: forall ctx era ledgerera.
-                   ShelleyLedgerEra era ~ ledgerera
-                => ShelleyBasedEra era
-                -> TxOut ctx era
-                -> Ledger.TxOut ledgerera
-toShelleyTxOutAny sbe (TxOut _ (TxOutAdaOnly ByronToAllegraEraByron _) _ _) =
+toShelleyTxOutAny :: ()
+  => ShelleyBasedEra era
+  -> TxOut ctx era
+  -> Ledger.TxOut (ShelleyLedgerEra era)
+toShelleyTxOutAny sbe = \case
+  TxOut _ (TxOutAdaOnly ByronToAllegraEraByron _) _ _ ->
     case sbe of {}
 
-toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly ByronToAllegraEraShelley value) _ _) =
+  TxOut addr (TxOutAdaOnly ByronToAllegraEraShelley value) _ _ ->
     L.mkBasicTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
-toShelleyTxOutAny _ (TxOut addr (TxOutAdaOnly ByronToAllegraEraAllegra value) _ _) =
+  TxOut addr (TxOutAdaOnly ByronToAllegraEraAllegra value) _ _ ->
     L.mkBasicTxOut (toShelleyAddr addr) (toShelleyLovelace value)
 
-toShelleyTxOutAny _ (TxOut addr (TxOutValue MaryEraOnwardsMary value) _ _) =
+  TxOut addr (TxOutValue MaryEraOnwardsMary value) _ _ ->
     L.mkBasicTxOut (toShelleyAddr addr) (toMaryValue value)
 
-toShelleyTxOutAny _ (TxOut addr (TxOutValue MaryEraOnwardsAlonzo value) txoutdata _) =
+  TxOut addr (TxOutValue MaryEraOnwardsAlonzo value) txoutdata _ ->
     L.mkBasicTxOut (toShelleyAddr addr) (toMaryValue value)
       & L.dataHashTxOutL .~ toAlonzoTxOutDataHash' AlonzoEraOnlyAlonzo txoutdata
 
-toShelleyTxOutAny sbe (TxOut addr (TxOutValue MaryEraOnwardsBabbage value) txoutdata refScript) =
+  TxOut addr (TxOutValue MaryEraOnwardsBabbage value) txoutdata refScript ->
     let cEra = shelleyBasedToCardanoEra sbe
     in L.mkBasicTxOut (toShelleyAddr addr) (toMaryValue value)
        & L.datumTxOutL .~ toBabbageTxOutDatum' BabbageEraOnwardsBabbage txoutdata
        & L.referenceScriptTxOutL .~ refScriptToShelleyScript cEra refScript
 
-toShelleyTxOutAny sbe (TxOut addr (TxOutValue MaryEraOnwardsConway value) txoutdata refScript) =
+  TxOut addr (TxOutValue MaryEraOnwardsConway value) txoutdata refScript ->
     let cEra = shelleyBasedToCardanoEra sbe
     in L.mkBasicTxOut (toShelleyAddr addr) (toMaryValue value)
        & L.datumTxOutL .~ toBabbageTxOutDatum' BabbageEraOnwardsConway txoutdata

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -2653,7 +2653,7 @@ convWithdrawals txWithdrawals =
 
 convTransactionFee :: ShelleyBasedEra era -> TxFee era -> Ledger.Coin
 convTransactionFee sbe = \case
-  TxFeeImplicit w  -> noByronEraInShelleyBasedEra sbe w
+  TxFeeImplicit w  -> disjointByronEraOnlyAndShelleyBasedEra w sbe
   TxFeeExplicit _ fee -> toShelleyLovelace fee
 
 convValidityInterval

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -118,9 +118,6 @@ module Cardano.Api.TxBody (
     renderScriptWitnessIndex,
     collectTxBodyScriptWitnesses,
 
-    -- * Conversion to inline data
-    scriptDataToInlineDatum,
-
     -- * Internal conversion functions & types
     toByronTxId,
     toShelleyTxId,
@@ -811,7 +808,7 @@ toBabbageTxOutDatum eon =
   babbageEraOnwardsConstraints eon $ \case
     TxOutDatumNone -> Babbage.NoDatum
     TxOutDatumHash _ (ScriptDataHash dh) -> Babbage.DatumHash dh
-    TxOutDatumInline _ sd -> scriptDataToInlineDatum sd
+    TxOutDatumInline _ sd -> L.Datum . L.dataToBinaryData $ toAlonzoData sd
 
 fromBabbageTxOutDatum :: ()
   => BabbageEraOnwards era
@@ -3267,7 +3264,7 @@ toBabbageTxOutDatum' eon =
     TxOutDatumInTx' _ (ScriptDataHash dh) _ ->
       Babbage.DatumHash dh
     TxOutDatumInline _ sd ->
-      scriptDataToInlineDatum sd
+      L.Datum . L.dataToBinaryData $ toAlonzoData sd
 
 
 -- ----------------------------------------------------------------------------
@@ -3502,14 +3499,3 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
 calculateExecutionUnitsLovelace :: Ledger.Prices -> ExecutionUnits -> Maybe Lovelace
 calculateExecutionUnitsLovelace prices eUnits =
   return . fromShelleyLovelace $ Alonzo.txscriptfee prices (toAlonzoExUnits eUnits)
-
--- ----------------------------------------------------------------------------
--- Inline data
---
--- | Conversion of ScriptData to binary data which allows for the storage of data
--- onchain within a transaction output.
---
-
-scriptDataToInlineDatum :: L.Era ledgerera => HashableScriptData -> L.Datum ledgerera
-scriptDataToInlineDatum d =
-  L.Datum . L.dataToBinaryData $ toAlonzoData d

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -110,6 +110,11 @@ module Cardano.Api (
     -- ** From Allegra
 
     -- ** From Mary
+    MaryEraOnly(..),
+    maryEraOnlyConstraints,
+    maryEraOnlyToCardanoEra,
+    maryEraOnlyToShelleyBasedEra,
+
     MaryEraOnwards(..),
     maryEraOnwardsConstraints,
     maryEraOnwardsToCardanoEra,
@@ -1026,6 +1031,7 @@ import           Cardano.Api.Eon.ByronToAllegraEra
 import           Cardano.Api.Eon.ByronToAlonzoEra
 import           Cardano.Api.Eon.ByronToMaryEra
 import           Cardano.Api.Eon.ConwayEraOnwards
+import           Cardano.Api.Eon.MaryEraOnly
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyEraOnly


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use fewer constraints.
    New `MaryEraOnly` eon
    New functions:
    - `caseMaryEraOnlyOrAlonzoEraOnwards`
    - `disjointByronEraOnlyAndShelleyBasedEra`
    - `disjointAlonzoEraOnlyAndBabbageEraOnwards`
    Deprecate:
    - `noByronEraInShelleyBasedEra`.  Use `disjointByronEraOnlyAndShelleyBasedEra` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Refactoring to rely less on constraints and demand fewer constraints from our functions.
The necessary constraints are summoned using `caseX` functions instead.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
