### PR TITLE
Disable simd on bitvec dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,6 +28,11 @@ package cryptonite
   -- generation is dubious. Set the flag so we use /dev/urandom by default.
   flags: -support_rdrand
 
+-- disable c++ nonsense on bitvec, to make it compile. The windows linker/loader
+-- chokes on c++ dependencies.
+package bitvec
+   flags: -simd
+
 constraints:
   -- io-classes-mtl-0.1.2.0 is not buildable
   io-classes-mtl < 0.1.2.0


### PR DESCRIPTION
This should hopefully make errors like the following go away (until we have the linker/loader for w32 fixed for c++ dependencies):

```
008c:err:setupapi:SetupDefaultQueueCallbackW copy error 1812 L"@C:\\windows\\system32\\drivers\\wineusb.sys,-1" -> L"C:\\windows\\inf\\wineusb.inf"
wine: failed to open L"C:\\windows\\syswow64\\rundll32.exe": c0000135
wine: configuration in L"/build" has been updated.
Listening on port 7200
iserv-proxy-interpreter.exe:|/nix/store/wi52hmyajdncvx8yhkyrwc6phq0cj3dw-bitv
ec-lib-bitvec-x86_64-w64-mingw32-1.1.5.0/lib/x86_64-windows-ghc-9.6.4/bitvec-1.1
.5.0-CuwZlpVmbRn6Ve35hpelj8/HSbitvec-1.1.5.0-CuwZlpVmbRn6Ve35hpelj8.o:unknown s
ymbol`__cpu_model'
iserv-proxy-interpreter.exe:CouldnotloadObjectCode/nix/store/wi52hmyajdncv
x8yhkyrwc6phq0cj3dw-bitvec-lib-bitvec-x86_64-w64-mingw32-1.1.5.0/lib/x86_64-wind
ows-ghc-9.6.4/bitvec-1.1.5.0-CuwZlpVmbRn6Ve35hpelj8/HSbitvec-1.1.5.0-CuwZlpVmbRn
6Ve35hpelj8.o.


<no location info>: error: unable to load unit `bitvec-1.1.5.0'
[ 17 of 186] Compiling PlutusCore.Pretty.ConfigName ( plutus-core/src/PlutusCore/Pretty/ConfigName.hs, dist/build/PlutusCore/Pretty/ConfigName.o )
[ 18 of 186] Compiling PlutusPrelude    ( prelude/PlutusPrelude.hs, dist/build/PlutusPrelude.o )
[ 19 of 186] Compiling PlutusCore.Version ( plutus-core/src/PlutusCore/Version.hs, dist/build/PlutusCore/Version.o )
0024:err:seh:call_stack_handlers invalid frame 00007FFFFF662F60 (0000000000022000-0000000000220000)
0024:err:seh:NtRaiseException Exception frame is not in stack limits => unable to dispatch exception.
iserv-proxy: {handle: <socket: 6>}: GHCi.Message.remoteCall: end of file

<no location info>: error: ghc-iserv terminated (1)
```

# Changelog

```yaml
- description: |
    disable c++ nonsense on bitvec, to make it compile. Required because the windows linker/loader chokes on c++ dependencies.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
