### PR TITLE
queryStateForBalancedTx: return current treasury value

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -105,6 +105,7 @@ import qualified Cardano.Ledger.Credential as Shelley
 import           Cardano.Ledger.Crypto (Crypto)
 import qualified Cardano.Ledger.Shelley.API as Shelley
 import qualified Cardano.Ledger.Shelley.Core as Core
+import qualified Cardano.Ledger.Shelley.LedgerState as L
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import           Cardano.Slotting.EpochInfo (hoistEpochInfo)
 import           Cardano.Slotting.Slot (WithOrigin (..))
@@ -301,6 +302,9 @@ data QueryInShelleyBasedEra era result where
     :: Set StakeCredential
     -> QueryInShelleyBasedEra era (Map StakeCredential L.Coin)
 
+  QueryAccountState
+    :: QueryInShelleyBasedEra era L.AccountState
+
   QueryConstitution
     :: QueryInShelleyBasedEra era (L.Constitution (ShelleyLedgerEra era))
 
@@ -349,6 +353,7 @@ instance NodeToClientVersionOf (QueryInShelleyBasedEra era result) where
   nodeToClientVersionOf (QueryStakeSnapshot _) = NodeToClientV_14
   nodeToClientVersionOf (QueryStakeDelegDeposits _) = NodeToClientV_15
   -- Conway >= v16
+  nodeToClientVersionOf QueryAccountState = NodeToClientV_16
   nodeToClientVersionOf QueryConstitution = NodeToClientV_16
   nodeToClientVersionOf QueryGovState = NodeToClientV_16
   nodeToClientVersionOf QueryDRepState{} = NodeToClientV_16
@@ -675,6 +680,9 @@ toConsensusQueryShelleyBased sbe = \case
     where
       creds' = Set.map toShelleyStakeCredential creds
 
+  QueryAccountState ->
+    Some (consensusQueryInEraInMode era Consensus.GetAccountState)
+
   QueryGovState ->
     Some (consensusQueryInEraInMode era Consensus.GetGovState)
 
@@ -936,6 +944,11 @@ fromConsensusQueryResultShelleyBased sbe sbeQuery q' r' =
       case q' of
         Consensus.GetStakeDelegDeposits{} ->
           Map.mapKeysMonotonic fromShelleyStakeCredential r'
+        _ -> fromConsensusQueryResultMismatch
+    QueryAccountState{} ->
+      case q' of
+        Consensus.GetAccountState{} ->
+          r'
         _ -> fromConsensusQueryResultMismatch
     QueryGovState{} ->
       case q' of

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE GADTs #-}
 
 module Cardano.Api.Query.Expr
-  ( queryChainBlockNo
+  ( queryAccountState
+  , queryChainBlockNo
   , queryChainPoint
   , queryConstitution
   , queryCurrentEpochState
@@ -58,6 +59,7 @@ import           Cardano.Ledger.Core (EraCrypto)
 import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Keys as L
 import           Cardano.Ledger.SafeHash
+import qualified Cardano.Ledger.Shelley.LedgerState as L
 import           Cardano.Slotting.Slot
 import           Ouroboros.Consensus.HardFork.Combinator.AcrossEras as Consensus
 
@@ -259,3 +261,9 @@ queryStakeVoteDelegatees :: ()
 queryStakeVoteDelegatees era stakeCredentials = do
   let sbe = conwayEraOnwardsToShelleyBasedEra era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeVoteDelegatees stakeCredentials
+
+queryAccountState :: ()
+  => ConwayEraOnwards era
+  -> LocalStateQueryExpr block point QueryInMode r IO (Either UnsupportedNtcVersionError (Either EraMismatch L.AccountState))
+queryAccountState cOnwards =
+  queryExpr $ QueryInEra . QueryInShelleyBasedEra (conwayEraOnwardsToShelleyBasedEra cOnwards) $ QueryAccountState

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -926,6 +926,7 @@ module Cardano.Api (
 
     -- ** Queries
     QueryConvenienceError(..),
+    TxCurrentTreasuryValue(..),
     queryStateForBalancedTx,
     renderQueryConvenienceError,
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make the query used by the CLI's `transaction build` return the current treasury value, so that command to do treasury donation doesn't require the user to pass it. Corresponding CLI PR: https://github.com/IntersectMBO/cardano-cli/pull/778
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Required for `transaction build` not to perform a new call to retrieve the treasury's current value in https://github.com/IntersectMBO/cardano-cli/pull/778

# How to trust this PR

It returns additional data. Existing data is unchanged.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff