### PR TITLE
Fix missing month number in GHA cache key. Use the latest patch of toolchain tools

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,16 +20,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.4", "9.8.1"]
-        cabal: ["3.10.2.0"]
+        ghc: ["8.10.7", "9.6", "9.8"]
+        cabal: ["3.12"]
         sys:
           - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
           - { os: ubuntu-latest, shell: bash }
         include:
           # Using include, to make sure there will only be one macOS job, even if the matrix gets expanded later on.
           # We want a single job, because macOS runners are scarce.
-          - cabal: "3.10.2.0"
-            ghc: "9.6.4"
+          - cabal: "3.12"
+            ghc: "9.6"
             sys:
               os: macos-latest
               shell: bash
@@ -40,7 +40,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-02-29-golden"
+      CABAL_CACHE_VERSION: "2024-07-26"
       # these two are msys2 env vars, they have no effect on non-msys2 installs.
       MSYS2_PATH_TYPE: inherit
       MSYSTEM: MINGW64
@@ -98,7 +98,7 @@ jobs:
 
     # Use a fresh cache each month
     - name: Store month number as environment variable used in cache version
-      run:  echo "MONTHNUM=$(/usr/bin/date -u '+%m')" >> $GITHUB_ENV
+      run:  echo "MONTHNUM=$(date -u '+%m')" >> $GITHUB_ENV
 
     # From the dependency list we restore the cached dependencies.
     # We use the hash of `dependencies.txt` as part of the cache key because that will be stable
@@ -130,7 +130,7 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
         key:
-          cache-${{ env.CABAL_CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.MONTHNUM }}-${{ hashFiles('dependencies.txt') }}
+          ${{ steps.cache.outputs.cache-primary-key }}
 
     # Now we build.
     - name: Build all


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix missing month number in GHA cache key. Use the latest patch of toolchain tools
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
The same changes in cardano-node: https://github.com/IntersectMBO/cardano-node/pull/5921/files

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
