### PR TITLE
Deprecate createAndValidateTransactionBody

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -790,7 +790,7 @@ genValidTxBody sbe =
 -- | Partial! This function will throw an error when the generated transaction is invalid.
 genTxBody :: HasCallStack => ShelleyBasedEra era -> Gen (TxBody era)
 genTxBody era = do
-  res <- Api.createAndValidateTransactionBody era <$> genTxBodyContent era
+  res <- Api.createTransactionBody era <$> genTxBodyContent era
   case res of
     Left err -> error (docToString (prettyError err))
     Right txBody -> pure txBody

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -294,7 +294,7 @@ estimateBalancedTxBody
     let maxLovelaceFee = L.Coin (2 ^ (32 :: Integer) - 1)
     txbody1ForFeeEstimateOnly <-
       first TxFeeEstimationxBodyError $ -- TODO: impossible to fail now
-        createAndValidateTransactionBody
+        createTransactionBody
           sbe
           txbodycontent1
             { txFee = TxFeeExplicit sbe maxLovelaceFee
@@ -336,7 +336,7 @@ estimateBalancedTxBody
     --  3. Return and total collateral
     txbody2 <-
       first TxFeeEstimationxBodyError $ -- TODO: impossible to fail now
-        createAndValidateTransactionBody
+        createTransactionBody
           sbe
           txbodycontent1
             { txFee = TxFeeExplicit sbe fee
@@ -376,7 +376,7 @@ estimateBalancedTxBody
       first TxFeeEstimationFinalConstructionError $ -- TODO: impossible to fail now. We need to implement a function
       -- that simply creates a transaction body because we have already
       -- validated the transaction body earlier within makeTransactionBodyAutoBalance
-        createAndValidateTransactionBody sbe finalTxBodyContent
+        createTransactionBody sbe finalTxBodyContent
     return
       ( BalancedTxBody
           finalTxBodyContent

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -1853,6 +1853,7 @@ maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 maxTxOut :: Quantity
 maxTxOut = fromIntegral (maxBound :: Word64)
 
+{-# DEPRECATED createAndValidateTransactionBody "Use createTransactionBody instead" #-}
 createAndValidateTransactionBody
   :: ()
   => ShelleyBasedEra era
@@ -2815,10 +2816,7 @@ makeShelleyTransactionBody
           convPParamsToScriptIntegrityHash AlonzoEraOnwardsBabbage txProtocolParams redeemers datums languages
     let txbody =
           ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.collateralInputsTxBodyL azOn
-                .~ case txInsCollateral of
-                  TxInsCollateralNone -> Set.empty
-                  TxInsCollateral _ txins -> fromList (map toShelleyTxIn txins)
+              & A.collateralInputsTxBodyL azOn .~ convCollateralTxIns txInsCollateral
               & A.referenceInputsTxBodyL bOn .~ convReferenceInputs txInsReference
               & A.collateralReturnTxBodyL bOn .~ convReturnCollateral sbe txReturnCollateral
               & A.totalCollateralTxBodyL bOn .~ convTotalCollateral txTotalCollateral

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -280,6 +280,7 @@ module Cardano.Api
 
     -- ** Transaction bodies
   , TxBody (..)
+  , createTransactionBody
   , createAndValidateTransactionBody
   , makeByronTransactionBody
   , TxBodyContent (..)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecate createAndValidateTransactionBody. Use createTransactionBody instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
