### PR TITLE
Better `MonadError` handling to avoid nesting `ExceptT` in `modifyError`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -114,6 +114,7 @@ library internal
                         Cardano.Api.LedgerEvents.Rule.BBODY.UTXOW
                         Cardano.Api.LedgerEvents.LedgerEvent
                         Cardano.Api.Modes
+                        Cardano.Api.Monad.Error
                         Cardano.Api.NetworkId
                         Cardano.Api.OperationalCertificate
                         Cardano.Api.Pretty
@@ -204,6 +205,7 @@ library internal
                       , prettyprinter-ansi-terminal
                       , prettyprinter-configurable ^>= 1.15
                       , random
+                      , safe-exceptions
                       , scientific
                       , serialise
                       , small-steps ^>= 1.0

--- a/cardano-api/internal/Cardano/Api/Monad/Error.hs
+++ b/cardano-api/internal/Cardano/Api/Monad/Error.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{- | This module serves purpose as a single source of abstractions used in handling 'MonadError' and
+'ExceptT' through 'cardano-api'.
+-}
+
+module Cardano.Api.Monad.Error
+  ( MonadTransError
+  , MonadIOTransError
+  , liftExceptT
+  , modifyError
+  , handleIOExceptionsWith
+  , handleIOExceptionsLiftWith
+
+  , module Control.Monad.Except
+  , module Control.Monad.IO.Class
+  , module Control.Monad.Trans.Class
+  , module Control.Monad.Trans.Except
+  , module Control.Monad.Trans.Except.Extra
+  ) where
+
+import           Control.Exception.Safe
+import           Control.Monad.Except (ExceptT (..), MonadError (..), catchError, liftEither,
+                   mapExcept, mapExceptT, runExcept, runExceptT, withExcept)
+import           Control.Monad.IO.Class
+import           Control.Monad.Trans.Class
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Except.Extra
+import           Data.Bifunctor (first)
+
+-- | Convenience alias
+type MonadTransError e t m = (Monad m, MonadTrans t, MonadError e (t m))
+--
+-- | Same as 'MonadTransError', but with also 'MonadIO' constraint
+type MonadIOTransError e t m = (MonadIO m, MonadIO (t m), MonadTrans t, MonadError e (t m))
+
+-- | Modify an 'ExceptT' error and lift it to 'MonadError' transformer stack.
+--
+-- This implementation avoids nesting problem of @modifyError@ from 'mtl'. The issue with @modifyError@ (from
+-- 'mtl') is that when you use it on a function, you actually end up with @ExceptT e1 (ExceptT e2 m a)@:
+--
+-- > modifyError (f :: e2 -> e1) (foo :: ExceptT e2 (ExceptT e1 m) a) :: ExceptT e1 m a
+--
+-- and if you use @modifyError@ ('mtl') again, the more nested you get e.g.
+-- @ExceptT e1 (ExceptT e2 (ExceptT e3 m a))@. With a deeper monad stack you pay the overhead with every
+-- use of '>>='.
+--
+-- This function avoids that, but at the cost of limiting its application to transformers.
+modifyError
+  :: MonadTransError e' t m
+  => (e -> e') -- ^ mapping function
+  -> ExceptT e m a -- ^ value
+  -> t m a -- ^ result with modified error
+modifyError f m = lift (runExceptT m) >>= either (throwError . f) pure
+
+-- | Wrap an exception and lift it into 'MonadError'.
+handleIOExceptionsWith
+  :: MonadError e' m
+  => MonadCatch m
+  => Exception e
+  => (e -> e') -- ^ mapping function
+  -> m a -- ^ action that can throw
+  -> m a -- ^ result with caught exception
+handleIOExceptionsWith f act = liftEither . first f =<< try act
+
+-- | Wrap an exception and lift it into 'MonadError' stack.
+handleIOExceptionsLiftWith
+  :: MonadIOTransError e' t m
+  => Exception e
+  => MonadCatch m
+  => (e -> e') -- ^ mapping function
+  -> m a -- ^ action that can throw
+  -> t m a -- ^ action with caucht error lifted into 'MonadError' stack
+handleIOExceptionsLiftWith f act = liftEither =<< lift (first f <$> try act)
+
+-- | Lift 'ExceptT' into 'MonadTransError'
+liftExceptT :: MonadTransError e t m
+            => ExceptT e m a
+            -> t m a
+liftExceptT = modifyError id
+

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -25,7 +25,6 @@ module Cardano.Api.Utils
   , runParsecParser
   , textShow
   , modifyWith
-  , modifyError
 
     -- ** CLI option parsing
   , bounded
@@ -35,8 +34,6 @@ import           Cardano.Ledger.Shelley ()
 
 import           Control.Exception (bracket)
 import           Control.Monad (when)
-import           Control.Monad.Except (ExceptT, MonadError)
-import qualified Control.Monad.Except as Except
 import qualified Data.Aeson.Types as Aeson
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Builder as Builder
@@ -132,12 +129,3 @@ modifyWith :: ()
   -> (a -> a)
 modifyWith = id
 
-#if MIN_VERSION_mtl(2,3,1)
--- | See 'Except.modifyError'
-modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
-modifyError = Except.modifyError
-#else
--- | See 'Except.modifyError'
-modifyError :: MonadError e' m => (e -> e') -> ExceptT e m a -> m a
-modifyError f m = Except.runExceptT m >>= either (Except.throwError . f) pure
-#endif


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Better `MonadError` handling to avoid nesting `ExceptT` in `modifyError`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR addresses [problems with `modifyError` from `mtl`](https://input-output-rnd.slack.com/archives/C031GFLC3DF/p1705408536287209?thread_ts=1705328162.862129&cid=C031GFLC3DF) noticed by @newhoggy. Briefly speaking, `mtl`'s [`modifyError`](https://hackage.haskell.org/package/mtl-2.3.1/docs/Control-Monad-Error-Class.html#v:modifyError) nests `MonadError e m` in the `ExceptT`. Therefore using `modifyError` multiple times produces a type similar to:
```haskell
ExceptT e1 (ExceptT e2 (ExceptT e3 m a))
```
This is a problem, because nested monads will have a negative performance impact.

There are two ways to fix this:
1. **(this PR's approach)** Use `MonadTrans` constraint in addition to `MonadError`.
2. Use concrete monad for errors: `(MonadIO m, ...) => ExceptT e m a` everywhere instead of `MonadError`, use other monad constraints on `m`.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
