### PR TITLE
Expose default genesis for Conway and Alonzo, and DRepState constructors

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -169,7 +169,7 @@ library internal
                       , cardano-ledger-binary ^>= 1.3
                       , cardano-ledger-byron >= 1.0.0.4
                       , cardano-ledger-conway >= 1.12.0
-                      , cardano-ledger-core >= 1.10
+                      , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.10
                       , cardano-ledger-mary >= 1.5
                       , cardano-ledger-shelley >= 1.9.0
                       , cardano-protocol-tpraos >= 1.0.3.6
@@ -178,6 +178,7 @@ library internal
                       , cborg
                       , containers
                       , contra-tracer
+                      , data-default-class
                       , deepseq
                       , directory
                       , either

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -178,7 +178,6 @@ library internal
                       , cborg
                       , containers
                       , contra-tracer
-                      , data-default-class
                       , deepseq
                       , directory
                       , either

--- a/cardano-api/internal/Cardano/Api/Genesis.hs
+++ b/cardano-api/internal/Cardano/Api/Genesis.hs
@@ -4,6 +4,7 @@
 module Cardano.Api.Genesis
   ( ShelleyGenesis(..)
   , shelleyGenesisDefaults
+  , alonzoGenesisDefaults
   , conwayGenesisDefaults
 
   -- ** Configuration
@@ -32,20 +33,29 @@ import qualified Cardano.Chain.Genesis
 import qualified Cardano.Crypto.Hash.Blake2b
 import qualified Cardano.Crypto.Hash.Class
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
+import           Cardano.Ledger.Alonzo.Scripts (ExUnits (..), Prices (..))
+import           Cardano.Ledger.Api (CoinPerWord (..), ConwayEra)
 import           Cardano.Ledger.BaseTypes as Ledger
 import           Cardano.Ledger.Coin (Coin (..))
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import           Cardano.Ledger.Conway.Governance (Committee (..))
+import           Cardano.Ledger.Conway.PParams (DRepVotingThresholds (..),
+                   PoolVotingThresholds (..), UpgradeConwayPParams (..))
 import           Cardano.Ledger.Crypto (StandardCrypto)
+import           Cardano.Ledger.Plutus (Language (..))
+import           Cardano.Ledger.Plutus.CostModels (mkCostModelsLenient)
 import           Cardano.Ledger.Shelley.Core
 import           Cardano.Ledger.Shelley.Genesis (NominalDiffTimeMicro, ShelleyGenesis (..),
                    emptyGenesisStaking)
 import qualified Cardano.Ledger.Shelley.Genesis as Ledger
 import qualified Ouroboros.Consensus.Shelley.Eras as Shelley
 
+import           Data.Aeson (decode)
 import           Data.ByteString (ByteString)
-import qualified Data.Default.Class as DefaultClass
+import           Data.Functor.Identity (Identity)
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromJust)
 import           Data.Ratio
 import           Data.Text (Text)
 import qualified Data.Time as Time
@@ -139,7 +149,121 @@ shelleyGenesisDefaults =
     unsafeBR :: (HasCallStack, Typeable r, BoundedRational r) => Rational -> r
     unsafeBR = unsafeBoundedRational
 
-
+-- | Some reasonable starting defaults for constructing a 'ConwayGenesis'.
 conwayGenesisDefaults :: ConwayGenesis StandardCrypto
-conwayGenesisDefaults = DefaultClass.def
+conwayGenesisDefaults = ConwayGenesis { cgUpgradePParams = defaultUpgradeConwayParams
+                                      , cgConstitution = blankConstitution
+                                      , cgCommittee = emptyComittee
+                                      , cgDelegs = mempty
+                                      , cgInitialDReps = mempty
+                                      }
+  where
+  defaultUpgradeConwayParams :: UpgradeConwayPParams Identity
+  defaultUpgradeConwayParams = UpgradeConwayPParams { ucppPoolVotingThresholds = defaultPoolVotingThresholds
+                                                    , ucppGovActionLifetime = EpochInterval 10
+                                                    , ucppGovActionDeposit = Coin 1000000000
+                                                    , ucppDRepVotingThresholds = defaultDRepVotingThresholds
+                                                    , ucppDRepDeposit = Coin 2000000
+                                                    , ucppDRepActivity = EpochInterval 20
+                                                    , ucppCommitteeMinSize = 0
+                                                    , ucppCommitteeMaxTermLength = EpochInterval 200
+                                                    }
+    where
+    defaultPoolVotingThresholds :: PoolVotingThresholds
+    defaultPoolVotingThresholds = PoolVotingThresholds { pvtPPSecurityGroup = fromJust $ boundRational 0.51
+                                                       , pvtMotionNoConfidence = fromJust $ boundRational 0.51
+                                                       , pvtHardForkInitiation = fromJust $ boundRational 0.51
+                                                       , pvtCommitteeNormal = fromJust $ boundRational 0.51
+                                                       , pvtCommitteeNoConfidence = fromJust $ boundRational 0.51
+                                                       }
 
+    defaultDRepVotingThresholds :: DRepVotingThresholds
+    defaultDRepVotingThresholds = DRepVotingThresholds { dvtUpdateToConstitution = fromJust $ boundRational 0.51
+                                                       , dvtTreasuryWithdrawal = fromJust $ boundRational 0.51
+                                                       , dvtPPTechnicalGroup = fromJust $ boundRational 0.51
+                                                       , dvtPPNetworkGroup = fromJust $ boundRational 0.51
+                                                       , dvtPPGovGroup = fromJust $ boundRational 0.51
+                                                       , dvtPPEconomicGroup = fromJust $ boundRational 0.51
+                                                       , dvtMotionNoConfidence = fromJust $ boundRational 0.51
+                                                       , dvtHardForkInitiation = fromJust $ boundRational 0.51
+                                                       , dvtCommitteeNormal = fromJust $ boundRational 0.51
+                                                       , dvtCommitteeNoConfidence = fromJust $ boundRational 0.51
+                                                       }
+
+  blankConstitution :: Constitution (ConwayEra StandardCrypto)
+  blankConstitution = Constitution { constitutionAnchor = emptyAnchor
+                                   , constitutionScript = SNothing
+                                   }
+    where
+    emptyAnchor :: Anchor StandardCrypto
+    emptyAnchor = Anchor { anchorUrl = fromJust $ textToUrl 0 ""
+                         , anchorDataHash = fromJust $ decode "\"0000000000000000000000000000000000000000000000000000000000000000\""
+                         }
+
+  emptyComittee :: Committee (ConwayEra StandardCrypto)
+  emptyComittee = Committee { committeeQuorum = fromJust $ boundRational 0
+                            , committeeMembers = mempty
+                            }
+
+-- | Some reasonable starting defaults for constructing a 'AlonzoGenesis'.
+alonzoGenesisDefaults :: AlonzoGenesis
+alonzoGenesisDefaults = AlonzoGenesis { agPrices = Prices { prSteps = fromJust $ boundRational 721
+                                                          , prMem = fromJust $ boundRational 10000000
+                                                          }
+                                     , agMaxValSize = 5000
+                                     , agMaxTxExUnits = ExUnits { exUnitsMem = 10000000
+                                                                , exUnitsSteps = 10000000000
+                                                                }
+                                     , agMaxCollateralInputs = 3
+                                     , agMaxBlockExUnits =  ExUnits { exUnitsMem = 50000000
+                                                                    , exUnitsSteps = 40000000000
+                                                                    }
+                                     , agCostModels = apiCostModels
+                                     , agCollateralPercentage = 150
+                                     , agCoinsPerUTxOWord = CoinPerWord $ Coin 34482
+                                     }
+  where
+    -- Based on cardano-node/cardano-testnet/src/Testnet/Defaults.hs
+    apiCostModels = mkCostModelsLenient $ Map.fromList [ (fromIntegral $ fromEnum PlutusV1, defaultV1CostModel)
+                                                       , (fromIntegral $ fromEnum PlutusV2, defaultV2CostModel)
+                                                       , (fromIntegral $ fromEnum PlutusV3, defaultV3CostModel)
+                                                       ]
+      where
+        defaultV1CostModel = [ 205665, 812, 1, 1, 1000, 571, 0, 1, 1000, 24177, 4, 1, 1000, 32, 117366, 10475, 4
+                             , 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 100, 100
+                             , 23000, 100, 19537, 32, 175354, 32, 46417, 4, 221973, 511, 0, 1, 89141, 32, 497525
+                             , 14068, 4, 2, 196500, 453240, 220, 0, 1, 1, 1000, 28662, 4, 2, 245000, 216773, 62
+                             , 1, 1060367, 12586, 1, 208512, 421, 1, 187000, 1000, 52998, 1, 80436, 32, 43249, 32
+                             , 1000, 32, 80556, 1, 57667, 4, 1000, 10, 197145, 156, 1, 197145, 156, 1, 204924, 473
+                             , 1, 208896, 511, 1, 52467, 32, 64832, 32, 65493, 32, 22558, 32, 16563, 32, 76511, 32
+                             , 196500, 453240, 220, 0, 1, 1, 69522, 11687, 0, 1, 60091, 32, 196500, 453240, 220, 0
+                             , 1, 1, 196500, 453240, 220, 0, 1, 1, 806990, 30482, 4, 1927926, 82523, 4, 265318, 0
+                             , 4, 0, 85931, 32, 205665, 812, 1, 1, 41182, 32, 212342, 32, 31220, 32, 32696, 32, 43357
+                             , 32, 32247, 32, 38314, 32, 57996947, 18975, 10
+                             ]
+        defaultV2CostModel = [ 205665, 812, 1, 1, 1000, 571, 0, 1, 1000, 24177, 4, 1, 1000, 32, 117366, 10475, 4
+                             , 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 100, 100
+                             , 23000, 100, 19537, 32, 175354, 32, 46417, 4, 221973, 511, 0, 1, 89141, 32, 497525
+                             , 14068, 4, 2, 196500, 453240, 220, 0, 1, 1, 1000, 28662, 4, 2, 245000, 216773, 62
+                             , 1, 1060367, 12586, 1, 208512, 421, 1, 187000, 1000, 52998, 1, 80436, 32, 43249, 32
+                             , 1000, 32, 80556, 1, 57667, 4, 1000, 10, 197145, 156, 1, 197145, 156, 1, 204924, 473
+                             , 1, 208896, 511, 1, 52467, 32, 64832, 32, 65493, 32, 22558, 32, 16563, 32, 76511, 32
+                             , 196500, 453240, 220, 0, 1, 1, 69522, 11687, 0, 1, 60091, 32, 196500, 453240, 220, 0
+                             , 1, 1, 196500, 453240, 220, 0, 1, 1, 1159724, 392670, 0, 2, 806990, 30482, 4, 1927926
+                             , 82523, 4, 265318, 0, 4, 0, 85931, 32, 205665, 812, 1, 1, 41182, 32, 212342, 32, 31220
+                             , 32, 32696, 32, 43357, 32, 32247, 32, 38314, 32, 35892428, 10, 9462713, 1021, 10, 38887044
+                             , 32947, 10
+                             ]
+        defaultV3CostModel = [ 205665, 812, 1, 1, 1000, 571, 0, 1, 1000, 24177, 4, 1, 1000, 32, 117366, 10475, 4, 117366, 10475, 4, 832808, 18
+                             , 3209094, 6, 331451, 1, 65990684, 23097, 18, 114242, 18, 94393407
+                             , 87060, 18, 16420089, 18, 2145798, 36, 3795345, 12, 889023, 1, 204237282, 23271, 36, 129165, 36, 189977790
+                             , 85902, 36, 33012864, 36, 388443360, 1, 401885761, 72, 2331379, 72, 23000, 100, 23000, 100, 23000, 100, 23000, 100, 23000
+                             , 100, 23000, 100, 23000, 100, 23000, 100, 100, 100, 23000, 100
+                             , 19537, 32, 175354, 32, 46417, 4, 221973, 511, 0, 1, 89141, 32, 497525, 14068, 4, 2, 196500, 453240, 220, 0, 1, 1, 1000, 28662
+                             , 4, 2, 245000, 216773, 62, 1, 1060367, 12586, 1, 208512, 421, 1, 187000, 1000, 52998, 1, 80436, 32
+                             , 43249, 1000, 32, 32, 80556, 1, 57667, 4, 1927926, 82523, 4, 1000, 10, 197145, 156, 1, 197145, 156, 1, 204924, 473, 1, 208896
+                             , 511, 1, 52467, 32, 64832, 32, 65493, 32, 22558, 32, 16563, 32, 76511, 32, 196500, 453240, 220, 0
+                             , 1, 1, 69522, 11687, 0, 1, 60091, 32, 196500, 453240, 220, 0, 1, 1, 196500, 453240, 220, 0, 1, 1, 1159724, 392670, 0, 2, 806990
+                             , 30482, 4, 1927926, 82523, 4, 265318, 0, 4, 0, 85931, 32, 205665, 812, 1, 1, 41182
+                             , 32, 212342, 32, 31220, 32, 32696, 32, 43357, 32, 32247, 32, 38314, 32, 35190005, 10, 57996947, 18975, 10, 39121781, 32260, 10
+                             ]

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -64,6 +64,7 @@ module Cardano.Api.ProtocolParameters (
     -- * Execution units, prices and cost models,
     ExecutionUnits(..),
     ExecutionUnitPrices(..),
+    CostModels(..),
     CostModel(..),
     fromAlonzoCostModels,
 

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -62,12 +62,12 @@ module Cardano.Api.ReexposeLedger
   , Anchor(..)
   , Delegatee(..)
   , DRep(..)
-  , DRepState
+  , DRepState(..)
   , ConwayTxCert(..)
   , ConwayDelegCert(..)
   , ConwayEraTxCert(..)
   , ConwayGovCert(..)
-  , ConwayGenesis
+  , ConwayGenesis(..)
   , GovState
   , GovActionId(..)
   , Vote (..)
@@ -168,12 +168,12 @@ import           Cardano.Ledger.BaseTypes (AnchorData (..), DnsName, EpochInterv
 import           Cardano.Ledger.Binary (Annotated (..), ByteSpan (..), byronProtVer, fromCBOR,
                    serialize', slice, toCBOR, toPlainDecoder)
 import           Cardano.Ledger.Binary.Plain (Decoder)
-import           Cardano.Ledger.CertState (DRepState, csCommitteeCredsL)
+import           Cardano.Ledger.CertState (DRepState (..), csCommitteeCredsL)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
 import           Cardano.Ledger.Conway.Core (DRepVotingThresholds (..), PoolVotingThresholds (..),
                    dvtPPEconomicGroupL, dvtPPGovGroupL, dvtPPNetworkGroupL, dvtPPTechnicalGroupL,
                    dvtUpdateToConstitutionL)
-import           Cardano.Ledger.Conway.Genesis (ConwayGenesis)
+import           Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import           Cardano.Ledger.Conway.Governance (Anchor (..), GovActionId (..), GovState,
                    ProposalProcedure (..), Vote (..), Voter (..), VotingProcedure (..),
                    VotingProcedures (..))

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -9,6 +9,7 @@ module Cardano.Api.Shelley
     -- * Genesis
     ShelleyGenesis(..),
     shelleyGenesisDefaults,
+    alonzoGenesisDefaults,
     conwayGenesisDefaults,
 
     -- * Cryptographic key interface


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Exported more realistic default genesis for both Conway and Alonzo, and export DRepState constructors.
  type:
  - improvement
```

# Context

This is necessary to support the introduction of delegation and registration of DReps in `cardano-cli` without having to make `cardano-cli` depend on the ledger directly again.

This PR supports [this PR in cardano-cli](https://github.com/IntersectMBO/cardano-cli/pull/646). Maybe a good idea to review both together.

# How to trust this PR

Maybe have a look at the things exported and the default instances created.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

