### PR TITLE
Make ScriptDatum in spending scripts optional in accordance with CIP-0069

### DIFF
--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -766,7 +766,7 @@ instance Eq (ScriptWitness witctx era) where
 type ScriptRedeemer = HashableScriptData
 
 data ScriptDatum witctx where
-  ScriptDatumForTxIn :: HashableScriptData -> ScriptDatum WitCtxTxIn
+  ScriptDatumForTxIn :: Maybe HashableScriptData -> ScriptDatum WitCtxTxIn
   InlineScriptDatum :: ScriptDatum WitCtxTxIn
   NoScriptDatumForMint :: ScriptDatum WitCtxMint
   NoScriptDatumForStake :: ScriptDatum WitCtxStake

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -2301,7 +2301,7 @@ convScriptData sbe txOuts scriptWitnesses =
                               _
                               _
                               _
-                              (ScriptDatumForTxIn d)
+                              (ScriptDatumForTxIn (Just d))
                               _
                               _
                             )
@@ -2598,7 +2598,7 @@ makeShelleyTransactionBody
                       _
                       _
                       _
-                      (ScriptDatumForTxIn d)
+                      (ScriptDatumForTxIn (Just d))
                       _
                       _
                     )
@@ -2724,7 +2724,7 @@ makeShelleyTransactionBody
                       _
                       _
                       _
-                      (ScriptDatumForTxIn d)
+                      (ScriptDatumForTxIn (Just d))
                       _
                       _
                     )
@@ -2862,7 +2862,7 @@ makeShelleyTransactionBody
                       _
                       _
                       _
-                      (ScriptDatumForTxIn d)
+                      (ScriptDatumForTxIn (Just d))
                       _
                       _
                     )


### PR DESCRIPTION


# Changelog

```yaml
- description: |
    Make ScriptDatum in spending scripts optional in accordance with CIP-0069
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - compatible     # the API has changed but is non-breaking
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
