### PR TITLE
Make committee hash prefixes CIP-5 compliant

### DIFF
--- a/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
+++ b/cardano-api/internal/Cardano/Api/Keys/Shelley.hs
@@ -769,8 +769,8 @@ instance CastVerificationKeyRole CommitteeHotKey PaymentKey where
       PaymentVerificationKey (Shelley.VKey vk)
 
 instance SerialiseAsBech32 (Hash CommitteeHotKey) where
-    bech32PrefixFor         _ =  "committee_hot"
-    bech32PrefixesPermitted _ = ["committee_hot"]
+    bech32PrefixFor         _ =  "cc_hot"
+    bech32PrefixesPermitted _ = ["cc_hot"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeHotKey) where
     bech32PrefixFor         _ =  "cc_hot_vk"
@@ -877,8 +877,8 @@ instance CastVerificationKeyRole CommitteeColdKey PaymentKey where
       PaymentVerificationKey (Shelley.VKey vk)
 
 instance SerialiseAsBech32 (Hash CommitteeColdKey) where
-    bech32PrefixFor         _ =  "committee_cold"
-    bech32PrefixesPermitted _ = ["committee_cold"]
+    bech32PrefixFor         _ =  "cc_cold"
+    bech32PrefixesPermitted _ = ["cc_cold"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeColdKey) where
     bech32PrefixFor         _ =  "cc_cold_vk"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    bech32 prefixes for committee keys hashes were incorrect. This PR fixes that, in accordance with CIP-5: https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005/README.md?plain=1#L111
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff