### PR TITLE
Remove check for DRep metadata size

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -969,8 +969,7 @@ module Cardano.Api (
     DRepExtendedKey,
     DRepMetadata,
     DRepMetadataReference,
-    DRepMetadataValidationError,
-    validateAndHashDRepMetadata,
+    hashDRepMetadata,
 
     -- ** Governance related certificates
     AnchorDataHash(..),


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    https://cips.cardano.org/cip/CIP-0119 proposes using a schema where the basic jsonld structure is heavier than 512. The agreement is that DBsync will set a limit for the size of metadata that is downloaded into the DB, but API or CLI do not need to impose any restrictions.
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

https://cips.cardano.org/cip/CIP-0119 proposes using a schema where the basic jsonld structure is heavier than 512.
https://github.com/cardano-foundation/CIPs/pull/835

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
