### PR TITLE
Allow checkLedgerStateCondition check  to run in IO

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -242,7 +242,6 @@ library
                         Cardano.Api.Ledger
 
   reexported-modules:   Cardano.Api.Ledger.Lens
-                      , Cardano.Api.Pretty
 
   build-depends:        bytestring
                       , cardano-api:internal

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -141,7 +141,6 @@ import           Cardano.Api.Eon.AllegraEraOnwards (allegraEraOnwardsToShelleyBa
 import           Cardano.Api.Error
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as A
-import           Cardano.Api.Pretty
 import           Cardano.Api.Script (scriptInEraToRefScript)
 import           Cardano.Api.Shelley
 import qualified Cardano.Api.Shelley as ShelleyApi

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -85,6 +85,7 @@ type ConwayEraOnwardsConstraints era =
   , L.EraTxBody (ShelleyLedgerEra era)
   , L.EraTxOut (ShelleyLedgerEra era)
   , L.EraUTxO (ShelleyLedgerEra era)
+  , L.GovState (ShelleyLedgerEra era) ~ L.ConwayGovState (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody (ShelleyLedgerEra era)) L.EraIndependentTxBody L.StandardCrypto
   , L.MaryEraTxBody (ShelleyLedgerEra era)
   , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -38,6 +38,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Orphans ()
+import           Cardano.Api.Pretty (Pretty)
 
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import qualified Cardano.Crypto.Hash.Class as C
@@ -60,6 +61,7 @@ import           Data.Aeson (FromJSON (..), ToJSON, toJSON, withText)
 import qualified Data.Text as Text
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Data.Typeable (Typeable)
+import           Text.Pretty (Pretty (..))
 
 -- | Determine the value to use for a feature in a given 'ShelleyBasedEra'.
 inEonForShelleyBasedEra :: ()
@@ -135,6 +137,9 @@ instance NFData (ShelleyBasedEra era) where
 deriving instance Eq   (ShelleyBasedEra era)
 deriving instance Ord  (ShelleyBasedEra era)
 deriving instance Show (ShelleyBasedEra era)
+
+instance Pretty (ShelleyBasedEra era) where
+  pretty = pretty . shelleyBasedToCardanoEra
 
 instance ToJSON (ShelleyBasedEra era) where
    toJSON = toJSON . shelleyBasedToCardanoEra

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -748,7 +748,7 @@ module Cardano.Api (
     -- *** Ledger state conditions
     LedgerStateCondition(..),
     AnyNewEpochState(..),
-    checkLedgerStateCondition,
+    foldEpochState,
     getAnyNewEpochState,
 
     -- *** Errors
@@ -987,6 +987,10 @@ module Cardano.Api (
     makeDrepUpdateCertificate,
 
     ResolvablePointers(..),
+
+    -- ** Supporting modules
+    module Cardano.Api.Monad.Error,
+    module Cardano.Api.Pretty
   ) where
 
 import           Cardano.Api.Address
@@ -1029,9 +1033,11 @@ import           Cardano.Api.Keys.Read
 import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.LedgerState
 import           Cardano.Api.Modes
+import           Cardano.Api.Monad.Error
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
 import           Cardano.Api.Orphans ()
+import           Cardano.Api.Pretty
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Query hiding (LedgerState (..))

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -6,10 +6,7 @@ module Test.Cardano.Api.IO
 
 import           Cardano.Api
 import           Cardano.Api.IO
-import           Cardano.Api.Pretty
 
-import           Control.Monad.Except (runExceptT)
-import           Control.Monad.IO.Class (liftIO)
 import           System.Directory (removeFile)
 
 import           Hedgehog


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Allow checkLedgerStateCondition check to run in IO
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR allows `checkLedgerStateCondition` check function to run IO actions.
This enables more complex test logic, as well as real-time export of the new epoch state.
`cardano-testnet` was altered to support this change here:
* https://github.com/IntersectMBO/cardano-node/pull/5662

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
