### PR TITLE
Make committee keys able to sign transactions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -1088,16 +1088,11 @@ toShelleySigningKey key = case key of
   WitnessDRepKey            (DRepSigningKey sk)            -> ShelleyNormalSigningKey sk
 
   -- The cases for extended keys
-  WitnessPaymentExtendedKey (PaymentExtendedSigningKey sk) ->
-    ShelleyExtendedSigningKey sk
-  WitnessStakeExtendedKey (StakeExtendedSigningKey sk) ->
-    ShelleyExtendedSigningKey sk
-  WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk) ->
-    ShelleyExtendedSigningKey sk
-  WitnessGenesisDelegateExtendedKey (GenesisDelegateExtendedSigningKey sk) ->
-    ShelleyExtendedSigningKey sk
-  WitnessDRepExtendedKey (DRepExtendedSigningKey sk) ->
-    ShelleyExtendedSigningKey sk
+  WitnessPaymentExtendedKey (PaymentExtendedSigningKey sk) ->                 ShelleyExtendedSigningKey sk
+  WitnessStakeExtendedKey   (StakeExtendedSigningKey sk)   ->                 ShelleyExtendedSigningKey sk
+  WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk) ->                 ShelleyExtendedSigningKey sk
+  WitnessGenesisDelegateExtendedKey (GenesisDelegateExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
+  WitnessDRepExtendedKey (DRepExtendedSigningKey sk)       ->                 ShelleyExtendedSigningKey sk
 
 getShelleyKeyWitnessVerificationKey
   :: ShelleySigningKey

--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -738,9 +738,11 @@ data ShelleyWitnessSigningKey =
                                  (SigningKey GenesisDelegateExtendedKey)
      | WitnessGenesisUTxOKey     (SigningKey GenesisUTxOKey)
      | WitnessCommitteeColdKey   (SigningKey CommitteeColdKey)
-     | WitnessCommitteeHotKey    (SigningKey CommitteeHotKey)
-     | WitnessDRepKey            (SigningKey DRepKey)
-     | WitnessDRepExtendedKey    (SigningKey DRepExtendedKey)
+     | WitnessCommitteeColdExtendedKey (SigningKey CommitteeColdExtendedKey)
+     | WitnessCommitteeHotKey          (SigningKey CommitteeHotKey)
+     | WitnessCommitteeHotExtendedKey  (SigningKey CommitteeHotExtendedKey)
+     | WitnessDRepKey                  (SigningKey DRepKey)
+     | WitnessDRepExtendedKey          (SigningKey DRepExtendedKey)
 
 
 -- | We support making key witnesses with both normal and extended signing keys.
@@ -1051,6 +1053,7 @@ makeShelleyBasedBootstrapWitness sbe nwOrAddr txbody (ByronSigningKey sk) =
         (Byron.aaNetworkMagic . unAddrAttrs)
         eitherNwOrAddr
 
+
 makeShelleyKeyWitness :: forall era. ()
   => ShelleyBasedEra era
   -> TxBody era
@@ -1092,6 +1095,8 @@ toShelleySigningKey key = case key of
   WitnessStakeExtendedKey   (StakeExtendedSigningKey sk)   ->                 ShelleyExtendedSigningKey sk
   WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk) ->                 ShelleyExtendedSigningKey sk
   WitnessGenesisDelegateExtendedKey (GenesisDelegateExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
+  WitnessCommitteeColdExtendedKey   (CommitteeColdExtendedSigningKey sk)   -> ShelleyExtendedSigningKey sk
+  WitnessCommitteeHotExtendedKey    (CommitteeHotExtendedSigningKey sk)    -> ShelleyExtendedSigningKey sk
   WitnessDRepExtendedKey (DRepExtendedSigningKey sk)       ->                 ShelleyExtendedSigningKey sk
 
 getShelleyKeyWitnessVerificationKey

--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -1091,13 +1091,13 @@ toShelleySigningKey key = case key of
   WitnessDRepKey            (DRepSigningKey sk)            -> ShelleyNormalSigningKey sk
 
   -- The cases for extended keys
-  WitnessPaymentExtendedKey (PaymentExtendedSigningKey sk) ->                 ShelleyExtendedSigningKey sk
-  WitnessStakeExtendedKey   (StakeExtendedSigningKey sk)   ->                 ShelleyExtendedSigningKey sk
-  WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk) ->                 ShelleyExtendedSigningKey sk
+  WitnessPaymentExtendedKey (PaymentExtendedSigningKey sk)                 -> ShelleyExtendedSigningKey sk
+  WitnessStakeExtendedKey   (StakeExtendedSigningKey sk)                   -> ShelleyExtendedSigningKey sk
+  WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk)                 -> ShelleyExtendedSigningKey sk
   WitnessGenesisDelegateExtendedKey (GenesisDelegateExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
   WitnessCommitteeColdExtendedKey   (CommitteeColdExtendedSigningKey sk)   -> ShelleyExtendedSigningKey sk
   WitnessCommitteeHotExtendedKey    (CommitteeHotExtendedSigningKey sk)    -> ShelleyExtendedSigningKey sk
-  WitnessDRepExtendedKey (DRepExtendedSigningKey sk)       ->                 ShelleyExtendedSigningKey sk
+  WitnessDRepExtendedKey            (DRepExtendedSigningKey sk)            -> ShelleyExtendedSigningKey sk
 
 getShelleyKeyWitnessVerificationKey
   :: ShelleySigningKey

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -839,6 +839,7 @@ module Cardano.Api (
     CommitteeColdKey,
     CommitteeColdExtendedKey,
     CommitteeHotKey,
+    CommitteeHotExtendedKey,
 
     -- * Genesis file
     -- | Types and functions needed to inspect or create a genesis file.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -837,6 +837,7 @@ module Cardano.Api (
 
     -- * Constitutional Committee keys
     CommitteeColdKey,
+    CommitteeColdExtendedKey,
     CommitteeHotKey,
 
     -- * Genesis file


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make committee keys able to sign transactions
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* API part of making committee keys able to sign transactions
* Part of fixing https://github.com/IntersectMBO/cardano-cli/issues/586

# How to trust this PR

* Code from this PR has been written by taking the code for DRep extended keys and renaming the relevant bits.
* Code from this PR has been tested in this cardano-cli PR: https://github.com/IntersectMBO/cardano-cli/pull/596
* The bech32 prefixes have been taken from [CIP-5](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0005)
* The text envelopes `description` fields have been taken from @mkoura's original issue: https://github.com/IntersectMBO/cardano-cli/issues/586

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff