### PR TITLE
Expose getAnyNewEpochState. Simplify rendering LedgerState errors

### DIFF
--- a/cardano-api/internal/Cardano/Api/Error.hs
+++ b/cardano-api/internal/Cardano/Api/Error.hs
@@ -22,7 +22,6 @@ import           Control.Monad.Except (throwError)
 import           Control.Monad.IO.Class (MonadIO)
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT)
-import           Prettyprinter
 import           System.Directory (doesFileExist)
 import           System.IO (Handle)
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -90,7 +90,6 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Lens.Micro ((.~), (^.))
-import           Prettyprinter
 
 {- HLINT ignore "Redundant return" -}
 --- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Pretty.hs
+++ b/cardano-api/internal/Cardano/Api/Pretty.hs
@@ -3,11 +3,15 @@ module Cardano.Api.Pretty
   , Doc
   , Pretty(..)
   , ShowOf(..)
-  , viaShow
   , docToLazyText
   , docToText
   , docToString
   , pshow
+  , prettyException
+
+  , hsep
+  , vsep
+  , (<+>)
 
   , black
   , red
@@ -21,6 +25,7 @@ module Cardano.Api.Pretty
 
 import           Cardano.Api.Via.ShowOf
 
+import           Control.Exception.Safe
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TextLazy
 import           Prettyprinter
@@ -63,5 +68,10 @@ cyan = annotate (color Cyan)
 white :: Doc AnsiStyle -> Doc AnsiStyle
 white = annotate (color White)
 
+-- | Short hand for 'viaShow'.
 pshow :: Show a => a -> Doc ann
 pshow = viaShow
+
+-- | Short hand for @'pretty' . 'displayException'@
+prettyException :: Exception a => a -> Doc ann
+prettyException = pretty . displayException

--- a/cardano-api/internal/Cardano/Api/TxBody.hs
+++ b/cardano-api/internal/Cardano/Api/TxBody.hs
@@ -212,7 +212,7 @@ import qualified Cardano.Ledger.Alonzo.TxWits as Alonzo
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.Babbage.TxBody as Babbage
 import           Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import           Cardano.Ledger.Binary (Annotated (..), reAnnotate)
+import           Cardano.Ledger.Binary (Annotated (..))
 import qualified Cardano.Ledger.Binary as CBOR
 import qualified Cardano.Ledger.Block as Ledger
 import           Cardano.Ledger.Core ()
@@ -2409,7 +2409,7 @@ makeByronTransactionBody txIns txOuts = do
                 (\out -> toByronTxOut out ?! classifyRangeError out)
                 outs'
     return $
-      reAnnotate CBOR.byronProtVer $
+      CBOR.reAnnotate CBOR.byronProtVer $
         Annotated
           (Byron.UnsafeTx ins'' outs'' (Byron.mkAttributes ()))
           ()

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -746,18 +746,15 @@ module Cardano.Api (
 
     -- *** Ledger state conditions
     LedgerStateCondition(..),
-    checkLedgerStateCondition,
     AnyNewEpochState(..),
+    checkLedgerStateCondition,
+    getAnyNewEpochState,
 
     -- *** Errors
     LedgerStateError(..),
     FoldBlocksError(..),
     GenesisConfigError(..),
     InitialLedgerStateError(..),
-    renderLedgerStateError,
-    renderFoldBlocksError,
-    renderGenesisConfigError,
-    renderInitialLedgerStateError,
 
     -- ** Low level protocol interaction with a Cardano node
     connectToLocalNode,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose getAnyNewEpochState. Simplify rendering LedgerState errors
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
