### PR TITLE
Remove redundant era conversion functions. Handle IO Exceptions in consensus queries. Refactor `Cardano.Api.Convenience.Query` to work in `ExceptT e IO`.

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -634,7 +634,7 @@ genTxMintValue =
 
 genTxBodyContent :: ShelleyBasedEra era -> Gen (TxBodyContent BuildTx era)
 genTxBodyContent sbe = do
-  let era = shelleyBasedToCardanoEra sbe
+  let era = toCardanoEra sbe
   txIns <- map (, BuildTxWith (KeyWitness KeyWitnessForSpending)) <$> Gen.list (Range.constant 1 10) genTxIn
   txInsCollateral <- genTxInsCollateral era
   txInsReference <- genTxInsReference era

--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.AllegraEraOnwards
   ( AllegraEraOnwards(..)
   , allegraEraOnwardsConstraints
-  , allegraEraOnwardsToCardanoEra
   , allegraEraOnwardsToShelleyBasedEra
 
   , AllegraEraOnwardsConstraints
@@ -101,9 +100,6 @@ allegraEraOnwardsConstraints = \case
   AllegraEraOnwardsAlonzo  -> id
   AllegraEraOnwardsBabbage -> id
   AllegraEraOnwardsConway  -> id
-
-allegraEraOnwardsToCardanoEra :: AllegraEraOnwards era -> CardanoEra era
-allegraEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . allegraEraOnwardsToShelleyBasedEra
 
 allegraEraOnwardsToShelleyBasedEra :: AllegraEraOnwards era -> ShelleyBasedEra era
 allegraEraOnwardsToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.AlonzoEraOnwards
   ( AlonzoEraOnwards(..)
   , alonzoEraOnwardsConstraints
-  , alonzoEraOnwardsToCardanoEra
   , alonzoEraOnwardsToShelleyBasedEra
 
   , AlonzoEraOnwardsConstraints
@@ -112,9 +111,6 @@ alonzoEraOnwardsConstraints = \case
   AlonzoEraOnwardsAlonzo  -> id
   AlonzoEraOnwardsBabbage -> id
   AlonzoEraOnwardsConway  -> id
-
-alonzoEraOnwardsToCardanoEra :: AlonzoEraOnwards era -> CardanoEra era
-alonzoEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . alonzoEraOnwardsToShelleyBasedEra
 
 alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
 alonzoEraOnwardsToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.BabbageEraOnwards
   ( BabbageEraOnwards(..)
   , babbageEraOnwardsConstraints
-  , babbageEraOnwardsToCardanoEra
   , babbageEraOnwardsToShelleyBasedEra
 
   , BabbageEraOnwardsConstraints
@@ -106,9 +105,6 @@ babbageEraOnwardsConstraints :: ()
 babbageEraOnwardsConstraints = \case
   BabbageEraOnwardsBabbage -> id
   BabbageEraOnwardsConway  -> id
-
-babbageEraOnwardsToCardanoEra :: BabbageEraOnwards era -> CardanoEra era
-babbageEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . babbageEraOnwardsToShelleyBasedEra
 
 babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
 babbageEraOnwardsToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
@@ -10,7 +10,6 @@
 module Cardano.Api.Eon.ByronToAlonzoEra
   ( ByronToAlonzoEra(..)
   , byronToAlonzoEraConstraints
-  , byronToAlonzoEraToCardanoEra
 
   , ByronToAlonzoEraConstraints
   ) where
@@ -62,11 +61,3 @@ byronToAlonzoEraConstraints = \case
   ByronToAlonzoEraAllegra  -> id
   ByronToAlonzoEraMary     -> id
   ByronToAlonzoEraAlonzo   -> id
-
-byronToAlonzoEraToCardanoEra :: ByronToAlonzoEra era -> CardanoEra era
-byronToAlonzoEraToCardanoEra = \case
-  ByronToAlonzoEraByron    -> ByronEra
-  ByronToAlonzoEraShelley  -> ShelleyEra
-  ByronToAlonzoEraAllegra  -> AllegraEra
-  ByronToAlonzoEraMary     -> MaryEra
-  ByronToAlonzoEraAlonzo   -> AlonzoEra

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ConwayEraOnwards
   ( ConwayEraOnwards(..)
   , conwayEraOnwardsConstraints
-  , conwayEraOnwardsToCardanoEra
   , conwayEraOnwardsToShelleyBasedEra
 
   , ConwayEraOnwardsConstraints
@@ -108,9 +107,6 @@ conwayEraOnwardsConstraints :: ()
   -> a
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id
-
-conwayEraOnwardsToCardanoEra :: ConwayEraOnwards era -> CardanoEra era
-conwayEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . conwayEraOnwardsToShelleyBasedEra
 
 conwayEraOnwardsToShelleyBasedEra :: ConwayEraOnwards era -> ShelleyBasedEra era
 conwayEraOnwardsToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.MaryEraOnwards
   ( MaryEraOnwards(..)
   , maryEraOnwardsConstraints
-  , maryEraOnwardsToCardanoEra
   , maryEraOnwardsToShelleyBasedEra
 
   , MaryEraOnwardsConstraints
@@ -102,9 +101,6 @@ maryEraOnwardsConstraints = \case
   MaryEraOnwardsAlonzo  -> id
   MaryEraOnwardsBabbage -> id
   MaryEraOnwardsConway  -> id
-
-maryEraOnwardsToCardanoEra :: MaryEraOnwards era -> CardanoEra era
-maryEraOnwardsToCardanoEra = shelleyBasedToCardanoEra . maryEraOnwardsToShelleyBasedEra
 
 maryEraOnwardsToShelleyBasedEra :: MaryEraOnwards era -> ShelleyBasedEra era
 maryEraOnwardsToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -17,7 +17,6 @@ module Cardano.Api.Eon.ShelleyBasedEra
   , AnyShelleyBasedEra(..)
   , InAnyShelleyBasedEra(..)
   , inAnyShelleyBasedEra
-  , shelleyBasedToCardanoEra
   , inEonForShelleyBasedEra
   , inEonForShelleyBasedEraMaybe
   , forShelleyBasedEraInEon
@@ -71,7 +70,7 @@ inEonForShelleyBasedEra :: ()
   -> ShelleyBasedEra era
   -> a
 inEonForShelleyBasedEra no yes =
-  inEonForEra no yes . shelleyBasedToCardanoEra
+  inEonForEra no yes . toCardanoEra
 
 inEonForShelleyBasedEraMaybe :: ()
   => Eon eon
@@ -86,7 +85,7 @@ forShelleyBasedEraMaybeEon :: ()
   => ShelleyBasedEra era
   -> Maybe (eon era)
 forShelleyBasedEraMaybeEon =
-  inEonForEra Nothing Just . shelleyBasedToCardanoEra
+  inEonForEra Nothing Just . toCardanoEra
 
 forShelleyBasedEraInEon :: ()
   => Eon eon
@@ -139,10 +138,10 @@ deriving instance Ord  (ShelleyBasedEra era)
 deriving instance Show (ShelleyBasedEra era)
 
 instance Pretty (ShelleyBasedEra era) where
-  pretty = pretty . shelleyBasedToCardanoEra
+  pretty = pretty . toCardanoEra
 
 instance ToJSON (ShelleyBasedEra era) where
-   toJSON = toJSON . shelleyBasedToCardanoEra
+   toJSON = toJSON . toCardanoEra
 
 instance TestEquality ShelleyBasedEra where
     testEquality ShelleyBasedEraShelley ShelleyBasedEraShelley = Just Refl
@@ -305,15 +304,6 @@ inAnyShelleyBasedEra :: ()
   -> InAnyShelleyBasedEra thing
 inAnyShelleyBasedEra sbe a =
   shelleyBasedEraConstraints sbe $ InAnyShelleyBasedEra sbe a
-
--- | Converts a 'ShelleyBasedEra' to the broader 'CardanoEra'.
-shelleyBasedToCardanoEra :: ShelleyBasedEra era -> CardanoEra era
-shelleyBasedToCardanoEra ShelleyBasedEraShelley = ShelleyEra
-shelleyBasedToCardanoEra ShelleyBasedEraAllegra = AllegraEra
-shelleyBasedToCardanoEra ShelleyBasedEraMary    = MaryEra
-shelleyBasedToCardanoEra ShelleyBasedEraAlonzo  = AlonzoEra
-shelleyBasedToCardanoEra ShelleyBasedEraBabbage = BabbageEra
-shelleyBasedToCardanoEra ShelleyBasedEraConway  = ConwayEra
 
 -- ----------------------------------------------------------------------------
 -- Conversion to Shelley ledger library types

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ShelleyEraOnly
   ( ShelleyEraOnly(..)
   , shelleyEraOnlyConstraints
-  , shelleyEraOnlyToCardanoEra
   , shelleyEraOnlyToShelleyBasedEra
 
   , ShelleyEraOnlyConstraints
@@ -98,9 +97,6 @@ shelleyEraOnlyConstraints :: ()
   -> a
 shelleyEraOnlyConstraints = \case
   ShelleyEraOnlyShelley  -> id
-
-shelleyEraOnlyToCardanoEra :: ShelleyEraOnly era -> CardanoEra era
-shelleyEraOnlyToCardanoEra = shelleyBasedToCardanoEra . shelleyEraOnlyToShelleyBasedEra
 
 shelleyEraOnlyToShelleyBasedEra :: ShelleyEraOnly era -> ShelleyBasedEra era
 shelleyEraOnlyToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ShelleyToAllegraEra
   ( ShelleyToAllegraEra(..)
   , shelleyToAllegraEraConstraints
-  , shelleyToAllegraEraToCardanoEra
   , shelleyToAllegraEraToShelleyBasedEra
 
   , ShelleyToAllegraEraConstraints
@@ -101,9 +100,6 @@ shelleyToAllegraEraConstraints :: ()
 shelleyToAllegraEraConstraints = \case
   ShelleyToAllegraEraShelley -> id
   ShelleyToAllegraEraAllegra -> id
-
-shelleyToAllegraEraToCardanoEra :: ShelleyToAllegraEra era -> CardanoEra era
-shelleyToAllegraEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAllegraEraToShelleyBasedEra
 
 shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
 shelleyToAllegraEraToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ShelleyToAlonzoEra
   ( ShelleyToAlonzoEra(..)
   , shelleyToAlonzoEraConstraints
-  , shelleyToAlonzoEraToCardanoEra
   , shelleyToAlonzoEraToShelleyBasedEra
 
   , ShelleyToAlonzoEraConstraints
@@ -102,9 +101,6 @@ shelleyToAlonzoEraConstraints = \case
   ShelleyToAlonzoEraAllegra -> id
   ShelleyToAlonzoEraMary    -> id
   ShelleyToAlonzoEraAlonzo  -> id
-
-shelleyToAlonzoEraToCardanoEra :: ShelleyToAlonzoEra era -> CardanoEra era
-shelleyToAlonzoEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToAlonzoEraToShelleyBasedEra
 
 shelleyToAlonzoEraToShelleyBasedEra :: ShelleyToAlonzoEra era -> ShelleyBasedEra era
 shelleyToAlonzoEraToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ShelleyToBabbageEra
   ( ShelleyToBabbageEra(..)
   , shelleyToBabbageEraConstraints
-  , shelleyToBabbageEraToCardanoEra
   , shelleyToBabbageEraToShelleyBasedEra
 
   , ShelleyToBabbageEraConstraints
@@ -104,9 +103,6 @@ shelleyToBabbageEraConstraints = \case
   ShelleyToBabbageEraMary    -> id
   ShelleyToBabbageEraAlonzo  -> id
   ShelleyToBabbageEraBabbage -> id
-
-shelleyToBabbageEraToCardanoEra :: ShelleyToBabbageEra era -> CardanoEra era
-shelleyToBabbageEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToBabbageEraToShelleyBasedEra
 
 shelleyToBabbageEraToShelleyBasedEra :: ShelleyToBabbageEra era -> ShelleyBasedEra era
 shelleyToBabbageEraToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
@@ -11,7 +11,6 @@
 module Cardano.Api.Eon.ShelleyToMaryEra
   ( ShelleyToMaryEra(..)
   , shelleyToMaryEraConstraints
-  , shelleyToMaryEraToCardanoEra
   , shelleyToMaryEraToShelleyBasedEra
 
   , ShelleyToMaryEraConstraints
@@ -100,9 +99,6 @@ shelleyToMaryEraConstraints = \case
   ShelleyToMaryEraShelley -> id
   ShelleyToMaryEraAllegra -> id
   ShelleyToMaryEraMary    -> id
-
-shelleyToMaryEraToCardanoEra :: ShelleyToMaryEra era -> CardanoEra era
-shelleyToMaryEraToCardanoEra = shelleyBasedToCardanoEra . shelleyToMaryEraToShelleyBasedEra
 
 shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
 shelleyToMaryEraToShelleyBasedEra = \case

--- a/cardano-api/internal/Cardano/Api/Feature.hs
+++ b/cardano-api/internal/Cardano/Api/Feature.hs
@@ -48,4 +48,4 @@ asFeaturedInShelleyBasedEra :: ()
   => a
   -> ShelleyBasedEra era
   -> Maybe (Featured eon era a)
-asFeaturedInShelleyBasedEra value = asFeaturedInEra value . shelleyBasedToCardanoEra
+asFeaturedInShelleyBasedEra value = asFeaturedInEra value . toCardanoEra

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -328,7 +328,7 @@ evaluateTransactionFee :: forall era. ()
   -> L.Coin
 evaluateTransactionFee sbe pp txbody keywitcount byronwitcount refScriptsSize =
   shelleyBasedEraConstraints sbe $
-    case makeSignedTransaction' (shelleyBasedToCardanoEra sbe) [] txbody of
+    case makeSignedTransaction' (toCardanoEra sbe) [] txbody of
       ShelleyTx _ tx ->
           L.estimateMinFeeTx pp tx (fromIntegral keywitcount) (fromIntegral byronwitcount) refScriptsSize
 
@@ -353,7 +353,7 @@ calculateMinTxFee :: forall era. ()
   -> L.Coin
 calculateMinTxFee sbe pp utxo txbody keywitcount =
   shelleyBasedEraConstraints sbe $
-    case makeSignedTransaction' (shelleyBasedToCardanoEra sbe) [] txbody of
+    case makeSignedTransaction' (toCardanoEra sbe) [] txbody of
       ShelleyTx _ tx ->
         L.calcMinFeeTx (toLedgerUTxO sbe utxo) pp tx (fromIntegral keywitcount)
 
@@ -1102,7 +1102,7 @@ makeTransactionBodyAutoBalance sbe systemstart history lpp@(LedgerProtocolParame
     return (BalancedTxBody finalTxBodyContent txbody3 (TxOut changeaddr balance TxOutDatumNone ReferenceScriptNone) fee)
  where
    era :: CardanoEra era
-   era = shelleyBasedToCardanoEra sbe
+   era = toCardanoEra sbe
 
 -- | In the event of spending the exact amount of lovelace in
 -- the specified input(s), this function excludes the change

--- a/cardano-api/internal/Cardano/Api/Monad/Error.hs
+++ b/cardano-api/internal/Cardano/Api/Monad/Error.hs
@@ -14,6 +14,7 @@ module Cardano.Api.Monad.Error
   , handleIOExceptionsWith
   , handleIOExceptionsLiftWith
   , hoistIOEither
+  , liftMaybe
 
   , module Control.Monad.Except
   , module Control.Monad.IO.Class
@@ -87,3 +88,10 @@ hoistIOEither :: MonadIOTransError e t m
               => IO (Either e a)
               -> t m a
 hoistIOEither = liftExceptT . ExceptT . liftIO
+
+-- | Lift 'Maybe' into 'MonadError'
+liftMaybe :: MonadError e m
+          => e      -- ^ Error to throw, if 'Nothing'
+          -> Maybe a
+          -> m a
+liftMaybe e = maybe (throwError e) pure

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -1786,7 +1786,7 @@ checkProtocolParameters sbe ProtocolParameters{..} =
     ShelleyBasedEraBabbage -> checkBabbageParams
     ShelleyBasedEraConway -> checkBabbageParams
  where
-   era = shelleyBasedToCardanoEra sbe
+   era = toCardanoEra sbe
 
    cModel = not $ Map.null protocolParamCostModels
    prices = isJust protocolParamPrices

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -715,7 +715,7 @@ toConsensusQueryShelleyBased sbe = \case
       creds' = Set.map toShelleyStakeCredential creds
 
   where
-    era = shelleyBasedToCardanoEra sbe
+    era = toCardanoEra sbe
 
 consensusQueryInEraInMode
   :: forall era erablock modeblock result result' xs.

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -1412,7 +1412,7 @@ createTransactionBody :: ()
   -> Either TxBodyError (TxBody era)
 createTransactionBody sbe bc =
   shelleyBasedEraConstraints sbe $ do
-    let era = shelleyBasedToCardanoEra sbe
+    let era = toCardanoEra sbe
         apiTxOuts = txOuts bc
         apiScriptWitnesses = collectTxBodyScriptWitnesses sbe bc
         apiScriptValidity = txScriptValidity bc
@@ -1587,7 +1587,7 @@ validateTxInsCollateral txInsCollateral languages =
 
 validateTxOuts :: ShelleyBasedEra era -> [TxOut CtxTx era] -> Either TxBodyError ()
 validateTxOuts sbe txOuts = do
-  let era = shelleyBasedToCardanoEra sbe
+  let era = toCardanoEra sbe
   cardanoEraConstraints era $
     sequence_
       [ do

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -60,33 +60,27 @@ module Cardano.Api (
 
     ByronToAlonzoEra(..),
     byronToAlonzoEraConstraints,
-    byronToAlonzoEraToCardanoEra,
 
     -- ** From Shelley
 
     ShelleyEraOnly(..),
     shelleyEraOnlyConstraints,
-    shelleyEraOnlyToCardanoEra,
     shelleyEraOnlyToShelleyBasedEra,
 
     ShelleyToAllegraEra(..),
     shelleyToAllegraEraConstraints,
-    shelleyToAllegraEraToCardanoEra,
     shelleyToAllegraEraToShelleyBasedEra,
 
     ShelleyToMaryEra(..),
     shelleyToMaryEraConstraints,
-    shelleyToMaryEraToCardanoEra,
     shelleyToMaryEraToShelleyBasedEra,
 
     ShelleyToAlonzoEra(..),
     shelleyToAlonzoEraConstraints,
-    shelleyToAlonzoEraToCardanoEra,
     shelleyToAlonzoEraToShelleyBasedEra,
 
     ShelleyToBabbageEra(..),
     shelleyToBabbageEraConstraints,
-    shelleyToBabbageEraToCardanoEra,
     shelleyToBabbageEraToShelleyBasedEra,
 
     ShelleyBasedEra(..),
@@ -94,7 +88,6 @@ module Cardano.Api (
     AnyShelleyBasedEra(..),
     InAnyShelleyBasedEra(..),
     inAnyShelleyBasedEra,
-    shelleyBasedToCardanoEra,
     shelleyBasedEraConstraints,
 
     -- ** From Allegra
@@ -103,28 +96,24 @@ module Cardano.Api (
     -- ** From Mary
     MaryEraOnwards(..),
     maryEraOnwardsConstraints,
-    maryEraOnwardsToCardanoEra,
     maryEraOnwardsToShelleyBasedEra,
 
     -- ** From Alonzo
 
     AlonzoEraOnwards(..),
     alonzoEraOnwardsConstraints,
-    alonzoEraOnwardsToCardanoEra,
     alonzoEraOnwardsToShelleyBasedEra,
 
     -- ** From Babbage
 
     BabbageEraOnwards(..),
     babbageEraOnwardsConstraints,
-    babbageEraOnwardsToCardanoEra,
     babbageEraOnwardsToShelleyBasedEra,
 
     -- ** From Conway
 
     ConwayEraOnwards(..),
     conwayEraOnwardsConstraints,
-    conwayEraOnwardsToCardanoEra,
     conwayEraOnwardsToShelleyBasedEra,
 
     -- * Era case handling

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Eras.hs
@@ -23,7 +23,7 @@ prop_maxBound_CardanoMatchesShelley = property $ do
   AnyCardanoEra era <- forAll $ Gen.element [maxBound]
   AnyShelleyBasedEra sbe <- forAll $ Gen.element [maxBound]
 
-  fromEnum (anyCardanoEra era) === fromEnum (anyCardanoEra (shelleyBasedToCardanoEra sbe))
+  fromEnum (anyCardanoEra era) === fromEnum (anyCardanoEra (toCardanoEra sbe))
 
 --------------------------------------------------------------------------------
 -- Aeson instances
@@ -44,7 +44,7 @@ prop_toJSON_CardanoMatchesShelley :: Property
 prop_toJSON_CardanoMatchesShelley = property $ do
   AnyShelleyBasedEra sbe <- forAll $ Gen.element [minBound..maxBound]
 
-  toJSON (AnyShelleyBasedEra sbe) === toJSON (anyCardanoEra (shelleyBasedToCardanoEra sbe))
+  toJSON (AnyShelleyBasedEra sbe) === toJSON (anyCardanoEra (toCardanoEra sbe))
 
 tests :: TestTree
 tests = testGroup "Test.Cardano.Api.Json"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    * Remove redundant era conversion functions. Use `toCardanoEra` instead.
    * Add IO Exception handling to consensus query execution.
    * Refactor Cardano.Api.Convenience.Query to return `ExceptT e IO a` instead of `IO (Either e a)`

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Make things more composable.