### PR TITLE
Add MuxError handling in FoldBlocksError

### DIFF
--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -16,7 +16,7 @@
 
 module Cardano.Api.Orphans () where
 
-import           Cardano.Api.Pretty (Pretty (..), (<+>))
+import           Cardano.Api.Pretty (Pretty (..), prettyException, (<+>))
 import           Cardano.Api.Via.ShowOf
 
 import           Cardano.Binary (DecoderError (..))
@@ -74,6 +74,7 @@ import qualified Ouroboros.Consensus.Shelley.Eras as Consensus
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
 import qualified Ouroboros.Consensus.Shelley.Ledger.Query as Consensus
 import           Ouroboros.Network.Block (HeaderHash, Tip (..))
+import           Ouroboros.Network.Mux (MuxError)
 
 import qualified Codec.Binary.Bech32 as Bech32
 import qualified Codec.CBOR.Read as CBOR
@@ -474,3 +475,7 @@ instance Semigroup (Ledger.ConwayPParams StrictMaybe era) where
 
 lastMappendWithTHKD :: (a -> Ledger.THKD g StrictMaybe b) -> a -> a -> Ledger.THKD g StrictMaybe b
 lastMappendWithTHKD f a b = Ledger.THKD $ lastMappendWith (Ledger.unTHKD . f) a b
+
+instance Pretty MuxError where
+  pretty err = "Mux layer error:" <+> prettyException err
+

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -754,7 +754,9 @@ module Cardano.Api (
     chainSyncClientPipelinedWithLedgerState,
 
     -- *** Ledger state conditions
-    LedgerStateCondition(..),
+    ConditionResult(..),
+    fromConditionResult,
+    toConditionResult,
     AnyNewEpochState(..),
     foldEpochState,
     getAnyNewEpochState,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add MuxError handling in `FoldBlocksError`. Rename `LedgerStateCondition` to `ConditionResult`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Moves handling of errors removed in 
* https://github.com/IntersectMBO/cardano-node/pull/5863

to `cardano-api`. Seems that linking of epoch state logging thread sometimes results in errors: 
```
MuxError MuxBearerClosed "<socket: 71> closed when reading data, waiting on next header True"
```
or
```
Exception: ExceptionInLinkedThread (ThreadId 54) (MuxError (MuxIOException writev: resource vanished (Broken pipe)) "(sendAll errored)")
```
e.g. https://github.com/IntersectMBO/cardano-node/pull/5869/checks?check_run_id=25887156950. This change should let that error be captured by `FoldBlocksError`.

Also follow-up from 
* https://github.com/IntersectMBO/cardano-node/pull/5855

to make `LedgerStateCondition` more reusable.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
