### PR TITLE
Support Plutus V1 in Conway

### DIFF
--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -642,21 +642,19 @@ eraOfScriptLanguageInEra :: ScriptLanguageInEra lang era
 eraOfScriptLanguageInEra langInEra =
     case langInEra of
       SimpleScriptInShelley   -> ShelleyBasedEraShelley
-
       SimpleScriptInAllegra   -> ShelleyBasedEraAllegra
-
       SimpleScriptInMary      -> ShelleyBasedEraMary
-
       SimpleScriptInAlonzo    -> ShelleyBasedEraAlonzo
-      PlutusScriptV1InAlonzo  -> ShelleyBasedEraAlonzo
-
       SimpleScriptInBabbage   -> ShelleyBasedEraBabbage
       SimpleScriptInConway    -> ShelleyBasedEraConway
 
+      PlutusScriptV1InAlonzo  -> ShelleyBasedEraAlonzo
       PlutusScriptV1InBabbage -> ShelleyBasedEraBabbage
       PlutusScriptV1InConway  -> ShelleyBasedEraConway
+
       PlutusScriptV2InBabbage -> ShelleyBasedEraBabbage
       PlutusScriptV2InConway  -> ShelleyBasedEraConway
+
       PlutusScriptV3InConway  -> ShelleyBasedEraConway
 
 -- | Given a target era and a script in some language, check if the language is


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for Plutus V1 in Conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This closes #74. I think all that went wrong was someone forgetting the clause I add here.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
