### PR TITLE
Add `SlotNo` and `BlockNo` parameters to `foldEpochState`'s callback function

### DIFF
--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1874,7 +1874,9 @@ foldEpochState
   -> s
   -- ^ an initial value for the condition state
   -> ( AnyNewEpochState
-      -> StateT s IO LedgerStateCondition
+         -> SlotNo -- ^ Current (not necessarily the tip) slot number
+         -> BlockNo -- ^ Current (not necessarily the tip) block number
+         -> StateT s IO LedgerStateCondition
      )
   -- ^ Condition you want to check against the new epoch state.
   --
@@ -2020,7 +2022,7 @@ foldEpochState nodeConfigFilePath socketPath validationMode terminationEpoch ini
                               -- There can be only one place where `takeMVar stateMv` exists otherwise this
                               -- code will deadlock!
                               condition <- bracket (takeMVar stateMv) (tryPutMVar stateMv) $ \(_prevCondition, previousState) -> do
-                                updatedState@(!newCondition, !_) <- runStateT (checkCondition newEpochState) previousState
+                                updatedState@(!newCondition, !_) <- runStateT (checkCondition newEpochState slotNo currBlockNo) previousState
                                 putMVar stateMv updatedState
                                 pure newCondition
                               -- Have we reached the termination epoch?


### PR DESCRIPTION


# Changelog

```yaml
- description: |
    Add `SlotNo` and `BlockNo` parameters to `foldEpochState`'s callback function
    This gives access to the current `SlotNo` and `BlockNo` in a given requested block.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
