### PR TITLE
Replace unsafeMergeVotingProcedures by mergeVotingProcedures

### DIFF
--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -284,8 +284,8 @@ module Cardano.Api.Shelley
     fromLedgerPParamsUpdate,
 
     emptyVotingProcedures,
+    mergeVotingProcedures,
     singletonVotingProcedures,
-    unsafeMergeVotingProcedures,
   ) where
 
 import           Cardano.Api


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace unsafeMergeVotingProcedures by mergeVotingProcedures, that handles incompatible votes and return an error
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* This is the cardano-api part of https://github.com/IntersectMBO/cardano-cli/pull/681
* The return type for the error case is a bit different from the version in https://github.com/IntersectMBO/cardano-cli/pull/681. This version makes more sense for general-purpose callers and we can adapt the CLI's caller when we'll update.

# How to trust this PR

See https://github.com/IntersectMBO/cardano-cli/pull/681

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff