### PR TITLE
Fix for foldEpochState haddock

### DIFF
--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -1874,12 +1874,15 @@ foldEpochState
   -> s
   -- ^ an initial value for the condition state
   -> ( AnyNewEpochState
-         -> SlotNo -- ^ Current (not necessarily the tip) slot number
-         -> BlockNo -- ^ Current (not necessarily the tip) block number
+         -> SlotNo
+         -> BlockNo
          -> StateT s IO LedgerStateCondition
      )
   -- ^ Condition you want to check against the new epoch state.
   --
+  --   'SlotNo' - Current (not necessarily the tip) slot number
+  --
+  --   'BlockNo' - Current (not necessarily the tip) block number
   --
   -- Note: This function can safely assume no rollback will occur even though
   -- internally this is implemented with a client protocol that may require


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix for foldEpochState haddock
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
   - documentation  # change in code docs, haddocks...
```

# Context

fix chap CI failure: https://github.com/IntersectMBO/cardano-haskell-packages/actions/runs/8277787446/job/22648894380?pr=694#step:5:2532

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
