### PR TITLE
adding MinFeeRefScriptCostPerByte to Conway PParams

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/ProtocolParameters.hs
@@ -75,6 +75,7 @@ genIntroducedInConwayPParams =
     <*> genStrictMaybe Q.arbitrary
     <*> genStrictMaybe Q.arbitrary
     <*> genStrictMaybe Q.arbitrary
+    <*> genStrictMaybe Q.arbitrary
 
 genShelleyEraBasedProtocolParametersUpdate :: MonadGen m => m (EraBasedProtocolParametersUpdate ShelleyEra)
 genShelleyEraBasedProtocolParametersUpdate =

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -253,6 +253,7 @@ data IntroducedInConwayPParams era
     , icGovActionDeposit     :: StrictMaybe Ledger.Coin
     , icDRepDeposit          :: StrictMaybe Ledger.Coin
     , icDRepActivity         :: StrictMaybe Ledger.EpochInterval
+    , icMinFeeRefScriptCostPerByte  :: StrictMaybe Ledger.NonNegativeInterval
     } deriving Show
 
 
@@ -270,6 +271,7 @@ createIntroducedInConwayPParams IntroducedInConwayPParams{..} =
       & Ledger.ppuGovActionDepositL .~ icGovActionDeposit
       & Ledger.ppuDRepDepositL .~ icDRepDeposit
       & Ledger.ppuDRepActivityL .~ icDRepActivity
+      & Ledger.ppuMinFeeRefScriptCostPerByteL .~ icMinFeeRefScriptCostPerByte
 
 
 createEraBasedProtocolParamUpdate


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Adding `MinFeeRefScriptCostPerByte` to Conway PParams
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

https://github.com/IntersectMBO/cardano-ledger/issues/3952

# How to trust this PR


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
