### PR TITLE
Fix removal of toScriptIndex export

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -144,6 +144,7 @@ module Cardano.Api.Shelley
     fromAlonzoPrices,
     toAlonzoExUnits,
     fromAlonzoExUnits,
+    toScriptIndex,
     scriptDataFromJsonDetailedSchema,
     scriptDataToJsonDetailedSchema,
     calculateExecutionUnitsLovelace,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix removal of toScriptIndex export
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes: https://github.com/IntersectMBO/cardano-api/pull/436/files#diff-b9922f7294df3af9d6e30d914012d749b265d746ed35b9ea75ab69cddafeab87L147

This PR results in no change in visible API since 8.38 release, so it has a type `improvement`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
