### PR TITLE
Use MonadError for 'LedgerState'. Add `Show LedgerState`, `IOException` handling in `foldBlocks`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -419,9 +419,9 @@ newtype SerialisedDebugLedgerState era
 decodeDebugLedgerState :: forall era. ()
   => FromCBOR (DebugLedgerState era)
   => SerialisedDebugLedgerState era
-  -> Either LBS.ByteString (DebugLedgerState era)
+  -> Either (LBS.ByteString, DecoderError) (DebugLedgerState era)
 decodeDebugLedgerState (SerialisedDebugLedgerState (Serialised ls)) =
-  first (const ls) (Plain.decodeFull ls)
+  first (ls,) (Plain.decodeFull ls)
 
 newtype ProtocolState era
   = ProtocolState (Serialised (Consensus.ChainDepState (ConsensusProtocol era)))

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -25,6 +25,7 @@ module Cardano.Api.Utils
   , runParsecParser
   , textShow
   , modifyWith
+  , modifyError
 
     -- ** CLI option parsing
   , bounded
@@ -34,6 +35,8 @@ import           Cardano.Ledger.Shelley ()
 
 import           Control.Exception (bracket)
 import           Control.Monad (when)
+import           Control.Monad.Except (ExceptT, MonadError)
+import qualified Control.Monad.Except as Except
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
@@ -129,3 +132,12 @@ modifyWith :: ()
   -> (a -> a)
 modifyWith = id
 
+#if MIN_VERSION_mtl(2,3,1)
+-- | See 'Except.modifyError'
+modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
+modifyError = Except.modifyError
+#else
+-- | See 'Except.modifyError'
+modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
+modifyError f m = Except.runExceptT m >>= either (Except.throwError . f) pure
+#endif


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use MonadError for 'LedgerState'. Add `Show LedgerState`, `IOException` handling in `foldBlocks`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
`MonadError e m` allows to use functions without extra lifting if we need to use them in monad stacks with `ExceptT` underneath.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
