### PR TITLE
New `ToJSON` instance for `TxValidationErrorInCardanoMode`

### DIFF
--- a/cardano-api/internal/Cardano/Api/InMode.hs
+++ b/cardano-api/internal/Cardano/Api/InMode.hs
@@ -33,6 +33,7 @@ import           Cardano.Api.Modes
 import           Cardano.Api.Orphans ()
 import           Cardano.Api.Tx
 import           Cardano.Api.TxBody
+import           Cardano.Api.Utils (textShow)
 
 import qualified Cardano.Ledger.Api as L
 import qualified Ouroboros.Consensus.Byron.Ledger as Consensus
@@ -279,6 +280,18 @@ data TxValidationErrorInCardanoMode where
 
 deriving instance Show TxValidationErrorInCardanoMode
 
+instance ToJSON TxValidationErrorInCardanoMode where
+  toJSON = \case
+    TxValidationErrorInCardanoMode err ->
+      Aeson.object
+        [ "tag" .= Aeson.String "TxValidationErrorInCardanoMode"
+        , "contents" .= toJSON err
+        ]
+    TxValidationEraMismatch err ->
+      Aeson.object
+        [ "tag" .= Aeson.String "TxValidationEraMismatch"
+        , "contents" .= toJSON (textShow err)
+        ]
 
 fromConsensusApplyTxErr :: ()
   => Consensus.CardanoBlock L.StandardCrypto ~ block


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `ToJSON` instance for `TxValidationErrorInCardanoMode`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is required to render errors as JSON in `cardano-submit-api`.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
