### PR TITLE
Release/8.50.0.0

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for cardano-api
 
+## 8.50.0.0
+
+- * Remove redundant era conversion functions. Use `toCardanoEra` instead.
+  * Add IO Exception handling to consensus query execution.
+  * Refactor Cardano.Api.Convenience.Query to return `ExceptT e IO a` instead of `IO (Either e a)`
+  (breaking, refactoring)
+  [PR 566](https://github.com/IntersectMBO/cardano-api/pull/566)
+
 ## 8.49.0.0
 
 - Make the query used by the CLI's `transaction build` return the current treasury value, so that command to do treasury donation doesn't require the user to pass it. Corresponding CLI PR: https://github.com/IntersectMBO/cardano-cli/pull/778

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-api
-version:                8.49.0.0
+version:                8.50.0.0
 synopsis:               The cardano API
 description:            The cardano API.
 category:               Cardano,


### PR DESCRIPTION
# Changelog

- * Remove redundant era conversion functions. Use `toCardanoEra` instead.
  * Add IO Exception handling to consensus query execution.
  * Refactor Cardano.Api.Convenience.Query to return `ExceptT e IO a` instead of `IO (Either e a)`
  (breaking, refactoring)
  [PR 566](https://github.com/IntersectMBO/cardano-api/pull/566)

```yaml
- description: |
    release cardano-api 8.50.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

For cardano-node 9.0.0

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
