### PR TITLE
Deserialize `ouroboros-consensus`'s `PoolDistr` instead of `cardano-ledger`'s `PoolDist`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -465,7 +465,7 @@ newtype SerialisedPoolDistribution era
   = SerialisedPoolDistribution (Serialised (Consensus.PoolDistr (Core.EraCrypto (ShelleyLedgerEra era))))
 
 newtype PoolDistribution era = PoolDistribution
-  { unPoolDistr :: Shelley.PoolDistr (Core.EraCrypto (ShelleyLedgerEra era))
+  { unPoolDistr :: Consensus.PoolDistr (Core.EraCrypto (ShelleyLedgerEra era))
   }
 
 decodePoolDistribution


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deserialize `ouroboros-consensus`'s `PoolDistr` instead of `cardano-ledger`'s `PoolDist` to maintain backwards compatibility with the `PoolDistr` query. This is needed because `cardano-ledger`'s `PoolDistr` datatype has changed.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
