### PR TITLE
Fix bech32 prefixes of committee keys

### DIFF
--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -773,12 +773,12 @@ instance SerialiseAsBech32 (Hash CommitteeHotKey) where
     bech32PrefixesPermitted _ = ["committee_hot"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeHotKey) where
-    bech32PrefixFor         _ =  "drep_vk"
-    bech32PrefixesPermitted _ = ["drep_vk"]
+    bech32PrefixFor         _ =  "cc_hot_vk"
+    bech32PrefixesPermitted _ = ["cc_hot_vk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeHotKey) where
-    bech32PrefixFor         _ =  "drep_sk"
-    bech32PrefixesPermitted _ = ["drep_sk"]
+    bech32PrefixFor         _ =  "cc_hot_sk"
+    bech32PrefixesPermitted _ = ["cc_hot_sk"]
 
 --
 -- Constitutional Committee Cold Keys
@@ -881,12 +881,12 @@ instance SerialiseAsBech32 (Hash CommitteeColdKey) where
     bech32PrefixesPermitted _ = ["committee_cold"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeColdKey) where
-    bech32PrefixFor         _ =  "drep_vk"
-    bech32PrefixesPermitted _ = ["drep_vk"]
+    bech32PrefixFor         _ =  "cc_cold_vk"
+    bech32PrefixesPermitted _ = ["cc_cold_vk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeColdKey) where
-    bech32PrefixFor         _ =  "drep_sk"
-    bech32PrefixesPermitted _ = ["drep_sk"]
+    bech32PrefixFor         _ =  "cc_cold_sk"
+    bech32PrefixesPermitted _ = ["cc_cold_sk"]
 
 --
 -- Shelley genesis extended ed25519 keys


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix that bech32 prefixes for CC keys were incorrect
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Was looking at CC keys code for https://github.com/IntersectMBO/cardano-cli/issues/586 and stumbled upon what looked like a copy/paste typo.

# How to trust this PR

* That is a good question. Probably we should be testing this in cardano-cli.
* That being said, I ran `cardano-cli`'s tests against this PR, and all tests passed. So at least we're not breaking anything, but it's consistent with my impression that we are not testing this.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff