### PR TITLE
Fix links killed by GitHub migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Overview of the `cardano-api` repository
 
-Integration of the [`ledger`](https://github.com/input-output-hk/cardano-ledger), [`consensus`](https://github.com/input-output-hk/ouroboros-consensus) and
-[networking](https://github.com/input-output-hk/ouroboros-network/tree/master/ouroboros-network) repositories.
+Integration of the [`ledger`](https://github.com/IntersectMBO/cardano-ledger), [`consensus`](https://github.com/IntersectMBO/ouroboros-consensus) and
+[networking](https://github.com/IntersectMBO/ouroboros-network/tree/master/ouroboros-network) repositories.
 
 ## Contributing
 
@@ -17,4 +17,4 @@ See the [Contributing guide](CONTRIBUTING.md) for how to contribute to this proj
 
 Development documentation can be found in [Cardano Node Wiki](https://github.com/input-output-hk/cardano-node-wiki/wiki).
 
-Haddock documentation is available at: https://cardano-api.cardano.intersectmbo.org/
+Haddock documentation is available at: https://intersectmbo.github.io/cardano-api/

--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1732,7 +1732,7 @@ None
 - Improved tests for Byron era legacy key formats (#2259)
 - More precise error cases for tx outputs that are out of range (#2217)
 - Host up-to-date generated API documentation via github
-  https://cardano-node.cardano.intersectmbo.org/ (#2273, #2276, #2278)
+  https://intersectmbo.github.io/cardano-node/ (#2273, #2276, #2278)
 
 ## 1.24.2 -- December 2020
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make it possible to merge again, by fixing dead links
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A number of links have been made 404 by the GitHub migration

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff