### PR TITLE
Add return value to `checkLedgerStateCondition`

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -747,6 +747,7 @@ module Cardano.Api (
     -- *** Ledger state conditions
     LedgerStateCondition(..),
     checkLedgerStateCondition,
+    AnyNewEpochState(..),
 
     -- *** Errors
     LedgerStateError(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add return value to `checkLedgerStateCondition`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This change allows to return any value from `checkLedgerStatecondition`, for example it will be possible to return ledger state.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
