### PR TITLE
Prepare deprecation of ProtocolParameters

### DIFF
--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -175,8 +175,7 @@ instance IsShelleyBasedEra era => Eq (LedgerProtocolParameters era) where
     shelleyBasedEraConstraints (shelleyBasedEra @era)
       $ a == b
 
--- TODO: Conway era - remove me when we begin relying on the JSON
--- instances of Ledger.PParams
+{-# DEPRECATED convertToLedgerProtocolParameters "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 convertToLedgerProtocolParameters
   :: ShelleyBasedEra era
   -> ProtocolParameters
@@ -465,6 +464,7 @@ createIntroducedInBabbagePParams w (IntroducedInBabbagePParams coinsPerUTxOByte)
 --
 -- There are also parameters fixed in the Genesis file. See 'GenesisParameters'.
 --
+{-# DEPRECATED ProtocolParameters "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters" #-}
 data ProtocolParameters =
      ProtocolParameters {
 
@@ -1669,6 +1669,7 @@ toConwayPParams = toBabbagePParams
 -- Conversion functions: protocol parameters from ledger types
 --
 
+{-# DEPRECATED fromLedgerPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromLedgerPParams
   :: ShelleyBasedEra era
   -> Ledger.PParams (ShelleyLedgerEra era)
@@ -1681,6 +1682,7 @@ fromLedgerPParams ShelleyBasedEraBabbage = fromBabbagePParams
 fromLedgerPParams ShelleyBasedEraConway  = fromConwayPParams
 
 
+{-# DEPRECATED fromShelleyCommonPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromShelleyCommonPParams :: EraPParams ledgerera
                          => PParams ledgerera
                          -> ProtocolParameters
@@ -1714,6 +1716,7 @@ fromShelleyCommonPParams pp =
     , protocolParamMinUTxOValue        = Nothing -- Obsolete from Alonzo onwards
     }
 
+{-# DEPRECATED fromShelleyPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromShelleyPParams :: ( EraPParams ledgerera
                       , Ledger.AtMostEra Ledger.MaryEra ledgerera
                       , Ledger.AtMostEra Ledger.AlonzoEra ledgerera
@@ -1728,6 +1731,7 @@ fromShelleyPParams pp =
     }
 
 
+{-# DEPRECATED fromAlonzoPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromAlonzoPParams :: AlonzoEraPParams ledgerera
                         => PParams ledgerera
                         -> ProtocolParameters
@@ -1743,6 +1747,7 @@ fromAlonzoPParams pp =
     , protocolParamMaxCollateralInputs = Just $ pp ^. ppMaxCollateralInputsL
     }
 
+{-# DEPRECATED fromExactlyAlonzoPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromExactlyAlonzoPParams :: (AlonzoEraPParams ledgerera, Ledger.ExactEra Ledger.AlonzoEra ledgerera)
                         => PParams ledgerera
                         -> ProtocolParameters
@@ -1751,6 +1756,7 @@ fromExactlyAlonzoPParams pp =
       protocolParamUTxOCostPerByte = Just . unCoinPerWord $ pp ^. ppCoinsPerUTxOWordL
   }
 
+{-# DEPRECATED fromBabbagePParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromBabbagePParams :: BabbageEraPParams ledgerera
                    => PParams ledgerera
                    -> ProtocolParameters
@@ -1760,11 +1766,13 @@ fromBabbagePParams pp =
   , protocolParamDecentralization = Nothing
   }
 
+{-# DEPRECATED fromConwayPParams "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters." #-}
 fromConwayPParams :: BabbageEraPParams ledgerera
                   => PParams ledgerera
                   -> ProtocolParameters
 fromConwayPParams = fromBabbagePParams
 
+{-# DEPRECATED checkProtocolParameters "Use the ledger's PParams (from module Cardano.Api.Ledger) type instead of ProtocolParameters. PParams natively enforce these checks." #-}
 checkProtocolParameters :: ()
   => ShelleyBasedEra era
   -> ProtocolParameters

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/ProtocolParameters.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
+-- TODO remove me when ProtocolParameters is deleted
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Test.Golden.Cardano.Api.ProtocolParameters
   ( test_golden_ProtocolParameters
   , test_golden_ProtocolParameters_to_PParams

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/ProtocolParameters.hs
@@ -3,6 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
+-- TODO remove me when ProtocolParameters is deleted
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Test.Cardano.Api.ProtocolParameters
   ( tests
   ) where


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Prepare deprecation of ProtocolParameters
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  - documentation  # change in code docs, haddocks...
```

# Context

* This PR deprecates the `ProtocolParameters` type, as well as functions that produce values of type `ProtocolParameters`.
* We want to remove `ProtocolParameters` ultimately (this is https://github.com/IntersectMBO/cardano-api/issues/384)
* Corresponding CLI PR that stops using the deprecated functions: https://github.com/IntersectMBO/cardano-cli/pull/780

# How to trust this PR

It's only comments

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff