### PR TITLE
haskell.yml: remove useless steps: artifacts production

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -143,28 +143,6 @@ jobs:
         KEEP_WORKSPACE: 1
       run: cabal test all --enable-tests --test-show-details=direct -j1
 
-    - name: "Tar artifacts"
-      run: |
-        mkdir -p artifacts
-
-        for exe in $(cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[] | select(.style == "local" and (."component-name" | startswith("exe:"))) | ."bin-file"'); do
-          if [ -f $exe ]; then
-            echo "Including artifact $exe"
-
-            ( cd artifacts
-              tar -C "$(dirname $exe)" -czf "$(basename $exe).tar.gz" "$(basename $exe)"
-            )
-          else
-            echo "Skipping artifact $exe"
-          fi
-        done
-
-    - name: Save Artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: artifacts-${{ matrix.sys.os }}-${{ matrix.ghc }}
-        path: ./artifacts
-
     # Uncomment the following back in for debugging. Remember to launch a `pwsh` from
     # the tmux session to debug `pwsh` issues. And be reminded that the `/msys2` and
     # `/msys2/mingw64` paths are not in PATH by default for the workflow, but tmate


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    haskell.yml: remove useless steps: artifacts production
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We have two steps in the CI that:

1. Builds an archive with the executables produced by the build
2. Save this archive as a GitHub artifact

But we have no executable produced during our build, so those steps are useless. You can see that in the last PR that was merged:

https://github.com/IntersectMBO/cardano-api/actions/runs/9500405626/job/26183389287?pr=448

Look at the considered steps, that mention they are useless:

![image](https://github.com/IntersectMBO/cardano-api/assets/634720/c4965506-8169-4f86-aa3c-426a3f1752d0)

# How to trust this PR

* CI still passes
* It's only deletions

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff