### PR TITLE
Undeprecate `evaluateTransactionFee`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -95,7 +95,7 @@ import           Lens.Micro ((.~), (^.))
 -- assumption that there will be the given number of key witnesses (i.e.
 -- signatures).
 --
--- Use 'calculateMinTxFee' instead as that function is more accurate.
+-- Use 'calculateMinTxFee' if possible as that function is more accurate.
 evaluateTransactionFee :: forall era. ()
   => ShelleyBasedEra era
   -> Ledger.PParams (ShelleyLedgerEra era)
@@ -108,7 +108,6 @@ evaluateTransactionFee sbe pp txbody keywitcount byronwitcount =
     case makeSignedTransaction' (shelleyBasedToCardanoEra sbe) [] txbody of
       ShelleyTx _ tx ->
         L.estimateMinFeeTx pp tx (fromIntegral keywitcount) (fromIntegral byronwitcount)
-{-# DEPRECATED evaluateTransactionFee "Use 'calculateMinTxFee' instead" #-}
 
 -- | Estimate minimum transaction fee for a proposed transaction by looking
 -- into the transaction and figuring out how many and what kind of key


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Undeprecate `evaluateTransactionFee`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`evaluateTransactionFee` is still in use in `cardano-cli` and it is not straightforward to upgrade to `calculateMinTxFee`.

See https://github.com/IntersectMBO/cardano-cli/blob/newhoggy/new-calculate-min-tx-fee-command/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs#L1041

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
