### PR TITLE
Move renderSafeHashAsHex from cardano-node

### DIFF
--- a/cardano-api/internal/Cardano/Api/Hash.hs
+++ b/cardano-api/internal/Cardano/Api/Hash.hs
@@ -5,11 +5,16 @@ module Cardano.Api.Hash
   ( Hash
   , CastHash(..)
   , AsType(AsHash)
+  , renderSafeHashAsHex
   ) where
 
 import           Cardano.Api.HasTypeProxy
 
+import qualified Cardano.Crypto.Hash as Hash
+import qualified Cardano.Ledger.SafeHash as Ledger
+
 import           Data.Kind (Type)
+import qualified Data.Text as Text
 
 
 data family Hash keyrole :: Type
@@ -23,3 +28,6 @@ instance HasTypeProxy a => HasTypeProxy (Hash a) where
     data AsType (Hash a) = AsHash (AsType a)
     proxyToAsType _ = AsHash (proxyToAsType (Proxy :: Proxy a))
 
+
+renderSafeHashAsHex :: Ledger.SafeHash c tag -> Text.Text
+renderSafeHashAsHex = Hash.hashToTextAsHex . Ledger.extractHash

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -195,6 +195,7 @@ module Cardano.Api (
     -- used in many other places.
     Hash,
     castHash,
+    renderSafeHashAsHex,
 
     -- * Payment addresses
     -- | Constructing and inspecting normal payment addresses


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add renderSafeHashAsHex, which we want to remove from cardano-node and use in cardano-cli
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We're using this function in two places:

1. https://github.com/IntersectMBO/cardano-node/blob/76ef0fe7cd716426e41813958569521dd80cda8b/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs#L415
2. https://github.com/input-output-hk/cardano-cli/blob/694782210c6d73a1b5151400214ef691f6f3ecb0/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Hash.hs#L67

but this function is better placed here, and reused from these existing callers.

# How to trust this PR

This PR moves code around repos

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff