### PR TITLE
Remove CPP extension from `Cardano.Api.Fees`.  Use `IsList(toList,fromList)` instead of specialised functions.

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -221,7 +221,6 @@ library internal
     transformers,
     transformers-except ^>=0.1.3,
     typed-protocols ^>=0.1.1,
-    unordered-containers >=0.2.11,
     vector,
     yaml,
 

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -95,7 +95,6 @@ import qualified Cardano.Ledger.Keys as Ledger
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import qualified Data.Foldable as Foldable
 import           Data.IP (IPv4, IPv6)
 import           Data.Maybe
 import qualified Data.Sequence.Strict as Seq
@@ -104,6 +103,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable
+import           GHC.Exts (IsList (..))
 import           Network.Socket (PortNumber)
 
 -- ----------------------------------------------------------------------------
@@ -678,11 +678,11 @@ fromShelleyPoolParams
       , stakePoolMargin = Ledger.unboundRational ppMargin
       , stakePoolRewardAccount = fromShelleyStakeAddr ppRewardAccount
       , stakePoolPledge = ppPledge
-      , stakePoolOwners = map StakeKeyHash (Set.toList ppOwners)
+      , stakePoolOwners = map StakeKeyHash (toList ppOwners)
       , stakePoolRelays =
           map
             fromShelleyStakePoolRelay
-            (Foldable.toList ppRelays)
+            (toList ppRelays)
       , stakePoolMetadata =
           fromShelleyPoolMetadata
             <$> Ledger.strictMaybeToMaybe ppMetadata

--- a/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
+++ b/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs
@@ -41,10 +41,10 @@ import qualified Data.ByteString.Char8 as BSC
 import           Data.Char (toLower)
 import           Data.Data (Data)
 import           Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import           Formatting (build, sformat, (%))
+import           GHC.Exts (IsList (..))
 import           Prettyprinter
 
 ------------------------------------------------------------------------------
@@ -113,7 +113,7 @@ deserialiseInput
   -> ByteString
   -> Either InputDecodeError a
 deserialiseInput asType acceptedFormats inputBs =
-  go (NE.toList acceptedFormats)
+  go (toList acceptedFormats)
  where
   inputText :: Text
   inputText = Text.decodeUtf8 inputBs

--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -127,8 +127,8 @@ import           Control.Monad.IO.Class
 import           Control.Tracer (nullTracer)
 import           Data.Aeson (ToJSON, object, toJSON, (.=))
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.Map.Strict as Map
 import           Data.Void (Void)
+import           GHC.Exts (IsList (..))
 
 -- ----------------------------------------------------------------------------
 -- The types for the client side of the node-to-client IPC protocols
@@ -255,7 +255,7 @@ mkVersionedProtocols networkid ptcl unversionedClients =
             }
           (protocols (unversionedClients ptclVersion) ptclBlockVersion ptclVersion)
     )
-    (Map.toList (Consensus.supportedNodeToClientVersions proxy))
+    (toList (Consensus.supportedNodeToClientVersions proxy))
  where
   proxy :: Proxy block
   proxy = Proxy

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -152,6 +152,7 @@ import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.String (IsString)
 import           Data.Text (Text)
 import           Data.Word
+import           GHC.Exts (IsList (..))
 import           GHC.Generics
 import           Lens.Micro
 import           Numeric.Natural
@@ -1014,7 +1015,7 @@ toAlonzoCostModels
   :: Map AnyPlutusScriptVersion CostModel
   -> Either ProtocolParametersConversionError Alonzo.CostModels
 toAlonzoCostModels m = do
-  f <- mapM conv $ Map.toList m
+  f <- mapM conv $ toList m
   Right $ Plutus.mkCostModels $ Map.fromList f
  where
   conv
@@ -1030,7 +1031,7 @@ fromAlonzoCostModels
 fromAlonzoCostModels cModels =
   Map.fromList
     . map (bimap fromAlonzoScriptLanguage fromAlonzoCostModel)
-    $ Map.toList
+    $ toList
     $ Plutus.costModelsValid cModels
 
 toAlonzoScriptLanguage :: AnyPlutusScriptVersion -> Plutus.Language

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -122,7 +122,6 @@ import           Data.Aeson.Types (Parser)
 import           Data.Bifunctor (bimap, first)
 import qualified Data.ByteString.Lazy as LBS
 import           Data.Either.Combinators (rightToMaybe)
-import qualified Data.HashMap.Strict as HMS
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
@@ -132,6 +131,7 @@ import           Data.SOP.Constraint (SListI)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
+import           GHC.Exts (IsList (..))
 import           GHC.Stack
 
 -- ----------------------------------------------------------------------------
@@ -374,7 +374,7 @@ instance
   => FromJSON (UTxO era)
   where
   parseJSON = withObject "UTxO" $ \hm -> do
-    let l = HMS.toList $ KeyMap.toHashMapText hm
+    let l = toList $ KeyMap.toHashMapText hm
     res <- mapM toTxIn l
     pure . UTxO $ Map.fromList res
    where
@@ -475,7 +475,7 @@ toShelleyAddrSet era =
     -- e.g. Shelley addresses in the Byron era, as these would not
     -- appear in the UTxO anyway.
     . mapMaybe (rightToMaybe . anyAddressInEra era)
-    . Set.toList
+    . toList
 
 toLedgerUTxO
   :: ()
@@ -487,7 +487,7 @@ toLedgerUTxO sbe (UTxO utxo) =
     $ Shelley.UTxO
       . Map.fromList
       . map (bimap toShelleyTxIn (toShelleyTxOut sbe))
-      . Map.toList
+      . toList
     $ utxo
 
 fromLedgerUTxO
@@ -500,7 +500,7 @@ fromLedgerUTxO sbe (Shelley.UTxO utxo) =
     $ UTxO
       . Map.fromList
       . map (bimap fromShelleyTxIn (fromShelleyTxOut sbe))
-      . Map.toList
+      . toList
     $ utxo
 
 fromShelleyPoolDistr
@@ -511,7 +511,7 @@ fromShelleyPoolDistr =
   -- Map.fromListAsc or to use Map.mapKeysMonotonic
   Map.fromList
     . map (bimap StakePoolKeyHash Consensus.individualPoolStake)
-    . Map.toList
+    . toList
     . Consensus.unPoolDistr
 
 fromShelleyDelegations
@@ -526,7 +526,7 @@ fromShelleyDelegations =
   -- do not match the one for StakeCredential
   Map.fromList
     . map (bimap fromShelleyStakeCredential StakePoolKeyHash)
-    . Map.toList
+    . toList
 
 fromShelleyRewardAccounts
   :: Shelley.RewardAccounts Consensus.StandardCrypto
@@ -536,7 +536,7 @@ fromShelleyRewardAccounts =
   -- Map.fromListAsc or to use Map.mapKeysMonotonic
   Map.fromList
     . map (first fromShelleyStakeCredential)
-    . Map.toList
+    . toList
 
 -- ----------------------------------------------------------------------------
 -- Conversions of queries into the consensus types.

--- a/cardano-api/internal/Cardano/Api/Rewards.hs
+++ b/cardano-api/internal/Cardano/Api/Rewards.hs
@@ -15,6 +15,7 @@ import           Data.List (nub)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as Vector
+import           GHC.Exts (IsList (..))
 
 -- | A mapping of Shelley reward accounts to both the stake pool that they
 -- delegate to and their reward account balance.
@@ -40,7 +41,7 @@ instance ToJSON DelegationsAndRewards where
 
 instance FromJSON DelegationsAndRewards where
   parseJSON = withArray "DelegationsAndRewards" $ \arr -> do
-    let vals = Vector.toList arr
+    let vals = toList arr
     decoded <- mapM decodeObject vals
     pure $ zipper decoded
    where

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -169,7 +169,6 @@ import qualified Data.Text.Encoding as Text
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Data.Typeable (Typeable)
 import           Data.Vector (Vector)
-import qualified Data.Vector as Vector
 import           Numeric.Natural (Natural)
 
 -- ----------------------------------------------------------------------------
@@ -1397,7 +1396,7 @@ parseScriptAtLeast =
       _ -> fail "\"atLeast\" script value not found"
 
 gatherSimpleScriptTerms :: Vector Value -> Aeson.Parser [SimpleScript]
-gatherSimpleScriptTerms = mapM parseSimpleScript . Vector.toList
+gatherSimpleScriptTerms = mapM parseSimpleScript . toList
 
 parseScriptSig :: Value -> Aeson.Parser SimpleScript
 parseScriptSig =

--- a/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
@@ -28,6 +28,7 @@ import qualified Data.List as List
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Text (Text)
+import           GHC.Exts (IsList (..))
 
 class (HasTypeProxy a, SerialiseAsRawBytes a) => SerialiseAsBech32 a where
   -- | The human readable prefix to use when encoding this value to Bech32.
@@ -151,7 +152,7 @@ instance Error Bech32DecodeError where
       mconcat
         [ "Unexpected Bech32 prefix: the actual prefix is " <> pshow actual
         , ", but it was expected to be "
-        , mconcat $ List.intersperse " or " (map pshow (Set.toList permitted))
+        , mconcat $ List.intersperse " or " (map pshow (toList permitted))
         ]
     Bech32DataPartToBytesError _dataPart ->
       mconcat

--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -117,6 +117,7 @@ import           Data.Maybe
 import qualified Data.Set as Set
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import qualified Data.Vector as Vector
+import           GHC.Exts (IsList (..))
 import           Lens.Micro
 
 -- ----------------------------------------------------------------------------
@@ -859,7 +860,7 @@ getByronTxBody (Byron.ATxAux{Byron.aTaTx = txbody}) = txbody
 getTxWitnessesByron :: Byron.ATxAux ByteString -> [KeyWitness ByronEra]
 getTxWitnessesByron (Byron.ATxAux{Byron.aTaWitness = witnesses}) =
   map ByronKeyWitness
-    . Vector.toList
+    . toList
     . unAnnotated
     $ witnesses
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove CPP extension from Cardano.Api.Fees and reformat
    Use `IsList(toList,fromList)` instead of specialised functions
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
This PR can be reviewed on commit-by-commit basis.

Removed `CPP` extension from `Cardano.Api.Fees` on redundant pattern matching.

Replaced specialized `toList` and `fromList` with `IsList(toList, fromList)` functions. This reduces mental overhead when writing code - you don't have to wonder which collection are you converting to/from anymore.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
