### PR TITLE
Regression test for issue with deserialization of PoolDistr

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -369,6 +369,7 @@ test-suite cardano-api-golden
                       , cardano-ledger-alonzo
                       , cardano-ledger-api ^>= 1.9
                       , cardano-ledger-babbage >= 1.6.0
+                      , cardano-ledger-binary
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
                       , cardano-ledger-shelley
                       , cardano-ledger-shelley-test >= 1.2.0.1
@@ -379,6 +380,7 @@ test-suite cardano-api-golden
                       , hedgehog >= 1.1
                       , hedgehog-extras ^>= 0.6.1.0
                       , microlens
+                      , ouroboros-consensus-cardano
                       , ouroboros-network-api
                       , parsec
                       , plutus-core ^>= 1.30

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -311,12 +311,16 @@ test-suite cardano-api-test
                       , cardano-api
                       , cardano-api:gen
                       , cardano-api:internal
+                      , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-test ^>= 1.5
                       , cardano-crypto-tests ^>= 2.1
                       , cardano-ledger-api ^>= 1.9
+                      , cardano-ledger-binary
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
+                      , cardano-protocol-tpraos
+                      , cardano-slotting
                       , containers
                       , directory
                       , hedgehog >= 1.1
@@ -324,12 +328,18 @@ test-suite cardano-api-test
                       , hedgehog-quickcheck
                       , interpolatedstring-perl6
                       , mtl
+                      , ouroboros-consensus
+                      , ouroboros-consensus-cardano
+                      , ouroboros-consensus-protocol
+                      , ouroboros-network-api
                       , QuickCheck
                       , tasty
                       , tasty-hedgehog
                       , tasty-quickcheck
+                      , time
 
   other-modules:        Test.Cardano.Api.Crypto
+                        Test.Cardano.Api.EpochLeadership
                         Test.Cardano.Api.Eras
                         Test.Cardano.Api.IO
                         Test.Cardano.Api.Json
@@ -369,11 +379,9 @@ test-suite cardano-api-golden
                       , cardano-ledger-alonzo
                       , cardano-ledger-api ^>= 1.9
                       , cardano-ledger-babbage >= 1.6.0
-                      , cardano-ledger-binary
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
                       , cardano-ledger-shelley
                       , cardano-ledger-shelley-test >= 1.2.0.1
-                      , cardano-protocol-tpraos
                       , cardano-slotting ^>= 0.2.0.0
                       , containers
                       , errors
@@ -381,10 +389,6 @@ test-suite cardano-api-golden
                       , hedgehog >= 1.1
                       , hedgehog-extras ^>= 0.6.1.0
                       , microlens
-                      , ouroboros-consensus
-                      , ouroboros-consensus-cardano
-                      , ouroboros-consensus-protocol
-                      , ouroboros-network-api
                       , parsec
                       , plutus-core ^>= 1.30
                       , plutus-ledger-api ^>= 1.30
@@ -397,8 +401,7 @@ test-suite cardano-api-golden
 
   build-tool-depends:   tasty-discover:tasty-discover
 
-  other-modules:        Test.Golden.Cardano.Api.EpochLeadership
-                      , Test.Golden.Cardano.Api.Genesis
+  other-modules:        Test.Golden.Cardano.Api.Genesis
                       , Test.Golden.Cardano.Api.Ledger
                       , Test.Golden.Cardano.Api.Typed.Script
                       , Test.Golden.Cardano.Api.Value

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -379,6 +379,7 @@ test-suite cardano-api-golden
                       , hedgehog >= 1.1
                       , hedgehog-extras ^>= 0.6.1.0
                       , microlens
+                      , ouroboros-network-api
                       , parsec
                       , plutus-core ^>= 1.30
                       , plutus-ledger-api ^>= 1.30
@@ -391,7 +392,8 @@ test-suite cardano-api-golden
 
   build-tool-depends:   tasty-discover:tasty-discover
 
-  other-modules:        Test.Golden.Cardano.Api.Genesis
+  other-modules:        Test.Golden.Cardano.Api.EpochLeadership
+                      , Test.Golden.Cardano.Api.Genesis
                       , Test.Golden.Cardano.Api.Ledger
                       , Test.Golden.Cardano.Api.Typed.Script
                       , Test.Golden.Cardano.Api.Value

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -373,6 +373,7 @@ test-suite cardano-api-golden
                       , cardano-ledger-core:{cardano-ledger-core, testlib} >= 1.8
                       , cardano-ledger-shelley
                       , cardano-ledger-shelley-test >= 1.2.0.1
+                      , cardano-protocol-tpraos
                       , cardano-slotting ^>= 0.2.0.0
                       , containers
                       , errors
@@ -380,7 +381,9 @@ test-suite cardano-api-golden
                       , hedgehog >= 1.1
                       , hedgehog-extras ^>= 0.6.1.0
                       , microlens
+                      , ouroboros-consensus
                       , ouroboros-consensus-cardano
+                      , ouroboros-consensus-protocol
                       , ouroboros-network-api
                       , parsec
                       , plutus-core ^>= 1.30

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Golden.Cardano.Api.EpochLeadership
+  ( test_golden_currentEpochEligibleLeadershipSlots
+  ) where
+
+import           Cardano.Api (deterministicSigningKey)
+import           Cardano.Api.Block (EpochNo (..), Hash (StakePoolKeyHash), SlotNo (..))
+import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyBasedEra (..))
+import           Cardano.Api.Genesis (shelleyGenesisDefaults)
+import           Cardano.Api.GenesisParameters (EpochSize (..))
+import           Cardano.Api.Ledger (KeyHash (KeyHash))
+import           Cardano.Api.LedgerState (currentEpochEligibleLeadershipSlots)
+import           Cardano.Api.Query (ProtocolState (..),
+                   SerialisedPoolDistribution (SerialisedPoolDistribution))
+import           Cardano.Api.Shelley (VrfKey, proxyToAsType, unStakePoolKeyHash)
+
+import           Cardano.Crypto.Seed (mkSeedFromBytes)
+import           Cardano.Ledger.Api.PParams (emptyPParams)
+import           Cardano.Slotting.EpochInfo (EpochInfo (..))
+import           Cardano.Slotting.Time (RelativeTime (..), mkSlotLength)
+import           Ouroboros.Network.Block (Serialised (..))
+
+import           Data.Proxy (Proxy (..))
+import qualified Data.Set as Set
+import           Data.Time.Clock (secondsToNominalDiffTime)
+
+import qualified Hedgehog as H
+import           Test.Tasty (TestTree)
+import           Test.Tasty.Hedgehog (testProperty)
+
+test_golden_currentEpochEligibleLeadershipSlots :: TestTree
+test_golden_currentEpochEligibleLeadershipSlots = testProperty "golden EpochLeadership" $
+  H.property $ do
+    let sbe = ShelleyBasedEraShelley
+        sGen = shelleyGenesisDefaults
+        eInfo = EpochInfo { epochInfoSize_ = const (Right (EpochSize 10))
+                          , epochInfoFirst_ = \(EpochNo x) -> pure $ SlotNo (x * 10)
+                          , epochInfoEpoch_ = \(SlotNo x) -> pure $ EpochNo (x `div` 10)
+                          , epochInfoSlotToRelativeTime_ = \(SlotNo x) -> pure $ RelativeTime (secondsToNominalDiffTime (fromIntegral x * 10))
+                          , epochInfoSlotLength_ = const (pure $ mkSlotLength 10)
+                          }
+        pp = emptyPParams
+        ptclState = ProtocolState (Serialised "dummyProtocolState")
+        poolid = StakePoolKeyHash { unStakePoolKeyHash = KeyHash "58eef2925db2789f76ea057c51069e52c5e0a44550f853c6cdf620f8" }
+        vrskey = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "")
+        serPoolDistr = SerialisedPoolDistribution (Serialised "dummyPoolDistr")
+        currentEpoch = EpochNo 4
+        eEligibileSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey serPoolDistr currentEpoch
+        expectedEligibleSlots = [SlotNo 2, SlotNo 6]
+    eligibileSlots <- H.evalEither eEligibileSlots
+    eligibileSlots H.=== Set.fromList expectedEligibleSlots

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
@@ -92,7 +92,7 @@ test_golden_currentEpochEligibleLeadershipSlots =
                        ]
         serPoolDistr = SerialisedPoolDistribution (Serialised (serialize (toByronCBOR poolDistr)))
         currentEpoch = EpochNo 4
-        eEligibileSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey1 serPoolDistr currentEpoch
+        eEligibleSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey1 serPoolDistr currentEpoch
         expectedEligibleSlots = [ SlotNo 406, SlotNo 432, SlotNo 437, SlotNo 443, SlotNo 484 ]
-    eligibileSlots <- H.evalEither eEligibileSlots
-    eligibileSlots H.=== Set.fromList expectedEligibleSlots
+    eligibleSlots <- H.evalEither eEligibleSlots
+    eligibleSlots H.=== Set.fromList expectedEligibleSlots

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
@@ -9,18 +9,22 @@ import           Cardano.Api.Block (EpochNo (..), Hash (StakePoolKeyHash), SlotN
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyBasedEra (..))
 import           Cardano.Api.Genesis (shelleyGenesisDefaults)
 import           Cardano.Api.GenesisParameters (EpochSize (..))
-import           Cardano.Api.Ledger (KeyHash (KeyHash))
+import           Cardano.Api.Ledger (KeyHash (..), StandardCrypto)
 import           Cardano.Api.LedgerState (currentEpochEligibleLeadershipSlots)
 import           Cardano.Api.Query (ProtocolState (..),
                    SerialisedPoolDistribution (SerialisedPoolDistribution))
 import           Cardano.Api.Shelley (VrfKey, proxyToAsType, unStakePoolKeyHash)
 
+import           Cardano.Binary (serialize)
 import           Cardano.Crypto.Seed (mkSeedFromBytes)
 import           Cardano.Ledger.Api.PParams (emptyPParams)
+import           Cardano.Ledger.Binary.Encoding (toByronCBOR)
 import           Cardano.Slotting.EpochInfo (EpochInfo (..))
 import           Cardano.Slotting.Time (RelativeTime (..), mkSlotLength)
+import           Ouroboros.Consensus.Shelley.Ledger.Query.Types (PoolDistr (..))
 import           Ouroboros.Network.Block (Serialised (..))
 
+import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import           Data.Time.Clock (secondsToNominalDiffTime)
@@ -44,7 +48,8 @@ test_golden_currentEpochEligibleLeadershipSlots = testProperty "golden EpochLead
         ptclState = ProtocolState (Serialised "dummyProtocolState")
         poolid = StakePoolKeyHash { unStakePoolKeyHash = KeyHash "58eef2925db2789f76ea057c51069e52c5e0a44550f853c6cdf620f8" }
         vrskey = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "")
-        serPoolDistr = SerialisedPoolDistribution (Serialised "dummyPoolDistr")
+        poolDistr :: PoolDistr StandardCrypto = PoolDistr Map.empty
+        serPoolDistr = SerialisedPoolDistribution (Serialised (serialize (toByronCBOR poolDistr)))
         currentEpoch = EpochNo 4
         eEligibileSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey serPoolDistr currentEpoch
         expectedEligibleSlots = [SlotNo 2, SlotNo 6]

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/EpochLeadership.hs
@@ -7,7 +7,8 @@ module Test.Golden.Cardano.Api.EpochLeadership
   ( test_golden_currentEpochEligibleLeadershipSlots
   ) where
 
-import           Cardano.Api (deterministicSigningKey)
+import           Cardano.Api (Key (verificationKeyHash), deterministicSigningKey,
+                   getVerificationKey)
 import           Cardano.Api.Block (EpochNo (..), Hash (StakePoolKeyHash), SlotNo (..))
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyBasedEra (..))
 import           Cardano.Api.Genesis (shelleyGenesisDefaults)
@@ -17,7 +18,7 @@ import           Cardano.Api.LedgerState (currentEpochEligibleLeadershipSlots)
 import           Cardano.Api.Modes (ConsensusProtocol)
 import           Cardano.Api.Query (ProtocolState (..),
                    SerialisedPoolDistribution (SerialisedPoolDistribution))
-import           Cardano.Api.Shelley (VrfKey, proxyToAsType, unStakePoolKeyHash)
+import           Cardano.Api.Shelley (Hash (VrfKeyHash), VrfKey, proxyToAsType, unStakePoolKeyHash)
 
 import           Cardano.Binary (ToCBOR, serialize)
 import           Cardano.Crypto.Seed (mkSeedFromBytes)
@@ -29,11 +30,13 @@ import           Cardano.Slotting.EpochInfo (EpochInfo (..))
 import           Cardano.Slotting.Time (RelativeTime (..), mkSlotLength)
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import           Ouroboros.Consensus.Protocol.TPraos (TPraosState (..))
-import           Ouroboros.Consensus.Shelley.Ledger.Query.Types (PoolDistr (..))
+import           Ouroboros.Consensus.Shelley.Ledger.Query.Types (IndividualPoolStake (..),
+                   PoolDistr (..))
 import           Ouroboros.Network.Block (Serialised (..))
 
 import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
+import           Data.Ratio ((%))
 import qualified Data.Set as Set
 import           Data.Time.Clock (secondsToNominalDiffTime)
 
@@ -54,21 +57,42 @@ test_golden_currentEpochEligibleLeadershipSlots =
   H.property $ do
     let sbe = ShelleyBasedEraShelley
         sGen = shelleyGenesisDefaults
-        eInfo = EpochInfo { epochInfoSize_ = const (Right (EpochSize 10))
-                          , epochInfoFirst_ = \(EpochNo x) -> pure $ SlotNo (x * 10)
-                          , epochInfoEpoch_ = \(SlotNo x) -> pure $ EpochNo (x `div` 10)
-                          , epochInfoSlotToRelativeTime_ = \(SlotNo x) -> pure $ RelativeTime (secondsToNominalDiffTime (fromIntegral x * 10))
-                          , epochInfoSlotLength_ = const (pure $ mkSlotLength 10)
+        eInfo = EpochInfo { epochInfoSize_ = const (Right (EpochSize 100))
+                          , epochInfoFirst_ = \(EpochNo x) -> pure $ SlotNo (x * 100)
+                          , epochInfoEpoch_ = \(SlotNo x) -> pure $ EpochNo (x `div` 100)
+                          , epochInfoSlotToRelativeTime_ = \(SlotNo x) -> pure $ RelativeTime (secondsToNominalDiffTime (fromIntegral x * 60))
+                          , epochInfoSlotLength_ = const (pure $ mkSlotLength 100)
                           }
         pp = emptyPParams
         chainDepState = TPraosState Origin (API.initialChainDepState NeutralNonce Map.empty)
         ptclState = encodeProtocolState chainDepState
-        poolid = StakePoolKeyHash { unStakePoolKeyHash = KeyHash "58eef2925db2789f76ea057c51069e52c5e0a44550f853c6cdf620f8" }
-        vrskey = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "")
-        poolDistr :: PoolDistr StandardCrypto = PoolDistr Map.empty
+        poolid = StakePoolKeyHash { unStakePoolKeyHash = KeyHash "83c5da842d7437e411d3c4db8aaa7a7d2c1642aee932108c9857282d" }
+        vrskey1 = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "V5UlALekTHL9bIbe3Yb0Kk4T49gn9smf")
+        VrfKeyHash hash1 = verificationKeyHash $ getVerificationKey vrskey1
+        vrskey2 = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "OLjPbWC6JCjSwO4lqUms0EgkinoLoIhz")
+        VrfKeyHash hash2 = verificationKeyHash $ getVerificationKey vrskey2
+        vrskey3 = deterministicSigningKey (proxyToAsType (Proxy :: Proxy VrfKey)) (mkSeedFromBytes "eF0R2dENRrHM8iyb9q7puTw4y2l8e2z4")
+        VrfKeyHash hash3 = verificationKeyHash $ getVerificationKey vrskey3
+        poolDistr :: PoolDistr StandardCrypto = PoolDistr $
+          Map.fromList [ ( KeyHash "a2927c1e43974b036d8e6838d410279266946e8a094895cfc748c91d"
+                         , IndividualPoolStake { individualPoolStake = 1 % 3
+                                               , individualPoolStakeVrf = hash1
+                                               }
+                         )
+                       , ( KeyHash "83c5da842d7437e411d3c4db8aaa7a7d2c1642aee932108c9857282d"
+                         , IndividualPoolStake { individualPoolStake = 1 % 3
+                                               , individualPoolStakeVrf = hash2
+                                               }
+                         )
+                       , ( KeyHash "362c2c2128ee75ca39690c27b42e809301231098003443669e2b03f3"
+                         , IndividualPoolStake { individualPoolStake = 1 % 3
+                                               , individualPoolStakeVrf = hash3
+                                               }
+                         )
+                       ]
         serPoolDistr = SerialisedPoolDistribution (Serialised (serialize (toByronCBOR poolDistr)))
         currentEpoch = EpochNo 4
-        eEligibileSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey serPoolDistr currentEpoch
-        expectedEligibleSlots = [SlotNo 2, SlotNo 6]
+        eEligibileSlots = currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid vrskey1 serPoolDistr currentEpoch
+        expectedEligibleSlots = [ SlotNo 406, SlotNo 432, SlotNo 437, SlotNo 443, SlotNo 484 ]
     eligibileSlots <- H.evalEither eEligibileSlots
     eligibileSlots H.=== Set.fromList expectedEligibleSlots

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -7,6 +7,7 @@ import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncod
 import qualified Test.Gen.Cardano.Api.Byron
 
 import qualified Test.Cardano.Api.Crypto
+import qualified Test.Cardano.Api.EpochLeadership
 import qualified Test.Cardano.Api.Eras
 import qualified Test.Cardano.Api.IO
 import qualified Test.Cardano.Api.Json
@@ -39,6 +40,7 @@ tests =
   testGroup "Cardano.Api"
     [ Test.Gen.Cardano.Api.Byron.tests
     , Test.Cardano.Api.Crypto.tests
+    , Test.Cardano.Api.EpochLeadership.tests
     , Test.Cardano.Api.Eras.tests
     , Test.Cardano.Api.IO.tests
     , Test.Cardano.Api.Json.tests


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add regression golden test for deserialization bug with PoolDistribution.
  type:
  - test           # fixes/modifies tests
```

# Context

There was recently an issue with the `cardano-cli query leadership-schedule` command, which caused a deserialization error. It was due to a subtle error with using the wrong type (a type with the same name, but different) when deserializing.

[The patch that fixes the error](https://github.com/IntersectMBO/cardano-api/pull/562/commits/17c02c4161df2707f3ba98fbc7b33968cee6678d) rewraps from [Ouroboros.Consensus.Shelley.Ledger.Query.Types.PoolDistr](https://github.com/IntersectMBO/ouroboros-consensus/blob/d2ecdfe90af84eec438c5add9d36940127b7bfee/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query/Types.hs#L62) to [Cardano.Ledger.PoolDistr](https://github.com/IntersectMBO/cardano-ledger/blob/d529098771f9104e5990849107113e58dd032977/libs/cardano-ledger-core/src/Cardano/Ledger/PoolDistr.hs#L100).

The test calls the [currentEpochEligibleLeadershipSlots](https://github.com/IntersectMBO/cardano-api/blob/dfaf1e971ac03b06aadfe048ae5129156a4ca43e/cardano-api/internal/Cardano/Api/LedgerState.hs#L1734) function with some random but deterministic parameters and checks that the output is what it was when I wrote the test, which I ensured is neither something trivial nor an error. This gives some assurance that future changes don't break the function.

# How to trust this PR

It is a test, and it works, so bug wise it is probably fine. I would check that I am testing the right thing, that it is sensible, and that stylistically it is ok.

I have also ran the test against the code before the fix and it fails as expected:
```
        97 ┃     eligibileSlots <- H.evalEither eEligibileSlots
           ┃     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ┃     │ LeaderErrDecodeProtocolEpochStateFailure
           ┃     │   (DecoderErrorDeserialiseFailure
           ┃     │      "PoolDistr StandardCrypto"
           ┃     │      (DeserialiseFailure 0 "expected list len or indef"))
        98 ┃     eligibileSlots H.=== Set.fromList expectedEligibleSlots
```
See back-ported branch: [regression-test-deserialization2](https://github.com/IntersectMBO/cardano-api/tree/regression-test-deserialization2)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

