### PR TITLE
Open union encoding of Eon

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -66,6 +66,7 @@ library internal
                         Cardano.Api.Eon.ByronToAlonzoEra
                         Cardano.Api.Eon.ByronToMaryEra
                         Cardano.Api.Eon.ConwayEraOnwards
+                        Cardano.Api.Eon.Core
                         Cardano.Api.Eon.MaryEraOnly
                         Cardano.Api.Eon.MaryEraOnwards
                         Cardano.Api.Eon.ShelleyBasedEra
@@ -204,6 +205,7 @@ library internal
                       , typed-protocols ^>= 0.1
                       , unordered-containers >= 0.2.11
                       , vector
+                      , world-peace
                       , yaml
 
 library

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -205,7 +205,6 @@ library internal
                       , typed-protocols ^>= 0.1
                       , unordered-containers >= 0.2.11
                       , vector
-                      , world-peace
                       , yaml
 
 library

--- a/cardano-api/internal/Cardano/Api/Eon/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Core.hs
@@ -208,6 +208,43 @@ memberSubsetEx2 mp sp =
     MemberTail mz ->
       case mz of {}
 
+memberSubsetEx3 :: ()
+  => Byron          ∈ ByronToShelley
+  -> ByronToShelley ⊆ ByronToAllegra
+  -> Byron          ∈ ByronToAllegra
+memberSubsetEx3 mp sp =
+  case mp of
+    MemberHead ->
+      case sp of
+        SubsetCons pm _ ->
+          pm
+    MemberTail mz ->
+      case mz of
+        MemberTail mzz ->
+          case mzz of {}
+
+
+memberSubsetEx4 :: ()
+  => Shelley        ∈ ByronToShelley
+  -> ByronToShelley ⊆ ByronToAllegra
+  -> Shelley        ∈ ByronToAllegra
+memberSubsetEx4 mp sp =
+  case mp of
+    MemberTail mz ->
+      case mz of
+        MemberHead ->
+          case sp of
+            SubsetCons (MemberTail (MemberTail (MemberTail z))) _ ->
+              case z of {}
+            SubsetCons MemberHead spp ->
+              case spp of
+                SubsetCons (MemberTail _) sppp ->
+                  case sppp of
+                    SubsetNil ->
+                      MemberTail MemberHead
+        MemberTail mzz ->
+          case mzz of {}
+
 -- memberSubset :: ()
 --   => a  ∈ as
 --   -> as ⊆ bs

--- a/cardano-api/internal/Cardano/Api/Eon/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Core.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Eon.Core where
+
+import           Data.Kind
+import           Data.WorldPeace
+
+data Eon (eras :: [Type]) era where
+  Eon
+    :: IsMember era eras
+    => OpenUnion eras
+    -> Eon eras era
+
+data Byron = Byron deriving (Eq, Show)
+data Shelley = Shelley deriving (Eq, Show)
+data Allegra = Allegra deriving (Eq, Show)
+data Mary = Mary deriving (Eq, Show)
+data Alonzo = Alonzo deriving (Eq, Show)
+data Babbage = Babbage deriving (Eq, Show)
+data Conway = Conway deriving (Eq, Show)
+
+type ByronEraOnly       = '[Byron                                                 ]
+type ShelleyEraOnly     = '[       Shelley                                        ]
+type AllegraEraOnly     = '[                Allegra                               ]
+type MaryEraOnly        = '[                         Mary                         ]
+type AlonzoEraOnly      = '[                               Alonzo                 ]
+type BabbageEraOnly     = '[                                       Babbage        ]
+type ConwayEraOnly      = '[                                                Conway]
+
+type ByronEraOnwards    = '[Byron, Shelley, Allegra, Mary, Alonzo, Babbage, Conway]
+type ShelleyEraOnwards  = '[       Shelley, Allegra, Mary, Alonzo, Babbage, Conway]
+type AllegraEraOnwards  = '[                Allegra, Mary, Alonzo, Babbage, Conway]
+type MaryEraOnwards     = '[                         Mary, Alonzo, Babbage, Conway]
+type AlonzoEraOnwards   = '[                               Alonzo, Babbage, Conway]
+type BabbageEraOnwards  = '[                                       Babbage, Conway]
+type ConwayEraOnwards   = '[                                                Conway]
+
+relaxEon :: ()
+  => Contains as bs
+  => IsMember a bs -- This constraing shouldn't be needed
+  => Eon as a
+  -> Eon bs a
+relaxEon (Eon a) = Eon (relaxOpenUnion a)
+
+example1 :: ()
+  => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
+  => Eon ByronEraOnwards era
+  -> Eon ByronEraOnwards era
+example1 = relaxEon
+
+example2 :: ()
+  => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
+  => Eon ShelleyEraOnwards era
+  -> Eon ByronEraOnwards era
+example2 = relaxEon

--- a/cardano-api/internal/Cardano/Api/Eon/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Core.hs
@@ -170,6 +170,21 @@ example8 p (Eon m era) =
     MemberTail (MemberTail m') ->
       case m' of {}
 
+relaxEon :: ()
+  => as ⊆ bs
+  -> Eon as a
+  -> Eon bs a
+relaxEon p (Eon m era) =
+  case m of
+    MemberHead ->
+      case p of
+        SubsetCons pm _ ->
+          Eon pm era
+    MemberTail mpm ->
+      case p of
+        SubsetCons _ ssn ->
+          relaxEon ssn (Eon mpm era)
+
 -- example2 :: ()
 --   => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
 --   => Eon ShelleyEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Core.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -7,17 +8,11 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Api.Eon.Core where
 
 import           Data.Kind
-import           Data.WorldPeace
-
-data Eon (eras :: [Type]) era where
-  Eon
-    :: IsMember era eras
-    => OpenUnion eras
-    -> Eon eras era
 
 data Byron = Byron deriving (Eq, Show)
 data Shelley = Shelley deriving (Eq, Show)
@@ -27,13 +22,13 @@ data Alonzo = Alonzo deriving (Eq, Show)
 data Babbage = Babbage deriving (Eq, Show)
 data Conway = Conway deriving (Eq, Show)
 
-type ByronEraOnly       = '[Byron                                                 ]
-type ShelleyEraOnly     = '[       Shelley                                        ]
-type AllegraEraOnly     = '[                Allegra                               ]
-type MaryEraOnly        = '[                         Mary                         ]
-type AlonzoEraOnly      = '[                               Alonzo                 ]
-type BabbageEraOnly     = '[                                       Babbage        ]
-type ConwayEraOnly      = '[                                                Conway]
+type ByronOnly          = '[Byron                                                 ]
+type ShelleyOnly        = '[       Shelley                                        ]
+type AllegraOnly        = '[                Allegra                               ]
+type MaryOnly           = '[                         Mary                         ]
+type AlonzoOnly         = '[                               Alonzo                 ]
+type BabbageOnly        = '[                                       Babbage        ]
+type ConwayOnly         = '[                                                Conway]
 
 type ByronEraOnwards    = '[Byron, Shelley, Allegra, Mary, Alonzo, Babbage, Conway]
 type ShelleyEraOnwards  = '[       Shelley, Allegra, Mary, Alonzo, Babbage, Conway]
@@ -43,21 +38,140 @@ type AlonzoEraOnwards   = '[                               Alonzo, Babbage, Conw
 type BabbageEraOnwards  = '[                                       Babbage, Conway]
 type ConwayEraOnwards   = '[                                                Conway]
 
-relaxEon :: ()
-  => Contains as bs
-  => IsMember a bs -- This constraing shouldn't be needed
-  => Eon as a
-  -> Eon bs a
-relaxEon (Eon a) = Eon (relaxOpenUnion a)
+type ByronToBabbage     = '[Byron, Shelley, Allegra, Mary, Alonzo, Babbage]
+type ShelleyToBabbage   = '[       Shelley, Allegra, Mary, Alonzo, Babbage]
+type AllegraToBabbage   = '[                Allegra, Mary, Alonzo, Babbage]
+type MaryToBabbage      = '[                         Mary, Alonzo, Babbage]
+type AlonzoToBabbage    = '[                               Alonzo, Babbage]
+
+type ByronToAlonzo      = '[Byron, Shelley, Allegra, Mary, Alonzo]
+type ShelleyToAlonzo    = '[       Shelley, Allegra, Mary, Alonzo]
+type AllegraToAlonzo    = '[                Allegra, Mary, Alonzo]
+type MaryToAlonzo       = '[                         Mary, Alonzo]
+
+type ByronToMary        = '[Byron, Shelley, Allegra, Mary]
+type ShelleyToMary      = '[       Shelley, Allegra, Mary]
+type AllegraToMary      = '[                Allegra, Mary]
+
+type ByronToAllegra     = '[Byron, Shelley, Allegra]
+type ShelleyToAllegra   = '[       Shelley, Allegra]
+
+type ByronToShelley     = '[Byron, Shelley]
+
+data Elem t where
+  Elem :: Elem t
+
+data (∈) (a :: Type) (as :: [Type]) where
+  MemberHead :: a ∈ (a ': as)
+  MemberTail :: a ∈ as -> a ∈ (b ': as)
+
+data (⊆) (as :: [Type]) (bs :: [Type]) where
+  SubsetCons
+    :: a ∈ bs
+    -> as ⊆ bs
+    -> (a:as) ⊆ bs
+
+  SubsetNil
+    :: '[] ⊆ bs
+
+data Eon (eras :: [Type]) era where
+  Eon
+    :: era ∈ eras
+    -> era
+    -> Eon eras era
+
+-- relaxEon :: ()
+--   => as ⊆ bs
+--   -> Eon as a
+--   -> Eon bs a
+-- relaxEon subsetProof (Eon membership era) =
+--   case membership of
+--     MemberHead ->
+--       case subsetProof of
+--         SubsetCons Elem subsetProofRest ->
+--           Eon _u era
 
 example1 :: ()
-  => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
-  => Eon ByronEraOnwards era
-  -> Eon ByronEraOnwards era
-example1 = relaxEon
+  => Eon ConwayEraOnwards era
+  -> Eon ConwayEraOnwards era
+example1 (Eon m era) = Eon m era
 
 example2 :: ()
-  => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
-  => Eon ShelleyEraOnwards era
-  -> Eon ByronEraOnwards era
-example2 = relaxEon
+  => Eon ConwayEraOnwards era
+  -> Eon BabbageEraOnwards era
+example2 (Eon m era) =
+  case m of
+    MemberHead -> Eon (MemberTail MemberHead) era
+    MemberTail m' -> case m' of {}
+
+example3 :: ()
+  => Eon ConwayEraOnwards era
+  -> Eon AlonzoEraOnwards era
+example3 (Eon m era) =
+  case m of
+    MemberHead -> Eon (MemberTail (MemberTail MemberHead)) era
+    MemberTail m' -> case m' of {}
+
+example4 :: ()
+  => Eon ByronOnly era
+  -> Eon ByronToShelley era
+example4 (Eon m era) =
+  case m of
+    MemberHead -> Eon MemberHead era
+    MemberTail m' -> case m' of {}
+
+example5 :: ()
+  => Eon ShelleyOnly era
+  -> Eon ByronToAllegra era
+example5 (Eon m era) =
+  case m of
+    MemberHead -> Eon (MemberTail MemberHead) era
+    MemberTail m' -> case m' of {}
+
+example6 :: ()
+  => Eon ShelleyToAllegra era
+  -> Eon ByronToAllegra era
+example6 (Eon m era) =
+  case m of
+    MemberHead -> Eon (MemberTail MemberHead) era
+    MemberTail MemberHead -> Eon (MemberTail (MemberTail MemberHead)) era
+    MemberTail (MemberTail m') -> case m' of {}
+
+example7 :: ()
+  => ShelleyToAllegra ⊆ ByronToAllegra
+  -> Eon ShelleyToAllegra era
+  -> Eon ByronToAllegra era
+example7 _ (Eon m era) =
+  case m of
+    MemberHead -> Eon (MemberTail MemberHead) era
+    MemberTail MemberHead -> Eon (MemberTail (MemberTail MemberHead)) era
+    MemberTail (MemberTail m') -> case m' of {}
+
+moo :: ShelleyToAllegra ⊆ ByronToAllegra -> ()
+moo p = case p of
+  SubsetCons _pShelley p' -> case p' of
+    SubsetCons _pAllegra p'' -> case p'' of
+      SubsetNil -> ()
+
+example8 :: ()
+  => ShelleyToAllegra ⊆ ByronToAllegra
+  -> Eon ShelleyToAllegra era
+  -> Eon ByronToAllegra era
+example8 p (Eon m era) =
+  case m of
+    MemberHead ->
+      case p of
+        SubsetCons pShelley _ ->
+          Eon pShelley era
+    MemberTail MemberHead ->
+      case p of
+        SubsetCons _ p' -> case p' of
+          SubsetCons pAllegra _ -> Eon pAllegra era
+    MemberTail (MemberTail m') ->
+      case m' of {}
+
+-- example2 :: ()
+--   => IsMember era ByronEraOnwards -- These constraints are due to relaxEon.  They shouldn't be needed.
+--   => Eon ShelleyEraOnwards era
+--   -> Eon ByronEraOnwards era
+-- example2 = relaxEon

--- a/cardano-api/internal/Cardano/Api/Eon/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Core.hs
@@ -80,16 +80,23 @@ data Eon (eras :: [Type]) era where
     -> era
     -> Eon eras era
 
--- relaxEon :: ()
---   => as ⊆ bs
---   -> Eon as a
---   -> Eon bs a
--- relaxEon subsetProof (Eon membership era) =
---   case membership of
---     MemberHead ->
---       case subsetProof of
---         SubsetCons Elem subsetProofRest ->
---           Eon _u era
+class Member (a :: Type) (as :: [Type]) where
+  member :: a ∈ as
+
+instance Member a (a ': as) where
+  member = MemberHead
+
+instance Member a as => Member a (b ': as) where
+  member = MemberTail member
+
+class Subset (as :: [Type]) (bs :: [Type]) where
+  subset :: as ⊆ bs
+
+instance Subset '[] bs where
+  subset = SubsetNil
+
+-- instance (Member a as, Subset as bs) => Subset (a ': as) bs where
+--   subset = SubsetCons member subset
 
 example1 :: ()
   => Eon ConwayEraOnwards era
@@ -169,6 +176,53 @@ example8 p (Eon m era) =
           SubsetCons pAllegra _ -> Eon pAllegra era
     MemberTail (MemberTail m') ->
       case m' of {}
+
+
+-- data (∈) (a :: Type) (as :: [Type]) where
+--   MemberHead :: a ∈ (a ': as)
+--   MemberTail :: a ∈ as -> a ∈ (b ': as)
+
+memberSubsetEx1 :: ()
+  => Byron      ∈ ByronOnly
+  -> ByronOnly  ⊆ ByronToShelley
+  -> Byron      ∈ ByronToShelley
+memberSubsetEx1 mp sp =
+  case mp of
+    MemberHead ->
+      case sp of
+        SubsetCons pm _ ->
+          pm
+    MemberTail mz ->
+      case mz of {}
+
+memberSubsetEx2 :: ()
+  => Shelley     ∈ ShelleyOnly
+  -> ShelleyOnly ⊆ ByronToShelley
+  -> Shelley     ∈ ByronToShelley
+memberSubsetEx2 mp sp =
+  case mp of
+    MemberHead ->
+      case sp of
+        SubsetCons pm _ ->
+          pm
+    MemberTail mz ->
+      case mz of {}
+
+-- memberSubset :: ()
+--   => a  ∈ as
+--   -> as ⊆ bs
+--   -> a  ∈ bs
+-- memberSubset mp sp =
+--   case mp of
+--     MemberHead ->
+--       case sp of
+--         SubsetCons pm _ ->
+--           pm
+--     MemberTail mpm ->
+--       memberSubset mpm sp
+--       -- case sp of
+--       --   SubsetCons _ ssn ->
+
 
 relaxEon :: ()
   => as ⊆ bs


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    WIP Open union encoding of Eon
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This doesn't work.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
