### PR TITLE
Tidy up "New calculateMinTxFee function"

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -384,6 +384,7 @@ module Cardano.Api (
     LedgerEpochInfo(..),
     toLedgerEpochInfo,
     evaluateTransactionFee,
+    calculateMinTxFee,
     estimateTransactionKeyWitnessCount,
 
     -- ** Minimum required UTxO calculation

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -382,9 +382,7 @@ module Cardano.Api (
 
     -- ** Fee calculation
     LedgerEpochInfo(..),
-    transactionFee,
     toLedgerEpochInfo,
-    estimateTransactionFee,
     evaluateTransactionFee,
     estimateTransactionKeyWitnessCount,
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Re-implement `evaluateTransactionFee` using ledger's `calcMinFeeTx`
    The `evaluateTransactionFee` takes an additional `utxo` parameter and no longer takes `byronwitcount`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This improves the accurate of the `evaluateTransactionFee` function.

See https://github.com/IntersectMBO/cardano-cli/pull/534#issuecomment-1952627060

# Impact on `cardano-cli`

`cardano-cli` uses `evaluateTransactionFee` [here](https://github.com/IntersectMBO/cardano-cli/blob/main/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs#L1039).

This usage does not have `utxo` in scope which will be required after this change is introduced.

A possible solution is to query for the utxo [like this](https://github.com/IntersectMBO/cardano-cli/blob/main/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs#L551).

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
