### PR TITLE
Upload GHA cache instead of restoring it twice

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -124,7 +124,7 @@ jobs:
 
     # Always store the cabal cache.
     - name: Cache Cabal store
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upload GHA cache instead of restoring it twice
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

GHA was restoring cache twice instead of uploading newly compiled dependencies e.g. https://github.com/IntersectMBO/cardano-api/actions/runs/8661950643/job/23752935624?pr=517#step:12:23

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
