### PR TITLE
Use `L.Coin` instead of `Lovelace`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -197,11 +197,11 @@ _genAddressInEraByron = byronAddressInEra <$> genAddressByron
 genKESPeriod :: Gen KESPeriod
 genKESPeriod = KESPeriod <$> Gen.word Range.constantBounded
 
-genLovelace :: Gen Lovelace
-genLovelace = Lovelace <$> Gen.integral (Range.linear 0 5000)
+genLovelace :: Gen L.Coin
+genLovelace = L.Coin <$> Gen.integral (Range.linear 0 5000)
 
-genPositiveLovelace :: Gen Lovelace
-genPositiveLovelace = Lovelace <$> Gen.integral (Range.linear 1 5000)
+genPositiveLovelace :: Gen L.Coin
+genPositiveLovelace = L.Coin <$> Gen.integral (Range.linear 1 5000)
 
 
 ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -261,7 +261,7 @@ makeStakeAddressRegistrationCertificate = \case
   StakeAddrRegistrationConway cOnwards deposit scred ->
     conwayEraOnwardsConstraints cOnwards
       $ ConwayCertificate cOnwards
-      $ Ledger.mkRegDepositTxCert (toShelleyStakeCredential scred) (toShelleyLovelace deposit)
+      $ Ledger.mkRegDepositTxCert (toShelleyStakeCredential scred) deposit
 
 makeStakeAddressUnregistrationCertificate :: StakeAddressRequirements era -> Certificate era
 makeStakeAddressUnregistrationCertificate req =
@@ -269,7 +269,7 @@ makeStakeAddressUnregistrationCertificate req =
     StakeAddrRegistrationConway cOnwards deposit scred ->
       conwayEraOnwardsConstraints cOnwards
         $ ConwayCertificate cOnwards
-        $ Ledger.mkUnRegDepositTxCert (toShelleyStakeCredential scred) (toShelleyLovelace deposit)
+        $ Ledger.mkUnRegDepositTxCert (toShelleyStakeCredential scred) deposit
 
     StakeAddrRegistrationPreConway atMostEra scred ->
       shelleyToBabbageEraConstraints atMostEra
@@ -396,10 +396,7 @@ makeDrepRegistrationCertificate :: ()
 makeDrepRegistrationCertificate (DRepRegistrationRequirements conwayOnwards vcred deposit) anchor =
   ConwayCertificate conwayOnwards
     . Ledger.ConwayTxCertGov
-    $ Ledger.ConwayRegDRep
-        vcred
-        (toShelleyLovelace deposit)
-        (noInlineMaybeToStrictMaybe anchor)
+    $ Ledger.ConwayRegDRep vcred deposit (noInlineMaybeToStrictMaybe anchor)
 
 data CommitteeHotKeyAuthorizationRequirements era where
   CommitteeHotKeyAuthorizationRequirements
@@ -448,8 +445,7 @@ makeDrepUnregistrationCertificate :: ()
 makeDrepUnregistrationCertificate (DRepUnregistrationRequirements conwayOnwards vcred deposit) =
   ConwayCertificate conwayOnwards
     . Ledger.ConwayTxCertGov
-    . Ledger.ConwayUnRegDRep vcred
-    $ toShelleyLovelace deposit
+    $ Ledger.ConwayUnRegDRep vcred deposit
 
 makeStakeAddressAndDRepDelegationCertificate :: ()
   => ConwayEraOnwards era
@@ -460,10 +456,7 @@ makeStakeAddressAndDRepDelegationCertificate :: ()
 makeStakeAddressAndDRepDelegationCertificate w cred delegatee deposit =
   conwayEraOnwardsConstraints w
     $ ConwayCertificate w
-    $ Ledger.mkRegDepositDelegTxCert
-        (toShelleyStakeCredential cred)
-        delegatee
-        (toShelleyLovelace deposit)
+    $ Ledger.mkRegDepositDelegTxCert (toShelleyStakeCredential cred) delegatee deposit
 
 -- ----------------------------------------------------------------------------
 -- Helper functions
@@ -588,8 +581,8 @@ toShelleyPoolParams StakePoolParameters {
     Ledger.PoolParams {
       Ledger.ppId      = poolkh
     , Ledger.ppVrf     = vrfkh
-    , Ledger.ppPledge  = toShelleyLovelace stakePoolPledge
-    , Ledger.ppCost    = toShelleyLovelace stakePoolCost
+    , Ledger.ppPledge  = stakePoolPledge
+    , Ledger.ppCost    = stakePoolCost
     , Ledger.ppMargin  = fromMaybe
                                (error "toShelleyPoolParams: invalid PoolMargin")
                                (Ledger.boundRational stakePoolMargin)
@@ -655,10 +648,10 @@ fromShelleyPoolParams
     StakePoolParameters {
       stakePoolId            = StakePoolKeyHash ppId
     , stakePoolVRF           = VrfKeyHash ppVrf
-    , stakePoolCost          = fromShelleyLovelace ppCost
+    , stakePoolCost          = ppCost
     , stakePoolMargin        = Ledger.unboundRational ppMargin
     , stakePoolRewardAccount = fromShelleyStakeAddr ppRewardAcnt
-    , stakePoolPledge        = fromShelleyLovelace ppPledge
+    , stakePoolPledge        = ppPledge
     , stakePoolOwners        = map StakeKeyHash (Set.toList ppOwners)
     , stakePoolRelays        = map fromShelleyStakePoolRelay
                                    (Foldable.toList ppRelays)

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -89,6 +89,8 @@ import           Cardano.Api.StakePoolMetadata
 import           Cardano.Api.Utils (noInlineMaybeToStrictMaybe)
 import           Cardano.Api.Value
 
+import qualified Cardano.Ledger.Coin as L
+
 import           Data.ByteString (ByteString)
 import qualified Data.Foldable as Foldable
 import           Data.IP (IPv4, IPv6)
@@ -189,10 +191,10 @@ data StakePoolParameters =
      StakePoolParameters {
        stakePoolId            :: PoolId,
        stakePoolVRF           :: Hash VrfKey,
-       stakePoolCost          :: Lovelace,
+       stakePoolCost          :: L.Coin,
        stakePoolMargin        :: Rational,
        stakePoolRewardAccount :: StakeAddress,
-       stakePoolPledge        :: Lovelace,
+       stakePoolPledge        :: L.Coin,
        stakePoolOwners        :: [Hash StakeKey],
        stakePoolRelays        :: [StakePoolRelay],
        stakePoolMetadata      :: Maybe StakePoolMetadataReference
@@ -241,7 +243,7 @@ data DRepMetadataReference =
 data StakeAddressRequirements era where
   StakeAddrRegistrationConway
     :: ConwayEraOnwards era
-    -> Lovelace
+    -> L.Coin
     -> StakeCredential
     -> StakeAddressRequirements era
 
@@ -383,7 +385,7 @@ data DRepRegistrationRequirements era where
   DRepRegistrationRequirements
     :: ConwayEraOnwards era
     -> (Ledger.Credential Ledger.DRepRole (EraCrypto (ShelleyLedgerEra era)))
-    -> Lovelace
+    -> L.Coin
     -> DRepRegistrationRequirements era
 
 
@@ -437,7 +439,7 @@ data DRepUnregistrationRequirements era where
   DRepUnregistrationRequirements
     :: ConwayEraOnwards era
     -> (Ledger.Credential Ledger.DRepRole (EraCrypto (ShelleyLedgerEra era)))
-    -> Lovelace
+    -> L.Coin
     -> DRepUnregistrationRequirements era
 
 makeDrepUnregistrationCertificate :: ()
@@ -453,7 +455,7 @@ makeStakeAddressAndDRepDelegationCertificate :: ()
   => ConwayEraOnwards era
   -> StakeCredential
   -> Ledger.Delegatee (EraCrypto (ShelleyLedgerEra era))
-  -> Lovelace
+  -> L.Coin
   -> Certificate era
 makeStakeAddressAndDRepDelegationCertificate w cred delegatee deposit =
   conwayEraOnwardsConstraints w

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -24,9 +24,9 @@ import           Cardano.Api.Query
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
-import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Keys as L
 
@@ -51,8 +51,8 @@ constructBalancedTx :: ()
   -> LedgerEpochInfo
   -> SystemStart
   -> Set PoolId       -- ^ The set of registered stake pools
-  -> Map.Map StakeCredential Lovelace
-  -> Map.Map (L.Credential L.DRepRole L.StandardCrypto) Lovelace
+  -> Map.Map StakeCredential L.Coin
+  -> Map.Map (L.Credential L.DRepRole L.StandardCrypto) L.Coin
   -> [ShelleyWitnessSigningKey]
   -> Either TxBodyErrorAutoBalance (Tx era)
 constructBalancedTx sbe txbodcontent changeAddr mOverrideWits utxo lpp

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -34,6 +34,7 @@ import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.CertState (DRepState (..))
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Keys as L
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch (..))
@@ -84,8 +85,8 @@ queryStateForBalancedTx :: ()
           , EraHistory
           , SystemStart
           , Set PoolId
-          , Map StakeCredential Lovelace
-          , Map (L.Credential L.DRepRole L.StandardCrypto) Lovelace))
+          , Map StakeCredential L.Coin
+          , Map (L.Credential L.DRepRole L.StandardCrypto) L.Coin))
 queryStateForBalancedTx era allTxIns certs = runExceptT $ do
   sbe <- requireShelleyBasedEra era
     & onNothing (left ByronEraNotSupported)

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -30,7 +30,6 @@ import           Cardano.Api.Query
 import           Cardano.Api.Query.Expr
 import           Cardano.Api.TxBody
 import           Cardano.Api.Utils
-import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
 import           Cardano.Ledger.CertState (DRepState (..))
@@ -120,7 +119,7 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
 
   drepDelegDeposits <-
     forEraInEon @ConwayEraOnwards era (pure mempty) $ \_ ->
-      Map.map (fromShelleyLovelace . drepDeposit) <$>
+      Map.map drepDeposit <$>
       (lift (queryDRepState sbe drepCreds)
           & onLeft (left . QceUnsupportedNtcVersion)
           & onLeft (left . QueryEraMismatch))

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -70,7 +70,7 @@ import qualified Cardano.Ledger.Alonzo.Tx as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxInfo as Alonzo
 import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as L
-import qualified Cardano.Ledger.Coin as Ledger
+import qualified Cardano.Ledger.Coin as L
 import           Cardano.Ledger.Credential as Ledger (Credential)
 import qualified Cardano.Ledger.Crypto as Ledger
 import qualified Cardano.Ledger.Keys as Ledger
@@ -107,17 +107,17 @@ import           Prettyprinter.Render.String
 --
 transactionFee :: ()
   => ShelleyBasedEra era
-  -> Lovelace -- ^ The fixed tx fee
-  -> Lovelace -- ^ The tx fee per byte
+  -> L.Coin -- ^ The fixed tx fee
+  -> L.Coin -- ^ The tx fee per byte
   -> Tx era
-  -> Lovelace
+  -> L.Coin
 transactionFee sbe txFeeFixed txFeePerByte tx =
   let a = toInteger txFeePerByte
       b = toInteger txFeeFixed
   in
   case tx of
     ShelleyTx _ tx' ->
-      let x = shelleyBasedEraConstraints sbe $ tx' ^. L.sizeTxF in Lovelace (a * x + b)
+      let x = shelleyBasedEraConstraints sbe $ tx' ^. L.sizeTxF in L.Coin (a * x + b)
       --TODO: This can be made to work for Byron txs too.
     ByronTx ByronEraOnlyByron _ -> case sbe of {}
 
@@ -137,20 +137,20 @@ transactionFee sbe txFeeFixed txFeePerByte tx =
 estimateTransactionFee :: ()
   => ShelleyBasedEra era
   -> NetworkId
-  -> Lovelace -- ^ The fixed tx fee
-  -> Lovelace -- ^ The tx fee per byte
+  -> L.Coin -- ^ The fixed tx fee
+  -> L.Coin -- ^ The tx fee per byte
   -> Tx era
   -> Int -- ^ The number of extra UTxO transaction inputs
   -> Int -- ^ The number of extra transaction outputs
   -> Int -- ^ The number of extra Shelley key witnesses
   -> Int -- ^ The number of extra Byron key witnesses
-  -> Lovelace
+  -> L.Coin
 estimateTransactionFee sbe nw txFeeFixed txFeePerByte = \case
   -- TODO: This can be made to work for Byron txs too.
   ByronTx ByronEraOnlyByron _ ->
     case sbe of {}
   ShelleyTx era tx ->
-    let Lovelace baseFee = transactionFee sbe txFeeFixed txFeePerByte (ShelleyTx era tx)
+    let L.Coin baseFee = transactionFee sbe txFeeFixed txFeePerByte (ShelleyTx era tx)
     in \nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
       --TODO: this is fragile. Move something like this to the ledger and
       -- make it robust, based on the txsize calculation.
@@ -161,7 +161,7 @@ estimateTransactionFee sbe nw txFeeFixed txFeePerByte = \case
             + nByronKeyWitnesses    * sizeByronKeyWitnesses
             + nShelleyKeyWitnesses  * sizeShelleyKeyWitnesses
 
-      in Lovelace (baseFee + toInteger txFeePerByte * toInteger extraBytes)
+      in L.Coin (baseFee + toInteger txFeePerByte * toInteger extraBytes)
   where
     sizeInput               = smallArray + uint + hashObj
     sizeOutput              = smallArray + uint + address
@@ -210,7 +210,7 @@ evaluateTransactionFee :: forall era. ()
   -> TxBody era
   -> Word  -- ^ The number of Shelley key witnesses
   -> Word  -- ^ The number of Byron key witnesses
-  -> Lovelace
+  -> L.Coin
 evaluateTransactionFee _ _ _ _ byronwitcount | byronwitcount > 0 =
   error "evaluateTransactionFee: TODO support Byron key witnesses"
 
@@ -559,8 +559,8 @@ evaluateTransactionBalance :: forall era. ()
                            => ShelleyBasedEra era
                            -> Ledger.PParams (ShelleyLedgerEra era)
                            -> Set PoolId
-                           -> Map StakeCredential Lovelace
-                           -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) Lovelace
+                           -> Map StakeCredential L.Coin
+                           -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) L.Coin
                            -> UTxO era
                            -> TxBody era
                            -> TxOutValue era
@@ -583,13 +583,13 @@ evaluateTransactionBalance sbe pp poolids stakeDelegDeposits drepDelegDeposits u
     isRegPool kh = StakePoolKeyHash kh `Set.member` poolids
 
     lookupDelegDeposit ::
-      Ledger.Credential 'Ledger.Staking L.StandardCrypto -> Maybe Ledger.Coin
+      Ledger.Credential 'Ledger.Staking L.StandardCrypto -> Maybe L.Coin
     lookupDelegDeposit stakeCred =
       toShelleyLovelace <$>
       Map.lookup (fromShelleyStakeCredential stakeCred) stakeDelegDeposits
 
     lookupDRepDeposit ::
-      Ledger.Credential 'Ledger.DRepRole L.StandardCrypto -> Maybe Ledger.Coin
+      Ledger.Credential 'Ledger.DRepRole L.StandardCrypto -> Maybe L.Coin
     lookupDRepDeposit drepCred =
       toShelleyLovelace <$>
       Map.lookup drepCred drepDelegDeposits
@@ -615,7 +615,7 @@ data TxBodyErrorAutoBalance =
        -- The transaction should be changed to provide more input ada, or
        -- otherwise adjusted to need less (e.g. outputs, script etc).
        --
-     | TxBodyErrorAdaBalanceNegative Lovelace
+     | TxBodyErrorAdaBalanceNegative L.Coin
 
        -- | There is enough ada to cover both the outputs and the fees, but the
        -- resulting change is too small: it is under the minimum value for
@@ -626,9 +626,9 @@ data TxBodyErrorAutoBalance =
          -- ^ Offending TxOut
          TxOutInAnyEra
          -- ^ Minimum UTxO
-         Lovelace
+         L.Coin
          -- ^ Tx balance
-         Lovelace
+         L.Coin
 
        -- | 'makeTransactionBodyAutoBalance' does not yet support the Byron era.
      | TxBodyErrorByronEraNotSupported
@@ -646,7 +646,7 @@ data TxBodyErrorAutoBalance =
          -- ^ Offending TxOut
          TxOutInAnyEra
          -- ^ Minimum UTxO
-         Lovelace
+         L.Coin
      | TxBodyErrorNonAdaAssetsUnbalanced Value
      | TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap
          ScriptWitnessIndex
@@ -721,7 +721,7 @@ data BalancedTxBody era
       (TxBodyContent BuildTx era)
       (TxBody era)
       (TxOut CtxTx era) -- ^ Transaction balance (change output)
-      Lovelace    -- ^ Estimated transaction fee
+      L.Coin    -- ^ Estimated transaction fee
 
 -- | This is much like 'makeTransactionBody' but with greater automation to
 -- calculate suitable values for several things.
@@ -752,10 +752,10 @@ makeTransactionBodyAutoBalance :: forall era. ()
   -> LedgerProtocolParameters era
   -> Set PoolId       -- ^ The set of registered stake pools, that are being
                       --   unregistered in this transaction.
-  -> Map StakeCredential Lovelace
+  -> Map StakeCredential L.Coin
                       -- ^ Map of all deposits for stake credentials that are being
                       --   unregistered in this transaction
-  -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) Lovelace
+  -> Map (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto) L.Coin
                       -- ^ Map of all deposits for drep credentials that are being
                       --   unregistered in this transaction
   -> UTxO era         -- ^ Just the transaction inputs, not the entire 'UTxO'.
@@ -807,8 +807,8 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
     -- of less than around 18 trillion ada  (2^64-1 lovelace).
     -- However, since at this point we know how much non-Ada change to give
     -- we can use the true values for that.
-    let maxLovelaceChange = Lovelace (2^(64 :: Integer)) - 1
-    let maxLovelaceFee = Lovelace (2^(32 :: Integer) - 1)
+    let maxLovelaceChange = L.Coin (2^(64 :: Integer)) - 1
+    let maxLovelaceFee = L.Coin (2^(32 :: Integer) - 1)
 
     let outgoing = mconcat [v | (TxOut _ (TxOutValueShelleyBased _ v) _ _) <- txOuts txbodycontent]
     let incoming = mconcat [v | (TxOut _ (TxOutValueShelleyBased _ v) _ _) <- Map.elems $ unUTxO utxo]
@@ -900,10 +900,10 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
               let dummyRetCol =
                     TxReturnCollateral w
                     ( TxOut cAddr
-                        (lovelaceToTxOutValue sbe $ Lovelace (2^(64 :: Integer)) - 1)
+                        (lovelaceToTxOutValue sbe $ L.Coin (2^(64 :: Integer)) - 1)
                         TxOutDatumNone ReferenceScriptNone
                     )
-                  dummyTotCol = TxTotalCollateral w (Lovelace (2^(32 :: Integer) - 1))
+                  dummyTotCol = TxTotalCollateral w (L.Coin (2^(32 :: Integer) - 1))
               in case (txReturnCollateral, txTotalCollateral) of
                 (rc@TxReturnCollateral{}, tc@TxTotalCollateral{}) -> (rc, tc)
                 (rc@TxReturnCollateral{},TxTotalCollateralNone) -> (rc, dummyTotCol)
@@ -915,7 +915,7 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
    calcReturnAndTotalCollateral :: ()
       => Ledger.AlonzoEraPParams (ShelleyLedgerEra era)
       => BabbageEraOnwards era
-      -> Lovelace -- ^ Fee
+      -> L.Coin -- ^ Fee
       -> Ledger.PParams (ShelleyLedgerEra era)
       -> TxInsCollateral era -- ^ From the initial TxBodyContent
       -> TxReturnCollateral CtxTx era -- ^ From the initial TxBodyContent
@@ -933,17 +933,17 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
         -- collateral tx inputs to cover the tx
         let txOuts = catMaybes [ Map.lookup txin utxo' | txin <- collIns]
             totalCollateralLovelace = mconcat $ map (\(TxOut _ txOutVal _ _) -> txOutValueToLovelace txOutVal) txOuts
-            requiredCollateral@(Lovelace reqAmt) = fromIntegral colPerc * fee
+            requiredCollateral@(L.Coin reqAmt) = fromIntegral colPerc * fee
             totalCollateral = TxTotalCollateral retColSup . fromShelleyLovelace
-                                                          . Ledger.rationalToCoinViaCeiling
+                                                          . L.rationalToCoinViaCeiling
                                                           $ reqAmt % 100
             -- Why * 100? requiredCollateral is the product of the collateral percentage and the tx fee
             -- We choose to multiply 100 rather than divide by 100 to make the calculation
             -- easier to manage. At the end of the calculation we then use % 100 to perform our division
             -- and round up.
             enoughCollateral = totalCollateralLovelace * 100 >= requiredCollateral
-            Lovelace amt = totalCollateralLovelace * 100 - requiredCollateral
-            returnCollateral = fromShelleyLovelace . Ledger.rationalToCoinViaFloor $ amt % 100
+            L.Coin amt = totalCollateralLovelace * 100 - requiredCollateral
+            returnCollateral = fromShelleyLovelace . L.rationalToCoinViaFloor $ amt % 100
 
         case (txReturnCollateral, txTotalCollateral) of
 #if MIN_VERSION_base(4,16,0)
@@ -977,7 +977,7 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
    accountForNoChange :: TxOut CtxTx era -> [TxOut CtxTx era] -> [TxOut CtxTx era]
    accountForNoChange change@(TxOut _ balance _ _) rest =
      case txOutValueToLovelace balance of
-       Lovelace 0 -> rest
+       L.Coin 0 -> rest
        -- We append change at the end so a client can predict the indexes
        -- of the outputs
        _ -> rest ++ [change]
@@ -1084,7 +1084,7 @@ mapTxScriptWitnesses f txbodycontent@TxBodyContent {
     mapScriptWitnessesWithdrawals (TxWithdrawals supported withdrawals) =
       let mappedWithdrawals
             :: [( StakeAddress
-                , Lovelace
+                , L.Coin
                 , Either TxBodyErrorAutoBalance (BuildTxWith BuildTx (Witness WitCtxStake era))
                 )]
           mappedWithdrawals =
@@ -1160,7 +1160,7 @@ calculateMinimumUTxO
   :: ShelleyBasedEra era
   -> TxOut CtxTx era
   -> Ledger.PParams (ShelleyLedgerEra era)
-  -> Lovelace
+  -> L.Coin
 calculateMinimumUTxO sbe txout pp =
   shelleyBasedEraConstraints sbe
     $ let txOutWithMinCoin = L.setMinCoinTxOut pp (toShelleyTxOutAny sbe txout)

--- a/cardano-api/internal/Cardano/Api/GenesisParameters.hs
+++ b/cardano-api/internal/Cardano/Api/GenesisParameters.hs
@@ -20,8 +20,8 @@ import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
 import           Cardano.Api.NetworkId
 import qualified Cardano.Api.ReexposeLedger as Ledger
-import           Cardano.Api.Value
 
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Shelley.Genesis as Shelley
 import           Cardano.Slotting.Slot (EpochSize (..))
 
@@ -87,7 +87,7 @@ data GenesisParameters era =
        -- | The maximum supply for Lovelace. This determines the initial value
        -- of the reserves.
        --
-       protocolParamMaxLovelaceSupply :: Lovelace,
+       protocolParamMaxLovelaceSupply :: L.Coin,
 
        -- | The initial values of the updateable 'ProtocolParameters'.
        --
@@ -129,7 +129,6 @@ fromShelleyGenesis
     , protocolParamSlotsPerKESPeriod      = fromIntegral sgSlotsPerKESPeriod
     , protocolParamMaxKESEvolutions       = fromIntegral sgMaxKESEvolutions
     , protocolParamUpdateQuorum           = fromIntegral sgUpdateQuorum
-    , protocolParamMaxLovelaceSupply      = Lovelace
-                                              (fromIntegral sgMaxLovelaceSupply)
+    , protocolParamMaxLovelaceSupply      = L.Coin $ fromIntegral sgMaxLovelaceSupply
     , protocolInitialUpdateableProtocolParameters = Shelley.sgProtocolParams sg
     }

--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -26,6 +26,7 @@ import           Cardano.Api.Value
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Ledger.Address as L
 import           Cardano.Ledger.BaseTypes
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway as Conway
 import qualified Cardano.Ledger.Conway.Governance as Gov
 import qualified Cardano.Ledger.Conway.Governance as Ledger
@@ -57,7 +58,7 @@ data GovernanceAction era
       (Map (Hash CommitteeColdKey) EpochNo) -- ^ New committee members with epoch number when each of them expires
       Rational -- ^ Quorum of the committee that is necessary for a successful vote
   | InfoAct
-  | TreasuryWithdrawal [(Network, StakeCredential, Lovelace)]
+  | TreasuryWithdrawal [(Network, StakeCredential, L.Coin)]
   | InitiateHardfork
       (StrictMaybe (Ledger.PrevGovActionId Ledger.HardForkPurpose StandardCrypto))
       ProtVer
@@ -156,7 +157,7 @@ instance HasTypeProxy era => HasTypeProxy (Proposal era) where
 createProposalProcedure
   :: ShelleyBasedEra era
   -> Network
-  -> Lovelace -- ^ Deposit
+  -> L.Coin -- ^ Deposit
   -> Hash StakeKey -- ^ Return address
   -> GovernanceAction era
   -> Ledger.Anchor StandardCrypto
@@ -173,7 +174,7 @@ createProposalProcedure sbe nw dep (StakeKeyHash retAddrh) govAct anchor =
 fromProposalProcedure
   :: ShelleyBasedEra era
   -> Proposal era
-  -> (Lovelace, Hash StakeKey, GovernanceAction era)
+  -> (L.Coin, Hash StakeKey, GovernanceAction era)
 fromProposalProcedure sbe (Proposal pp) =
   shelleyBasedEraConstraints sbe
     ( fromShelleyLovelace $ Gov.pProcDeposit pp

--- a/cardano-api/internal/Cardano/Api/Ledger/Lens.hs
+++ b/cardano-api/internal/Cardano/Api/Ledger/Lens.hs
@@ -49,6 +49,7 @@ import           Cardano.Api.Eon.ShelleyEraOnly
 import           Cardano.Api.Eon.ShelleyToAllegraEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra
 import           Cardano.Api.Eras.Case
+import           Cardano.Api.Orphans ()
 
 import qualified Cardano.Ledger.Allegra.Core as L
 import qualified Cardano.Ledger.Alonzo.Core as L

--- a/cardano-api/internal/Cardano/Api/LedgerEvent.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerEvent.hs
@@ -21,7 +21,7 @@ where
 import           Cardano.Api.Address (StakeCredential, fromShelleyStakeCredential)
 import           Cardano.Api.Block (EpochNo)
 import           Cardano.Api.Keys.Shelley (Hash (StakePoolKeyHash), StakePoolKey)
-import           Cardano.Api.Value (fromShelleyDeltaLovelace, fromShelleyLovelace)
+import           Cardano.Api.Value (fromShelleyDeltaLovelace)
 
 import           Cardano.Ledger.Alonzo.Rules (AlonzoBbodyEvent (..), AlonzoUtxoEvent (..),
                    AlonzoUtxosEvent (FailedPlutusScriptsEvent, SuccessfulPlutusScriptsEvent),
@@ -210,8 +210,8 @@ pattern LEMirTransfer rp tp rtt ttr <-
         ( MirEvent
             ( MirTransfer
                 ( InstantaneousRewards
-                    (Map.mapKeys fromShelleyStakeCredential . fmap fromShelleyLovelace -> rp)
-                    (Map.mapKeys fromShelleyStakeCredential . fmap fromShelleyLovelace -> tp)
+                    (Map.mapKeys fromShelleyStakeCredential -> rp)
+                    (Map.mapKeys fromShelleyStakeCredential -> tp)
                     (fromShelleyDeltaLovelace -> rtt)
                     (fromShelleyDeltaLovelace -> ttr)
                   )
@@ -309,4 +309,4 @@ convertRetiredPoolsMap ::
   -> Map StakeCredential (Map (Hash StakePoolKey) L.Coin)
 convertRetiredPoolsMap =
   Map.mapKeys fromShelleyStakeCredential
-    . fmap (Map.mapKeys StakePoolKeyHash . fmap fromShelleyLovelace)
+    . fmap (Map.mapKeys StakePoolKeyHash)

--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Ledger.Alonzo.PParams as Ledger
 import qualified Cardano.Ledger.Babbage.PParams as Ledger
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway.PParams as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Crypto as CC (Crypto)
@@ -55,6 +56,16 @@ deriving instance Data DecoderError
 deriving instance Data CBOR.DeserialiseFailure
 deriving instance Data Bech32.DecodingError
 deriving instance Data Bech32.CharPosition
+
+-- | These instances originally existed on the Lovelace type.
+-- As the Lovelace type is deleted and we use L.Coin instead,
+-- these instances are added to L.Coin.  The instances are
+-- purely for the convenience of writing expressions involving
+-- L.Coin but be aware that not all uses of these typeclasses
+-- are valid.
+deriving newtype instance Real L.Coin
+deriving newtype instance Integral L.Coin
+deriving newtype instance Num L.Coin
 
 -- Orphan instances involved in the JSON output of the API queries.
 -- We will remove/replace these as we provide more API wrapper types

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -126,6 +126,7 @@ import           Cardano.Ledger.Api.PParams
 import qualified Cardano.Ledger.Babbage.Core as Ledger
 import           Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import qualified Cardano.Ledger.BaseTypes as Ledger
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Conway.PParams as Ledger
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import qualified Cardano.Ledger.Keys as Ledger
@@ -515,29 +516,29 @@ data ProtocolParameters =
 
        -- | The constant factor for the minimum fee calculation.
        --
-       protocolParamTxFeeFixed :: Lovelace,
+       protocolParamTxFeeFixed :: L.Coin,
 
        -- | Per byte linear factor for the minimum fee calculation.
        --
-       protocolParamTxFeePerByte :: Lovelace,
+       protocolParamTxFeePerByte :: L.Coin,
 
        -- | The minimum permitted value for new UTxO entries, ie for
        -- transaction outputs.
        --
-       protocolParamMinUTxOValue :: Maybe Lovelace,
+       protocolParamMinUTxOValue :: Maybe L.Coin,
 
        -- | The deposit required to register a stake address.
        --
-       protocolParamStakeAddressDeposit :: Lovelace,
+       protocolParamStakeAddressDeposit :: L.Coin,
 
        -- | The deposit required to register a stake pool.
        --
-       protocolParamStakePoolDeposit :: Lovelace,
+       protocolParamStakePoolDeposit :: L.Coin,
 
        -- | The minimum value that stake pools are permitted to declare for
        -- their cost parameter.
        --
-       protocolParamMinPoolCost :: Lovelace,
+       protocolParamMinPoolCost :: L.Coin,
 
        -- | The maximum number of epochs into the future that stake pools
        -- are permitted to schedule a retirement.
@@ -608,7 +609,7 @@ data ProtocolParameters =
        -- | Cost in ada per byte of UTxO storage.
        --
        -- /Introduced in Babbage/
-       protocolParamUTxOCostPerByte :: Maybe Lovelace
+       protocolParamUTxOCostPerByte :: Maybe L.Coin
 
     }
   deriving (Eq, Generic, Show)
@@ -743,29 +744,29 @@ data ProtocolParametersUpdate =
 
        -- | The constant factor for the minimum fee calculation.
        --
-       protocolUpdateTxFeeFixed :: Maybe Lovelace,
+       protocolUpdateTxFeeFixed :: Maybe L.Coin,
 
        -- | The linear factor for the minimum fee calculation.
        --
-       protocolUpdateTxFeePerByte :: Maybe Lovelace,
+       protocolUpdateTxFeePerByte :: Maybe L.Coin,
 
        -- | The minimum permitted value for new UTxO entries, ie for
        -- transaction outputs.
        --
-       protocolUpdateMinUTxOValue :: Maybe Lovelace,
+       protocolUpdateMinUTxOValue :: Maybe L.Coin,
 
        -- | The deposit required to register a stake address.
        --
-       protocolUpdateStakeAddressDeposit :: Maybe Lovelace,
+       protocolUpdateStakeAddressDeposit :: Maybe L.Coin,
 
        -- | The deposit required to register a stake pool.
        --
-       protocolUpdateStakePoolDeposit :: Maybe Lovelace,
+       protocolUpdateStakePoolDeposit :: Maybe L.Coin,
 
        -- | The minimum value that stake pools are permitted to declare for
        -- their cost parameter.
        --
-       protocolUpdateMinPoolCost :: Maybe Lovelace,
+       protocolUpdateMinPoolCost :: Maybe L.Coin,
 
        -- | The maximum number of epochs into the future that stake pools
        -- are permitted to schedule a retirement.
@@ -838,7 +839,7 @@ data ProtocolParametersUpdate =
        -- | Cost in ada per byte of UTxO storage.
        --
        -- /Introduced in Babbage/
-       protocolUpdateUTxOCostPerByte :: Maybe Lovelace
+       protocolUpdateUTxOCostPerByte :: Maybe L.Coin
     }
   deriving (Eq, Show)
 
@@ -1010,7 +1011,7 @@ fromLedgerNonce (Ledger.Nonce h)    = Just (PraosNonce (Crypto.castHash h))
 -- Script execution unit prices and cost models
 --
 
--- | The prices for 'ExecutionUnits' as a fraction of a 'Lovelace'.
+-- | The prices for 'ExecutionUnits' as a fraction of a 'L.Coin'.
 --
 -- These are used to determine the fee for the use of a script within a
 -- transaction, based on the 'ExecutionUnits' needed by the use of the script.

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -1223,25 +1223,19 @@ toShelleyCommonPParamsUpdate
   tau <- mapM (boundRationalEither "Tau") protocolUpdateTreasuryCut
   let ppuCommon =
         emptyPParamsUpdate
-        & ppuMinFeeAL     .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte)
-        & ppuMinFeeBL     .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed)
+        & ppuMinFeeAL     .~ noInlineMaybeToStrictMaybe protocolUpdateTxFeePerByte
+        & ppuMinFeeBL     .~ noInlineMaybeToStrictMaybe protocolUpdateTxFeeFixed
         & ppuMaxBBSizeL   .~ noInlineMaybeToStrictMaybe protocolUpdateMaxBlockBodySize
         & ppuMaxTxSizeL   .~ noInlineMaybeToStrictMaybe protocolUpdateMaxTxSize
         & ppuMaxBHSizeL   .~ noInlineMaybeToStrictMaybe protocolUpdateMaxBlockHeaderSize
-        & ppuKeyDepositL  .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit)
-        & ppuPoolDepositL .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit)
+        & ppuKeyDepositL  .~ noInlineMaybeToStrictMaybe protocolUpdateStakeAddressDeposit
+        & ppuPoolDepositL .~ noInlineMaybeToStrictMaybe protocolUpdateStakePoolDeposit
         & ppuEMaxL        .~ noInlineMaybeToStrictMaybe protocolUpdatePoolRetireMaxEpoch
         & ppuNOptL        .~ noInlineMaybeToStrictMaybe protocolUpdateStakePoolTargetNum
         & ppuA0L          .~ noInlineMaybeToStrictMaybe a0
-
         & ppuRhoL         .~ noInlineMaybeToStrictMaybe rho
         & ppuTauL         .~ noInlineMaybeToStrictMaybe tau
-        & ppuMinPoolCostL     .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost)
+        & ppuMinPoolCostL .~ noInlineMaybeToStrictMaybe protocolUpdateMinPoolCost
   pure ppuCommon
 
 toShelleyPParamsUpdate :: ( EraPParams ledgerera
@@ -1263,11 +1257,9 @@ toShelleyPParamsUpdate
   protVer <- mapM mkProtVer protocolUpdateProtocolVersion
   let ppuShelley =
         ppuCommon
-        & ppuDL            .~ noInlineMaybeToStrictMaybe d
-        & ppuExtraEntropyL .~
-          (toLedgerNonce <$> noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy)
-        & ppuMinUTxOValueL .~
-          (toShelleyLovelace <$> noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue)
+        & ppuDL               .~ noInlineMaybeToStrictMaybe d
+        & ppuExtraEntropyL    .~ (toLedgerNonce <$> noInlineMaybeToStrictMaybe protocolUpdateExtraPraosEntropy)
+        & ppuMinUTxOValueL    .~ noInlineMaybeToStrictMaybe protocolUpdateMinUTxOValue
         & ppuProtocolVersionL .~ noInlineMaybeToStrictMaybe protVer
   pure ppuShelley
 
@@ -1332,9 +1324,7 @@ toBabbageCommonPParamsUpdate
   ppuAlonzoCommon <- toAlonzoCommonPParamsUpdate protocolParametersUpdate
   let ppuBabbage =
         ppuAlonzoCommon
-        & ppuCoinsPerUTxOByteL .~
-          (CoinPerByte . toShelleyLovelace <$>
-           noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerByte)
+          & ppuCoinsPerUTxOByteL .~ fmap CoinPerByte (noInlineMaybeToStrictMaybe protocolUpdateUTxOCostPerByte)
   pure ppuBabbage
 
 toBabbagePParamsUpdate :: Ledger.Crypto crypto
@@ -1417,24 +1407,16 @@ fromShelleyCommonPParamsUpdate ppu =
     , protocolUpdateMaxBlockHeaderSize  = strictMaybeToMaybe (ppu ^. ppuMaxBHSizeL)
     , protocolUpdateMaxBlockBodySize    = strictMaybeToMaybe (ppu ^. ppuMaxBBSizeL)
     , protocolUpdateMaxTxSize           = strictMaybeToMaybe (ppu ^. ppuMaxTxSizeL)
-    , protocolUpdateTxFeeFixed          = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuMinFeeBL)
-    , protocolUpdateTxFeePerByte        = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuMinFeeAL)
-    , protocolUpdateStakeAddressDeposit = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuKeyDepositL)
-    , protocolUpdateStakePoolDeposit    = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuPoolDepositL)
-    , protocolUpdateMinPoolCost         = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuMinPoolCostL)
+    , protocolUpdateTxFeeFixed          = strictMaybeToMaybe (ppu ^. ppuMinFeeBL)
+    , protocolUpdateTxFeePerByte        = strictMaybeToMaybe (ppu ^. ppuMinFeeAL)
+    , protocolUpdateStakeAddressDeposit = strictMaybeToMaybe (ppu ^. ppuKeyDepositL)
+    , protocolUpdateStakePoolDeposit    = strictMaybeToMaybe (ppu ^. ppuPoolDepositL)
+    , protocolUpdateMinPoolCost         = strictMaybeToMaybe (ppu ^. ppuMinPoolCostL)
     , protocolUpdatePoolRetireMaxEpoch  = strictMaybeToMaybe (ppu ^. ppuEMaxL)
     , protocolUpdateStakePoolTargetNum  = strictMaybeToMaybe (ppu ^. ppuNOptL)
-    , protocolUpdatePoolPledgeInfluence = Ledger.unboundRational <$>
-                                            strictMaybeToMaybe (ppu ^. ppuA0L)
-    , protocolUpdateMonetaryExpansion   = Ledger.unboundRational <$>
-                                            strictMaybeToMaybe (ppu ^. ppuRhoL)
-    , protocolUpdateTreasuryCut         = Ledger.unboundRational <$>
-                                            strictMaybeToMaybe (ppu ^. ppuTauL)
+    , protocolUpdatePoolPledgeInfluence = Ledger.unboundRational <$> strictMaybeToMaybe (ppu ^. ppuA0L)
+    , protocolUpdateMonetaryExpansion   = Ledger.unboundRational <$> strictMaybeToMaybe (ppu ^. ppuRhoL)
+    , protocolUpdateTreasuryCut         = Ledger.unboundRational <$> strictMaybeToMaybe (ppu ^. ppuTauL)
     , protocolUpdateCostModels          = mempty
     , protocolUpdatePrices              = Nothing
     , protocolUpdateMaxTxExUnits        = Nothing
@@ -1463,8 +1445,7 @@ fromShelleyPParamsUpdate ppu =
                                             strictMaybeToMaybe (ppu ^. ppuDL)
     , protocolUpdateExtraPraosEntropy   = fromLedgerNonce <$>
                                             strictMaybeToMaybe (ppu ^. ppuExtraEntropyL)
-    , protocolUpdateMinUTxOValue        = fromShelleyLovelace <$>
-                                            strictMaybeToMaybe (ppu ^. ppuMinUTxOValueL)
+    , protocolUpdateMinUTxOValue        = strictMaybeToMaybe (ppu ^. ppuMinUTxOValueL)
     }
 
 fromAlonzoCommonPParamsUpdate :: AlonzoEraPParams ledgerera
@@ -1500,9 +1481,8 @@ fromBabbageCommonPParamsUpdate :: BabbageEraPParams ledgerera
                                => PParamsUpdate ledgerera
                                -> ProtocolParametersUpdate
 fromBabbageCommonPParamsUpdate ppu =
-  (fromAlonzoCommonPParamsUpdate ppu) {
-      protocolUpdateUTxOCostPerByte    = fromShelleyLovelace . unCoinPerByte <$>
-                                           strictMaybeToMaybe (ppu ^. ppuCoinsPerUTxOByteL)
+  (fromAlonzoCommonPParamsUpdate ppu)
+    { protocolUpdateUTxOCostPerByte = unCoinPerByte <$> strictMaybeToMaybe (ppu ^. ppuCoinsPerUTxOByteL)
     }
 
 fromBabbagePParamsUpdate :: Ledger.Crypto crypto
@@ -1562,20 +1542,20 @@ toShelleyCommonPParams
   protVer <- mkProtVer protocolParamProtocolVersion
   let ppCommon =
         emptyPParams
-        & ppMinFeeAL         .~ toShelleyLovelace protocolParamTxFeePerByte
-        & ppMinFeeBL         .~ toShelleyLovelace protocolParamTxFeeFixed
+        & ppMinFeeAL         .~ protocolParamTxFeePerByte
+        & ppMinFeeBL         .~ protocolParamTxFeeFixed
         & ppMaxBBSizeL       .~ protocolParamMaxBlockBodySize
         & ppMaxTxSizeL       .~ protocolParamMaxTxSize
         & ppMaxBHSizeL       .~ protocolParamMaxBlockHeaderSize
-        & ppKeyDepositL      .~ toShelleyLovelace protocolParamStakeAddressDeposit
-        & ppPoolDepositL     .~ toShelleyLovelace protocolParamStakePoolDeposit
+        & ppKeyDepositL      .~ protocolParamStakeAddressDeposit
+        & ppPoolDepositL     .~ protocolParamStakePoolDeposit
         & ppEMaxL            .~ protocolParamPoolRetireMaxEpoch
         & ppNOptL            .~ protocolParamStakePoolTargetNum
         & ppA0L              .~ a0
         & ppRhoL             .~ rho
         & ppTauL             .~ tau
         & ppProtocolVersionL .~ protVer
-        & ppMinPoolCostL     .~ toShelleyLovelace protocolParamMinPoolCost
+        & ppMinPoolCostL     .~ protocolParamMinPoolCost
   pure ppCommon
 
 toShelleyPParams :: ( EraPParams ledgerera
@@ -1597,7 +1577,7 @@ toShelleyPParams
         ppCommon
         & ppDL            .~ d
         & ppExtraEntropyL .~ toLedgerNonce protocolParamExtraPraosEntropy
-        & ppMinUTxOValueL .~ toShelleyLovelace minUTxOValue
+        & ppMinUTxOValueL .~ minUTxOValue
   pure ppShelley
 
 
@@ -1681,7 +1661,7 @@ toBabbagePParams
     requireParam "protocolParamUTxOCostPerByte" Right protocolParamUTxOCostPerByte
   let ppBabbage =
         ppAlonzoCommon
-        & ppCoinsPerUTxOByteL .~ CoinPerByte (toShelleyLovelace utxoCostPerByte)
+          & ppCoinsPerUTxOByteL .~ CoinPerByte utxoCostPerByte
   pure ppBabbage
 
 toConwayPParams :: BabbageEraPParams ledgerera
@@ -1715,11 +1695,11 @@ fromShelleyCommonPParams pp =
     , protocolParamMaxBlockHeaderSize  = pp ^. ppMaxBHSizeL
     , protocolParamMaxBlockBodySize    = pp ^. ppMaxBBSizeL
     , protocolParamMaxTxSize           = pp ^. ppMaxTxSizeL
-    , protocolParamTxFeeFixed          = fromShelleyLovelace (pp ^. ppMinFeeBL)
-    , protocolParamTxFeePerByte        = fromShelleyLovelace (pp ^. ppMinFeeAL)
-    , protocolParamStakeAddressDeposit = fromShelleyLovelace (pp ^. ppKeyDepositL)
-    , protocolParamStakePoolDeposit    = fromShelleyLovelace (pp ^. ppPoolDepositL)
-    , protocolParamMinPoolCost         = fromShelleyLovelace (pp ^. ppMinPoolCostL)
+    , protocolParamTxFeeFixed          = pp ^. ppMinFeeBL
+    , protocolParamTxFeePerByte        = pp ^. ppMinFeeAL
+    , protocolParamStakeAddressDeposit = pp ^. ppKeyDepositL
+    , protocolParamStakePoolDeposit    = pp ^. ppPoolDepositL
+    , protocolParamMinPoolCost         = pp ^. ppMinPoolCostL
     , protocolParamPoolRetireMaxEpoch  = pp ^. ppEMaxL
     , protocolParamStakePoolTargetNum  = pp ^. ppNOptL
     , protocolParamPoolPledgeInfluence = Ledger.unboundRational (pp ^. ppA0L)
@@ -1748,7 +1728,7 @@ fromShelleyPParams pp =
   (fromShelleyCommonPParams pp) {
       protocolParamDecentralization    = Just . Ledger.unboundRational $ pp ^. ppDL
     , protocolParamExtraPraosEntropy   = fromLedgerNonce $ pp ^. ppExtraEntropyL
-    , protocolParamMinUTxOValue        = Just . fromShelleyLovelace $ pp ^. ppMinUTxOValueL
+    , protocolParamMinUTxOValue        = Just $ pp ^. ppMinUTxOValueL
     }
 
 
@@ -1770,9 +1750,8 @@ fromBabbagePParams :: BabbageEraPParams ledgerera
                    => PParams ledgerera
                    -> ProtocolParameters
 fromBabbagePParams pp =
-  (fromAlonzoPParams pp) {
-    protocolParamUTxOCostPerByte = Just . fromShelleyLovelace . unCoinPerByte $
-                                     pp ^. ppCoinsPerUTxOByteL
+  (fromAlonzoPParams pp)
+    { protocolParamUTxOCostPerByte = Just . unCoinPerByte $ pp ^. ppCoinsPerUTxOByteL
     }
 
 fromConwayPParams :: BabbageEraPParams ledgerera

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -101,6 +101,7 @@ import qualified Cardano.Ledger.Api.State.Query as L
 import           Cardano.Ledger.Binary
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import qualified Cardano.Ledger.CertState as L
+import qualified Cardano.Ledger.Coin as L
 import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (Crypto)
 import qualified Cardano.Ledger.Shelley.API as Shelley
@@ -262,7 +263,7 @@ data QueryInShelleyBasedEra era result where
   QueryStakeAddresses
     :: Set StakeCredential
     -> NetworkId
-    -> QueryInShelleyBasedEra era (Map StakeAddress Lovelace, Map StakeAddress PoolId)
+    -> QueryInShelleyBasedEra era (Map StakeAddress L.Coin, Map StakeAddress PoolId)
 
   QueryStakePools
     :: QueryInShelleyBasedEra era (Set PoolId)
@@ -298,7 +299,7 @@ data QueryInShelleyBasedEra era result where
 
   QueryStakeDelegDeposits
     :: Set StakeCredential
-    -> QueryInShelleyBasedEra era (Map StakeCredential Lovelace)
+    -> QueryInShelleyBasedEra era (Map StakeCredential L.Coin)
 
   QueryConstitution
     :: QueryInShelleyBasedEra era (Maybe (L.Constitution (ShelleyLedgerEra era)))
@@ -312,7 +313,7 @@ data QueryInShelleyBasedEra era result where
 
   QueryDRepStakeDistr
     :: Set (Ledger.DRep StandardCrypto)
-    -> QueryInShelleyBasedEra era (Map (Ledger.DRep StandardCrypto) Lovelace)
+    -> QueryInShelleyBasedEra era (Map (Ledger.DRep StandardCrypto) L.Coin)
 
   QueryCommitteeMembersState
     :: Set (Shelley.Credential Shelley.ColdCommitteeRole StandardCrypto)
@@ -536,7 +537,7 @@ fromShelleyDelegations =
   . Map.toList
 
 fromShelleyRewardAccounts :: Shelley.RewardAccounts Consensus.StandardCrypto
-                          -> Map StakeCredential Lovelace
+                          -> Map StakeCredential L.Coin
 fromShelleyRewardAccounts =
     --TODO: write an appropriate property to show it is safe to use
     -- Map.fromListAsc or to use Map.mapKeysMonotonic

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -93,7 +93,6 @@ import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query.Types
 import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.TxBody
-import           Cardano.Api.Value
 
 import qualified Cardano.Chain.Update.Validation.Interface as Byron.Update
 import qualified Cardano.Ledger.Api as L
@@ -542,7 +541,7 @@ fromShelleyRewardAccounts =
     --TODO: write an appropriate property to show it is safe to use
     -- Map.fromListAsc or to use Map.mapKeysMonotonic
     Map.fromList
-  . map (bimap fromShelleyStakeCredential fromShelleyLovelace)
+  . map (first fromShelleyStakeCredential)
   . Map.toList
 
 
@@ -908,8 +907,7 @@ fromConsensusQueryResultShelleyBased _ QueryStakeSnapshot{} q' r' =
 
 fromConsensusQueryResultShelleyBased _ QueryStakeDelegDeposits{} q' stakeCreds' =
     case q' of
-      Consensus.GetStakeDelegDeposits{} -> Map.map fromShelleyLovelace
-                                         . Map.mapKeysMonotonic fromShelleyStakeCredential
+      Consensus.GetStakeDelegDeposits{} -> Map.mapKeysMonotonic fromShelleyStakeCredential
                                          $ stakeCreds'
       _                                 -> fromConsensusQueryResultMismatch
 
@@ -925,7 +923,7 @@ fromConsensusQueryResultShelleyBased _ QueryDRepState{} q' drepState'  =
 
 fromConsensusQueryResultShelleyBased _ QueryDRepStakeDistr{} q' stakeDistr' =
   case q' of
-    Consensus.GetDRepStakeDistr{} -> Map.map fromShelleyLovelace stakeDistr'
+    Consensus.GetDRepStakeDistr{} -> stakeDistr'
     _                             -> fromConsensusQueryResultMismatch
 
 fromConsensusQueryResultShelleyBased _ QueryCommitteeMembersState{} q' committeeMembersState' =

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -46,11 +46,11 @@ import           Cardano.Api.NetworkId
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query
 import qualified Cardano.Api.ReexposeLedger as Ledger
-import           Cardano.Api.Value
 
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Api.State.Query as L
 import qualified Cardano.Ledger.CertState as L
+import qualified Cardano.Ledger.Coin as L
 import           Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Keys as L
@@ -149,14 +149,14 @@ queryStakeAddresses :: ()
   => ShelleyBasedEra era
   -> Set StakeCredential
   -> NetworkId
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress Lovelace, Map StakeAddress PoolId)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map StakeAddress L.Coin, Map StakeAddress PoolId)))
 queryStakeAddresses sbe stakeCredentials networkId =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits :: ()
   => ShelleyBasedEra era
   -> Set StakeCredential
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential Lovelace)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either Consensus.EraMismatch (Map StakeCredential L.Coin)))
 queryStakeDelegDeposits sbe stakeCreds
   | S.null stakeCreds = pure . pure $ pure mempty
   | otherwise         = queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
@@ -223,7 +223,7 @@ queryDRepStakeDistribution :: ()
   => ShelleyBasedEra era
   -> Set (L.DRep L.StandardCrypto)
   -- ^ An empty DRep set means that distributions for all DReps will be returned
-  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) Lovelace)))
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) L.Coin)))
 queryDRepStakeDistribution sbe dreps = queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -202,6 +202,7 @@ import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import           Cardano.Ledger.Binary (Annotated (..), reAnnotate, recoverBytes)
 import qualified Cardano.Ledger.Binary as CBOR
 import qualified Cardano.Ledger.Block as Ledger
+import qualified Cardano.Ledger.Coin as L
 import           Cardano.Ledger.Core ()
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Core as Ledger
@@ -840,7 +841,7 @@ deriving instance Show (TxInsReference build era)
 data TxOutValue era where
 
   TxOutValueByron
-    :: Lovelace
+    :: L.Coin
     -> TxOutValue era
 
   TxOutValueShelleyBased
@@ -914,7 +915,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOutValue era) where
 
 lovelaceToTxOutValue :: ()
   => ShelleyBasedEra era
-  -> Lovelace
+  -> L.Coin
   -> TxOutValue era
 lovelaceToTxOutValue era ll =
   shelleyBasedEraConstraints era
@@ -923,7 +924,7 @@ lovelaceToTxOutValue era ll =
     $ lovelaceToCoin ll
 
 
-txOutValueToLovelace :: TxOutValue era -> Lovelace
+txOutValueToLovelace :: TxOutValue era -> L.Coin
 txOutValueToLovelace tv =
   case tv of
     TxOutValueByron             l -> l
@@ -960,7 +961,7 @@ data TxTotalCollateral era where
 
   TxTotalCollateral
     :: BabbageEraOnwards era
-    -> Lovelace
+    -> L.Coin
     -> TxTotalCollateral era
 
 deriving instance Eq   (TxTotalCollateral era)
@@ -1025,7 +1026,7 @@ parseHash asType = do
 data TxFee era where
   TxFeeImplicit :: ByronEraOnly era -> TxFee era
 
-  TxFeeExplicit :: ShelleyBasedEra era -> Lovelace -> TxFee era
+  TxFeeExplicit :: ShelleyBasedEra era -> L.Coin -> TxFee era
 
 deriving instance Eq   (TxFee era)
 deriving instance Show (TxFee era)
@@ -1138,7 +1139,7 @@ data TxWithdrawals build era where
 
   TxWithdrawals
     :: ShelleyBasedEra era
-    -> [(StakeAddress, Lovelace, BuildTxWith build (Witness WitCtxStake era))]
+    -> [(StakeAddress, L.Coin, BuildTxWith build (Witness WitCtxStake era))]
     -> TxWithdrawals build era
 
 deriving instance Eq   (TxWithdrawals build era)
@@ -3285,7 +3286,7 @@ orderStakeAddrs :: [(StakeAddress, x, v)] -> [(StakeAddress, x, v)]
 orderStakeAddrs = sortBy (compare `on` (\(k, _, _) -> k))
 
 
-toShelleyWithdrawal :: [(StakeAddress, Lovelace, a)] -> L.Withdrawals StandardCrypto
+toShelleyWithdrawal :: [(StakeAddress, L.Coin, a)] -> L.Withdrawals StandardCrypto
 toShelleyWithdrawal withdrawals =
     L.Withdrawals $
       Map.fromList
@@ -3295,7 +3296,7 @@ toShelleyWithdrawal withdrawals =
 
 fromShelleyWithdrawal
   :: L.Withdrawals StandardCrypto
-  -> [(StakeAddress, Lovelace, BuildTxWith ViewTx (Witness WitCtxStake era))]
+  -> [(StakeAddress, L.Coin, BuildTxWith ViewTx (Witness WitCtxStake era))]
 fromShelleyWithdrawal (L.Withdrawals withdrawals) =
   [ (fromShelleyStakeAddr stakeAddr, fromShelleyLovelace value, ViewTx)
   | (stakeAddr, value) <- Map.assocs withdrawals
@@ -3357,7 +3358,7 @@ genesisUTxOPseudoTxIn nw (GenesisUTxOKeyHash kh) =
              (Shelley.KeyHashObj kh)
              Shelley.StakeRefNull
 
-calculateExecutionUnitsLovelace :: Ledger.Prices -> ExecutionUnits -> Maybe Lovelace
+calculateExecutionUnitsLovelace :: Ledger.Prices -> ExecutionUnits -> Maybe L.Coin
 calculateExecutionUnitsLovelace prices eUnits =
   return . fromShelleyLovelace $ Alonzo.txscriptfee prices (toAlonzoExUnits eUnits)
 

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -47,15 +47,11 @@ module Cardano.Api.Value
     -- * Internal conversion functions
   , toByronLovelace
   , fromByronLovelace
-  , toShelleyLovelace
-  , fromShelleyLovelace
   , fromShelleyDeltaLovelace
   , toMaryValue
   , fromMaryValue
   , fromLedgerValue
-  , lovelaceToCoin
   , toLedgerValue
-  , coinToLovelace
 
     -- * Data family instances
   , AsType(..)
@@ -110,13 +106,6 @@ toByronLovelace (L.Coin x) =
 
 fromByronLovelace :: Byron.Lovelace -> L.Coin
 fromByronLovelace = L.Coin . Byron.lovelaceToInteger
-
-toShelleyLovelace :: L.Coin -> L.Coin
-toShelleyLovelace (L.Coin l) = L.Coin l
---TODO: validate bounds
-
-fromShelleyLovelace :: L.Coin -> L.Coin
-fromShelleyLovelace (L.Coin l) = L.Coin l
 
 fromShelleyDeltaLovelace :: L.DeltaCoin -> L.Coin
 fromShelleyDeltaLovelace (L.DeltaCoin d) = L.Coin d
@@ -259,14 +248,8 @@ selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
 lovelaceToValue :: L.Coin -> Value
 lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 
-lovelaceToCoin :: L.Coin -> L.Coin
-lovelaceToCoin (L.Coin ll) = L.Coin ll
-
-coinToLovelace :: L.Coin -> L.Coin
-coinToLovelace (L.Coin ll) = L.Coin ll
-
 coinToValue :: L.Coin -> Value
-coinToValue = lovelaceToValue . coinToLovelace
+coinToValue = lovelaceToValue -- jky
 
 -- | Check if the 'Value' consists of /only/ 'L.Coin' and no other assets,
 -- and if so then return the L.Coin.
@@ -323,8 +306,8 @@ fromMaryValue (MaryValue lovelace other) =
 -- | Calculate cost of making a UTxO entry for a given 'Value' and
 -- mininimum UTxO value derived from the 'ProtocolParameters'
 calcMinimumDeposit :: Value -> L.Coin -> L.Coin
-calcMinimumDeposit v minUTxo =
-  fromShelleyLovelace $ Mary.scaledMinDeposit (toMaryValue v) (toShelleyLovelace minUTxo)
+calcMinimumDeposit v =
+  Mary.scaledMinDeposit (toMaryValue v)
 
 -- ----------------------------------------------------------------------------
 -- An alternative nested representation

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -75,7 +75,7 @@ import           Cardano.Api.Utils (failEitherWith)
 
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Ledger.Allegra.Core as L
-import qualified Cardano.Ledger.Coin as Shelley
+import qualified Cardano.Ledger.Coin as L
 import           Cardano.Ledger.Crypto (StandardCrypto)
 import           Cardano.Ledger.Mary.TxOut as Mary (scaledMinDeposit)
 import           Cardano.Ledger.Mary.Value (MaryValue (..))
@@ -127,15 +127,15 @@ toByronLovelace (Lovelace x) =
 fromByronLovelace :: Byron.Lovelace -> Lovelace
 fromByronLovelace = Lovelace . Byron.lovelaceToInteger
 
-toShelleyLovelace :: Lovelace -> Shelley.Coin
-toShelleyLovelace (Lovelace l) = Shelley.Coin l
+toShelleyLovelace :: Lovelace -> L.Coin
+toShelleyLovelace (Lovelace l) = L.Coin l
 --TODO: validate bounds
 
-fromShelleyLovelace :: Shelley.Coin -> Lovelace
-fromShelleyLovelace (Shelley.Coin l) = Lovelace l
+fromShelleyLovelace :: L.Coin -> Lovelace
+fromShelleyLovelace (L.Coin l) = Lovelace l
 
-fromShelleyDeltaLovelace :: Shelley.DeltaCoin -> Lovelace
-fromShelleyDeltaLovelace (Shelley.DeltaCoin d) = Lovelace d
+fromShelleyDeltaLovelace :: L.DeltaCoin -> Lovelace
+fromShelleyDeltaLovelace (L.DeltaCoin d) = Lovelace d
 
 
 -- ----------------------------------------------------------------------------
@@ -262,7 +262,7 @@ negateValue (Value m) = Value (Map.map negate m)
 negateLedgerValue :: ShelleyBasedEra era -> L.Value (ShelleyLedgerEra era) -> L.Value (ShelleyLedgerEra era)
 negateLedgerValue sbe v =
   caseShelleyToAllegraOrMaryEraOnwards
-    (\_ -> v & A.adaAssetL sbe %~ Shelley.Coin . negate . Shelley.unCoin)
+    (\_ -> v & A.adaAssetL sbe %~ L.Coin . negate . L.unCoin)
     (\w -> v & A.multiAssetL w %~ invert)
     sbe
 
@@ -275,13 +275,13 @@ selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
 lovelaceToValue :: Lovelace -> Value
 lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 
-lovelaceToCoin :: Lovelace -> Shelley.Coin
-lovelaceToCoin (Lovelace ll) = Shelley.Coin ll
+lovelaceToCoin :: Lovelace -> L.Coin
+lovelaceToCoin (Lovelace ll) = L.Coin ll
 
-coinToLovelace :: Shelley.Coin -> Lovelace
-coinToLovelace (Shelley.Coin ll) = Lovelace ll
+coinToLovelace :: L.Coin -> Lovelace
+coinToLovelace (L.Coin ll) = Lovelace ll
 
-coinToValue :: Shelley.Coin -> Value
+coinToValue :: L.Coin -> Value
 coinToValue = lovelaceToValue . coinToLovelace
 
 -- | Check if the 'Value' consists of /only/ 'Lovelace' and no other assets,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -244,10 +244,6 @@ module Cardano.Api (
     StakeKey,
     StakeExtendedKey,
 
-    -- * Currency values
-    -- ** Ada \/ Lovelace
-    Lovelace(..),
-
     -- ** Multi-asset values
     Quantity(..),
     PolicyId(..),

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -28,7 +28,6 @@ module Cardano.Api.Byron
     TxIn(TxIn),
     TxOut(TxOut),
     TxIx(TxIx),
-    Lovelace(Lovelace),
 
     -- * Signing transactions
     -- | Creating transaction witnesses one by one, or all in one go.

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -57,7 +57,6 @@ module Cardano.Api.Shelley
     toShelleyTxOut,
     fromShelleyTxOut,
     TxIx(TxIx),
-    Lovelace(Lovelace),
     toShelleyLovelace,
     fromShelleyLovelace,
     toMaryValue,

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -57,8 +57,6 @@ module Cardano.Api.Shelley
     toShelleyTxOut,
     fromShelleyTxOut,
     TxIx(TxIx),
-    toShelleyLovelace,
-    fromShelleyLovelace,
     toMaryValue,
     fromMaryValue,
     calcMinimumDeposit,

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorAdaBalanceNegative.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorAdaBalanceNegative.txt
@@ -1,1 +1,1 @@
-The transaction does not balance in its use of ada. The net balance of the transaction is negative: Lovelace 1 lovelace. The usual solution is to provide more inputs, or inputs with more ada.
+The transaction does not balance in its use of ada. The net balance of the transaction is negative: Coin 1 lovelace. The usual solution is to provide more inputs, or inputs with more ada.

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorAdaBalanceTooSmall.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorAdaBalanceTooSmall.txt
@@ -1,5 +1,5 @@
 The transaction does balance in its use of ada, however the net balance does not meet the minimum UTxO threshold. 
-Balance: Lovelace 1
+Balance: Coin 1
 Offending output (change output): addr1vyjse2p4zsv3l882enhzave8d4ddje8p0np35pnkj8sye2qu9km4v + 1 lovelace
-Minimum UTxO threshold: Lovelace 0
+Minimum UTxO threshold: Coin 0
 The usual solution is to provide more inputs, or inputs with more ada to meet the minimum UTxO threshold

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorMinUTxONotMet.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Fees.TxBodyErrorAutoBalance/TxBodyErrorMinUTxONotMet.txt
@@ -1,2 +1,2 @@
 Minimum UTxO threshold not met for tx output: addr1vyjse2p4zsv3l882enhzave8d4ddje8p0np35pnkj8sye2qu9km4v + 1 lovelace
-Minimum required UTxO: Lovelace 1
+Minimum required UTxO: Coin 1


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `L.Coin` instead of `Lovelace`
    Delete:
    - `toShelleyLovelace`
    - `fromShelleyLovelace`
    - `lovelaceToCoin`
    - `coinToLovelace`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A lot of the code is converting between `L.Coin` and `Lovelace`.  Switching to `L.Coin` saves a lot of conversions.

Note that because we now use the ledger type, it also follows that we use the ledger type class instances.  This can have knock-on changes.  See the golden file diffs for examples.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
