### PR TITLE
Modify TxCertificates allow multiple script witnesses for a single stake credential

### DIFF
--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -477,7 +477,7 @@ estimateTransactionKeyWitnessCount
           _ -> 0
         + case txCertificates of
           TxCertificates _ _ (BuildTxWith witnesses) ->
-            length [() | KeyWitness{} <- Map.elems witnesses]
+            length [() | (_, KeyWitness{}) <- witnesses]
           _ -> 0
         + case txUpdateProposal of
           TxUpdateProposal _ (UpdateProposal updatePerGenesisKey _) ->
@@ -1517,10 +1517,10 @@ substituteExecutionUnits
               (ix, cert) <- zip [0 ..] certs
               , stakecred <- maybeToList (selectStakeCredentialWitness cert)
               , ScriptWitness ctx witness <-
-                  maybeToList (Map.lookup stakecred witnesses)
+                  maybeToList (List.lookup stakecred witnesses)
               , let witness' = substituteExecUnits (ScriptWitnessIndexCertificate ix) witness
               ]
-         in TxCertificates supported certs . BuildTxWith . Map.fromList
+         in TxCertificates supported certs . BuildTxWith
               <$> traverse
                 ( \(sCred, eScriptWitness) ->
                     case eScriptWitness of

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -1156,7 +1156,8 @@ data TxCertificates build era where
   TxCertificates
     :: ShelleyBasedEra era
     -> [Certificate era]
-    -> BuildTxWith build (Map StakeCredential (Witness WitCtxStake era))
+    -> BuildTxWith build [(StakeCredential, Witness WitCtxStake era)]
+    -- ^ There can be more than one script witness per stake credential
     -> TxCertificates build era
 
 deriving instance Eq (TxCertificates build era)
@@ -3157,7 +3158,7 @@ collectTxBodyScriptWitnesses
       (ix, cert) <- zip [0 ..] certs
       , ScriptWitness _ witness <- maybeToList $ do
           stakecred <- selectStakeCredentialWitness cert
-          Map.lookup stakecred witnesses
+          List.lookup stakecred witnesses
       ]
 
     scriptWitnessesMinting


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Modify TxCertificates allow multiple script witnesses for a single stake credential
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
