### PR TITLE
Revert "Remove unused constraint"

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eras/Core.hs
+++ b/cardano-api/internal/Cardano/Api/Eras/Core.hs
@@ -191,7 +191,8 @@ monoidForEraInEonA sbe = forEraInEon sbe (pure mempty)
 
 data EraInEon eon where
   EraInEon
-    :: ( Typeable (eon era)
+    :: ( Typeable era
+       , Typeable (eon era)
        , Eon eon
        )
     => eon era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Revert #316 "Remove unused constraint"
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This reverts https://github.com/IntersectMBO/cardano-api/pull/316. Seems that because of [`AnyShelleyBasedEra`](https://github.com/IntersectMBO/cardano-api/blob/443e0589918470d3806d7fbf48fad2ed3e05c34d/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs#L238) we need that constraint.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
