### PR TITLE
Add Classy versions of Era witness functions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eon.AllegraEraOnwards
   , allegraEraOnwardsConstraints
   , allegraEraOnwardsToShelleyBasedEra
   , AllegraEraOnwardsConstraints
+  , IsAllegraBasedEra (..)
   )
 where
 
@@ -109,3 +110,21 @@ allegraEraOnwardsToShelleyBasedEra = \case
   AllegraEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
   AllegraEraOnwardsBabbage -> ShelleyBasedEraBabbage
   AllegraEraOnwardsConway -> ShelleyBasedEraConway
+
+class IsAllegraBasedEra era where
+  allegraBasedEra :: AllegraEraOnwards era
+
+instance IsAllegraBasedEra AllegraEra where
+  allegraBasedEra = AllegraEraOnwardsAllegra
+
+instance IsAllegraBasedEra MaryEra where
+  allegraBasedEra = AllegraEraOnwardsMary
+
+instance IsAllegraBasedEra AlonzoEra where
+  allegraBasedEra = AllegraEraOnwardsAlonzo
+
+instance IsAllegraBasedEra BabbageEra where
+  allegraBasedEra = AllegraEraOnwardsBabbage
+
+instance IsAllegraBasedEra ConwayEra where
+  allegraBasedEra = AllegraEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eon.AlonzoEraOnwards
   , alonzoEraOnwardsConstraints
   , alonzoEraOnwardsToShelleyBasedEra
   , AlonzoEraOnwardsConstraints
+  , IsAlonzoBasedEra (..)
   )
 where
 
@@ -117,3 +118,15 @@ alonzoEraOnwardsToShelleyBasedEra = \case
   AlonzoEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
   AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
   AlonzoEraOnwardsConway -> ShelleyBasedEraConway
+
+class IsAlonzoBasedEra era where
+  alonzoBasedEra :: AlonzoEraOnwards era
+
+instance IsAlonzoBasedEra AlonzoEra where
+  alonzoBasedEra = AlonzoEraOnwardsAlonzo
+
+instance IsAlonzoBasedEra BabbageEra where
+  alonzoBasedEra = AlonzoEraOnwardsBabbage
+
+instance IsAlonzoBasedEra ConwayEra where
+  alonzoBasedEra = AlonzoEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eon.BabbageEraOnwards
   , babbageEraOnwardsConstraints
   , babbageEraOnwardsToShelleyBasedEra
   , BabbageEraOnwardsConstraints
+  , IsBabbageBasedEra (..)
   )
 where
 
@@ -111,3 +112,12 @@ babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra e
 babbageEraOnwardsToShelleyBasedEra = \case
   BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
   BabbageEraOnwardsConway -> ShelleyBasedEraConway
+
+class IsBabbageBasedEra era where
+  babbageBasedEra :: BabbageEraOnwards era
+
+instance IsBabbageBasedEra BabbageEra where
+  babbageBasedEra = BabbageEraOnwardsBabbage
+
+instance IsBabbageBasedEra ConwayEra where
+  babbageBasedEra = BabbageEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eon.ConwayEraOnwards
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToShelleyBasedEra
   , ConwayEraOnwardsConstraints
+  , IsConwayBasedEra (..)
   )
 where
 
@@ -112,3 +113,9 @@ conwayEraOnwardsConstraints = \case
 conwayEraOnwardsToShelleyBasedEra :: ConwayEraOnwards era -> ShelleyBasedEra era
 conwayEraOnwardsToShelleyBasedEra = \case
   ConwayEraOnwardsConway -> ShelleyBasedEraConway
+
+class IsConwayBasedEra era where
+  conwayBasedEra :: ConwayEraOnwards era
+
+instance IsConwayBasedEra ConwayEra where
+  conwayBasedEra = ConwayEraOnwardsConway

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Eon.MaryEraOnwards
   , maryEraOnwardsConstraints
   , maryEraOnwardsToShelleyBasedEra
   , MaryEraOnwardsConstraints
+  , IsMaryBasedEra (..)
   )
 where
 
@@ -109,3 +110,18 @@ maryEraOnwardsToShelleyBasedEra = \case
   MaryEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
   MaryEraOnwardsBabbage -> ShelleyBasedEraBabbage
   MaryEraOnwardsConway -> ShelleyBasedEraConway
+
+class IsMaryBasedEra era where
+  maryBasedEra :: MaryEraOnwards era
+
+instance IsMaryBasedEra MaryEra where
+  maryBasedEra = MaryEraOnwardsMary
+
+instance IsMaryBasedEra AlonzoEra where
+  maryBasedEra = MaryEraOnwardsAlonzo
+
+instance IsMaryBasedEra BabbageEra where
+  maryBasedEra = MaryEraOnwardsBabbage
+
+instance IsMaryBasedEra ConwayEra where
+  maryBasedEra = MaryEraOnwardsConway

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -79,26 +79,31 @@ module Cardano.Api
 
     -- ** From Allegra
   , AllegraEraOnwards (..)
+  , IsAllegraBasedEra (..)
 
     -- ** From Mary
   , MaryEraOnwards (..)
   , maryEraOnwardsConstraints
   , maryEraOnwardsToShelleyBasedEra
+  , IsMaryBasedEra (..)
 
     -- ** From Alonzo
   , AlonzoEraOnwards (..)
   , alonzoEraOnwardsConstraints
   , alonzoEraOnwardsToShelleyBasedEra
+  , IsAlonzoBasedEra (..)
 
     -- ** From Babbage
   , BabbageEraOnwards (..)
   , babbageEraOnwardsConstraints
   , babbageEraOnwardsToShelleyBasedEra
+  , IsBabbageBasedEra (..)
 
     -- ** From Conway
   , ConwayEraOnwards (..)
   , conwayEraOnwardsConstraints
   , conwayEraOnwardsToShelleyBasedEra
+  , IsConwayBasedEra (..)
 
     -- * Era case handling
 
@@ -501,6 +506,8 @@ module Cardano.Api
   , ScriptInEra (..)
   , toScriptInEra
   , eraOfScriptInEra
+  , HasScriptLanguageInEra (..)
+  , ToAlonzoScript (..)
 
     -- ** Use of a script in an era as a witness
   , WitCtxTxIn


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `IsAllegraBasedEra`, `IsAlonzoBasedEra`, `IsBabbageBasedEra`, `IsConwayBasedEra`, `IsMaryBasedEra` type classes.
    Add `ToAlonzoScript` and `HasScriptLanguageInEra` type classes.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Signed version of https://github.com/IntersectMBO/cardano-api/pull/537
* Also not on a clone, but on the true one cardano-api repo :copyright: 