### PR TITLE
Add a query for vote delegatees

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -320,6 +320,10 @@ data QueryInShelleyBasedEra era result where
     -> Set L.MemberStatus
     -> QueryInShelleyBasedEra era (Maybe (L.CommitteeMembersState StandardCrypto))
 
+  QueryStakeVoteDelegatees
+    :: Set StakeCredential
+    -> QueryInShelleyBasedEra era (Map StakeCredential (Ledger.DRep StandardCrypto))
+
 
 instance NodeToClientVersionOf (QueryInShelleyBasedEra era result) where
   nodeToClientVersionOf QueryEpoch = NodeToClientV_9
@@ -343,6 +347,7 @@ instance NodeToClientVersionOf (QueryInShelleyBasedEra era result) where
   nodeToClientVersionOf QueryDRepState{} = NodeToClientV_16
   nodeToClientVersionOf QueryDRepStakeDistr{} = NodeToClientV_16
   nodeToClientVersionOf QueryCommitteeMembersState{} = NodeToClientV_16
+  nodeToClientVersionOf QueryStakeVoteDelegatees{} = NodeToClientV_16
 
 deriving instance Show (QueryInShelleyBasedEra era result)
 
@@ -672,6 +677,13 @@ toConsensusQueryShelleyBased sbe = \case
   QueryCommitteeMembersState coldCreds hotCreds statuses ->
     Some (consensusQueryInEraInMode era (Consensus.GetCommitteeMembersState coldCreds hotCreds statuses))
 
+  QueryStakeVoteDelegatees creds ->
+    Some (consensusQueryInEraInMode era
+            (Consensus.GetFilteredVoteDelegatees creds'))
+    where
+      creds' :: Set (Shelley.Credential Shelley.Staking StandardCrypto)
+      creds' = Set.map toShelleyStakeCredential creds
+
   where
     era = shelleyBasedToCardanoEra sbe
 
@@ -931,6 +943,12 @@ fromConsensusQueryResultShelleyBased _ QueryCommitteeMembersState{} q' committee
   case q' of
     Consensus.GetCommitteeMembersState{} -> committeeMembersState'
     _                                    -> fromConsensusQueryResultMismatch
+
+fromConsensusQueryResultShelleyBased _ QueryStakeVoteDelegatees{} q' delegs' =
+    case q' of
+      Consensus.GetFilteredVoteDelegatees {}
+        -> Map.mapKeys fromShelleyStakeCredential delegs'
+      _ -> fromConsensusQueryResultMismatch
 
 -- | This should /only/ happen if we messed up the mapping in 'toConsensusQuery'
 -- and 'fromConsensusQueryResult' so they are inconsistent with each other.

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -31,6 +31,7 @@ module Cardano.Api.Query.Expr
   , queryDRepStakeDistribution
   , queryDRepState
   , queryGovState
+  , queryStakeVoteDelegatees
   ) where
 
 import           Cardano.Api.Address
@@ -236,3 +237,10 @@ queryCommitteeMembersState :: ()
   -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Maybe (L.CommitteeMembersState L.StandardCrypto))))
 queryCommitteeMembersState sbe coldCreds hotCreds statuses =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)
+
+queryStakeVoteDelegatees :: ()
+  => ShelleyBasedEra era
+  -> Set StakeCredential
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeCredential (L.DRep L.StandardCrypto))))
+queryStakeVoteDelegatees sbe stakeCredentials =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeVoteDelegatees stakeCredentials

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -959,6 +959,7 @@ module Cardano.Api (
     queryDRepState,
     queryDRepStakeDistribution,
     queryCommitteeMembersState,
+    queryStakeVoteDelegatees,
 
     -- ** Committee State Query
     MemberStatus (..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `QueryStakeVoteDelegatees` to return the vote delegatee associated to a stake credential
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR implements a query that is needed to solve [issue 423 of `cardano-api`](https://github.com/input-output-hk/cardano-cli/issues/423). It used to depend on cherry-picked commits of `ouroboros-consensus`, but with #359 merged, it doesn't any more.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
