### PR TITLE
Added a new query for a snapshot of big ledger peers

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -27,6 +27,7 @@ module Cardano.Api.Query.Expr
   , queryStakeSnapshot
   , querySystemStart
   , queryUtxo
+  , queryLedgerPeerSnapshot
   , L.MemberStatus (..)
   , L.CommitteeMembersState (..)
   , queryCommitteeMembersState
@@ -67,6 +68,8 @@ import           Cardano.Ledger.SafeHash
 import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Slotting.Slot
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
+import           Ouroboros.Network.Block (Serialised)
+import           Ouroboros.Network.PeerSelection.LedgerPeers (LedgerPeerSnapshot)
 
 import           Data.Map (Map)
 import           Data.Sequence (Seq)
@@ -135,6 +138,19 @@ queryDebugLedgerState
       (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedDebugLedgerState era)))
 queryDebugLedgerState sbe =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryDebugLedgerState
+
+queryLedgerPeerSnapshot
+  :: ()
+  => ShelleyBasedEra era
+  -> LocalStateQueryExpr
+      block
+      point
+      QueryInMode
+      r
+      IO
+      (Either UnsupportedNtcVersionError (Either EraMismatch (Serialised LedgerPeerSnapshot)))
+queryLedgerPeerSnapshot sbe =
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryLedgerPeerSnapshot
 
 queryEraHistory
   :: ()

--- a/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
@@ -1,5 +1,12 @@
-module Cardano.Api.ReexposeNetwork (Target (..), Serialised (..), SubmitResult (..)) where
+module Cardano.Api.ReexposeNetwork
+  ( LedgerPeerSnapshot (..)
+  , Target (..)
+  , Serialised (..)
+  , SubmitResult (..)
+  )
+where
 
 import           Ouroboros.Network.Block (Serialised (..))
+import           Ouroboros.Network.PeerSelection.LedgerPeers.Type (LedgerPeerSnapshot (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -998,6 +998,7 @@ module Cardano.Api
   , queryCurrentEpochState
   , queryCurrentEra
   , queryDebugLedgerState
+  , queryLedgerPeerSnapshot
   , queryEpoch
   , queryConstitutionHash
   , queryEraHistory

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -244,6 +244,7 @@ module Cardano.Api.Shelley
   , StakeSnapshot (..)
   , SerialisedStakeSnapshots (..)
   , decodeStakeSnapshot
+  , decodeBigLedgerPeerSnapshot
   , UTxO (..)
   , AcquiringFailure (..)
   , SystemStart (..)


### PR DESCRIPTION
This change introduces a new query tag and handler to support retrieval of a snapshot of big ledger peers from the current tip of a node.

# Changelog

```yaml
- description: |
    Added `GetBigLedgerPeerSnapshot` block query
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A snapshot of big ledger peers is very useful when bootstrapping a node from scratch in the upcoming Genesis consensus mode. Since only some, or none, of these peers are available to a node from its own ledger when syncing up, a snapshot is a means of providing these relays to the diffusion layer to ensure that a node ends up on a good chain.

# Checklist

- [x ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
