### PR TITLE
Bump ouroboros-consensus-diffusion

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-02-23T10:30:08Z
-  , cardano-haskell-packages 2024-02-25T11:35:42Z
+  , hackage.haskell.org 2024-03-18T13:14:14Z
+  , cardano-haskell-packages 2024-03-18T15:21:15Z
 
 packages:
     cardano-api

--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -45,6 +45,13 @@
   (compatible)
   [PR 316](https://github.com/IntersectMBO/cardano-api/pull/316)
 
+## 8.39.3.0
+
+- ouroboros-consensus-diffusion-0.12
+  (compatible)
+  [PR 487](https://github.com/IntersectMBO/cardano-api/pull/487)
+  [CHaP PR](https://github.com/IntersectMBO/cardano-haskell-packages/pull/704)
+
 ## 8.39.2.0
 
 - Update ouroboros-consensus-0.16, ouroboros-consensus-cardano-0.14, ouroboros-consensus-diffusion-0.11, ouroboros-consensus-protocol-0.7, ouroboros-network-api-0.7

--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for cardano-api
 
+## 8.39.3.0
+
+- ouroboros-consensus-diffusion-0.12
+  (compatible)
+  [PR 487](https://github.com/IntersectMBO/cardano-api/pull/487)
+  [CHaP PR](https://github.com/IntersectMBO/cardano-haskell-packages/pull/704)
+
 ## 8.41.0.0
 
 - Add plutus script support when making hot key authorisation certificates
@@ -44,13 +51,6 @@
 - Simplify `EraInEon` to take fewer constraints
   (compatible)
   [PR 316](https://github.com/IntersectMBO/cardano-api/pull/316)
-
-## 8.39.3.0
-
-- ouroboros-consensus-diffusion-0.12
-  (compatible)
-  [PR 487](https://github.com/IntersectMBO/cardano-api/pull/487)
-  [CHaP PR](https://github.com/IntersectMBO/cardano-haskell-packages/pull/704)
 
 ## 8.39.2.0
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -194,7 +194,7 @@ library internal
                       , optparse-applicative-fork
                       , ouroboros-consensus ^>= 0.16
                       , ouroboros-consensus-cardano ^>= 0.14
-                      , ouroboros-consensus-diffusion ^>= 0.11
+                      , ouroboros-consensus-diffusion ^>= 0.12
                       , ouroboros-consensus-protocol ^>= 0.7
                       , ouroboros-network
                       , ouroboros-network-api ^>= 0.7

--- a/flake.lock
+++ b/flake.lock
@@ -242,11 +242,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1708647761,
-        "narHash": "sha256-1WiRX2IqiopPq3sQTBPF7BswDacfGB9UUNnN9PYgrXA=",
+        "lastModified": 1710721411,
+        "narHash": "sha256-0B1YATLPUKKOexhhfSFkTQlZH6o4yWJ/0WJeyZMxBKg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6a164db037c9cb2fd7ea946e7a0d62d7d8f53766",
+        "rev": "99719945242bc0c965560ed708868aa088748524",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1708729825,
-        "narHash": "sha256-mufjeGjZjgdfcxXzssMpRM/KggPVWQu6hFbYWPyBY78=",
+        "lastModified": 1710776263,
+        "narHash": "sha256-oCVYnekYokL2DxvfiPmFg/LIu6RRofZSx84+1UWbiJ4=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "42963de660ded965e14477f91a4c5df53fb1072d",
+        "rev": "8ee7c573bc4fa0b61617fcc353158f81ec1d95ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Bump ouroboros-consensus-diffusion 0.12
- Added entry for cardano-api 8.39.3 release.

# Changelog

```yaml
- description: |
    Bump ouroboros-consensus-diffusion 0.12
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

See https://github.com/IntersectMBO/cardano-api/pull/487#issuecomment-2004359319