### PR TITLE
Show diff on failure in cabal-gild check action

### DIFF
--- a/.github/workflows/check-cabal-gild.yml
+++ b/.github/workflows/check-cabal-gild.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Run cabal-gild over all modified files
       run: |
         rc="0"
-        
+        echo "cabal-gild version: ${{env.CABAL_GILD_VERSION}}"        
         for file in $(git ls-files "*.cabal")
         do
           echo "cabal-gild --mode=check --input=$file"

--- a/.github/workflows/check-cabal-gild.yml
+++ b/.github/workflows/check-cabal-gild.yml
@@ -9,22 +9,22 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      CARDANO_GUILD_VERSION: "1.3.1.2"
+      CABAL_GILD_VERSION: "1.3.1.2"
 
     steps:
-    - name: Download cardano-gild
+    - name: Download cabal-gild
       run: |
-        cardano_gild_path="$(mktemp -d)"
-        version="${{env.CARDANO_GUILD_VERSION}}"
+        cabal_gild_path="$(mktemp -d)"
+        version="${{env.CABAL_GILD_VERSION}}"
         curl -sL \
           "https://github.com/tfausak/cabal-gild/releases/download/$version/cabal-gild-$version-linux-x64.tar.gz" \
-          | tar -C "$cardano_gild_path" -xz
+          | tar -C "$cabal_gild_path" -xz
 
-        echo "PATH=$cardano_gild_path:$PATH" >> "$GITHUB_ENV"
+        echo "PATH=$cabal_gild_path:$PATH" >> "$GITHUB_ENV"
 
     - uses: actions/checkout@v4
 
-    - name: Run cardano-gild over all modified files
+    - name: Run cabal-gild over all modified files
       run: |
         rc="0"
         
@@ -33,8 +33,13 @@ jobs:
           echo "cabal-gild --mode=check --input=$file"
           if ! cabal-gild --mode=check --input="$file"
           then
+            cabal-gild --mode=format --io="$file"
             echo "💣 $file is badly formatted. Fix it with:"
             echo "cabal-gild --mode=format --io=$file"
+            echo -e
+            echo "Diff for $file:"
+            git diff "$file"
+            echo -e
             rc="1"
           fi
         done


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added diff to output of cardano-gild check action
  type:
  - test           # fixes/modifies tests
```

# Context

It is nice to know what is wrong specifically with the formatting when CI fails, so this PR modifies the `cardano-gild` action to show a diff when it fails.

I am also using the opportunity to fix a wrong variable name.

Related PR on `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/857

# How to trust this PR

This is what happens when format check fails: [Failed run](https://github.com/IntersectMBO/cardano-api/actions/runs/10218919486/job/28276103781)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
