### PR TITLE
Expose `querySPOStakeDistribution` query

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -30,6 +30,7 @@ module Cardano.Api.Query.Expr
   , L.CommitteeMembersState (..)
   , queryCommitteeMembersState
   , queryDRepStakeDistribution
+  , querySPOStakeDistribution
   , queryDRepState
   , queryGovState
   , queryStakeVoteDelegatees
@@ -415,6 +416,25 @@ queryDRepStakeDistribution
 queryDRepStakeDistribution era dreps = do
   let sbe = conwayEraOnwardsToShelleyBasedEra era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
+
+querySPOStakeDistribution
+  :: ()
+  => ConwayEraOnwards era
+  -> Set (L.KeyHash 'L.StakePool L.StandardCrypto)
+  -- ^ An empty SPO key hash set means that distributions for all SPOs will be returned
+  -> LocalStateQueryExpr
+      block
+      point
+      QueryInMode
+      r
+      IO
+      ( Either
+          UnsupportedNtcVersionError
+          (Either EraMismatch (Map (L.KeyHash 'L.StakePool L.StandardCrypto) L.Coin))
+      )
+querySPOStakeDistribution era spos = do
+  let sbe = conwayEraOnwardsToShelleyBasedEra era
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QuerySPOStakeDistr spos
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.
 -- If empty sets are passed as filters, then no filtering is done.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -970,6 +970,7 @@ module Cardano.Api
   , queryGovState
   , queryDRepState
   , queryDRepStakeDistribution
+  , querySPOStakeDistribution
   , queryCommitteeMembersState
   , queryStakeVoteDelegatees
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Exposed `querySPOStakeDistribution` query
  type:
  - feature        # introduces a new feature
```

# Context

We want to provide a governance query for stake distribution of stake pools to the `cardano-cli` (see [this issue](https://github.com/IntersectMBO/cardano-cli/issues/850)), so we need to be able to do the query through the `cardano-api`. This PR does just that, it exposes the new query.

Associated PRs:
- In `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/854
- In `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/5932

# How to trust this PR

I think the fact that it compiles is pretty telling. But maybe ensure that there is nothing missing to export, that it doesn't have any typos or so. And it is is quite based on the similar query for `dreps`s, so it is not difficult that I failed to change replace some of the DRep mentions, stay alert for those (I did double-check myself though).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
