### PR TITLE
Sort metadata keys for no-schema json for canonical CBOR

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -319,6 +319,7 @@ test-suite cardano-api-test
                       , hedgehog >= 1.1
                       , hedgehog-extras
                       , hedgehog-quickcheck
+                      , interpolatedstring-perl6
                       , mtl
                       , QuickCheck
                       , tasty


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Sort metadata keys for no-schema json for canonical CBOR
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR changes sorting for `--json-metadata-no-schema` JSON to [canonical CBOR](https://datatracker.ietf.org/doc/html/rfc7049#section-3.9). It changes transaction file output CBOR representation (reorders metadata keys for this case), so it's marked as a breaking change.

Note that there's always `--json-metadata-schema` JSON format available which allows to specify metadata keys ordering. [See example](https://github.com/IntersectMBO/cardano-node/issues/4335#issuecomment-2047984996).

Fixes https://github.com/IntersectMBO/cardano-node/issues/4335

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
