### PR TITLE
flake.nix: ghc 9.6.3 -> ghc 9.6.4

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work or should be used only with default compiler
-              haskell-language-server = "2.5.0.0";
+              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.6";
               hlint = "3.6.1";
               stylish-haskell = "0.14.5.0";
             };

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
         inherit (nixpkgs) lib;
 
         # see flake `variants` below for alternative compilers
-        defaultCompiler = "ghc963";
+        defaultCompiler = "ghc964";
         haddockShellCompiler = defaultCompiler;
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade Nix's default GHC to 9.6.4
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Despite using Nix, my system prefers (e.g. less GHC panics) when our repos' default version of GHC is the same. Right now [cardano-cli uses GHC 9.6.4](https://github.com/IntersectMBO/cardano-cli/blob/main/flake.nix#L48). So this PR upgrades `cardano-api` to do the same.

This will also get rid of warnings regarding GHC 9.6.3 being obsolete when loading the flake.

Also the GHA CI [uses GHC 9.6.4 already](https://github.com/IntersectMBO/cardano-api/blob/main/.github/workflows/haskell.yml#L19).

# How to trust this PR

CI passes

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff