### PR TITLE
Use `IsList(toList,fromList)` instead of specialised functions

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api.hs
@@ -20,6 +20,7 @@ import           Cardano.Ledger.Shelley.TxAuxData (Metadatum (..), ShelleyTxAuxD
 
 import qualified Data.Map.Strict as Map
 import           Data.Word (Word64)
+import           GHC.Exts (IsList (..))
 
 import           Test.Gen.Cardano.Api.Typed (genCostModel, genRational)
 
@@ -32,7 +33,7 @@ genMetadata = do
   numberOfIndices <- Gen.integral (Range.linear 1 15)
   let indices = map (\i -> fromIntegral i :: Word64) [1 .. numberOfIndices]
   mData <- Gen.list (Range.singleton numberOfIndices) genMetadatum
-  return . ShelleyTxAuxData . Map.fromList $ zip indices mData
+  return . ShelleyTxAuxData . fromList $ zip indices mData
 
 genMetadatum :: Gen Metadatum
 genMetadatum = do

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Metadata.hs
@@ -15,11 +15,11 @@ import qualified Data.Aeson.Key as Aeson
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
-import qualified Data.Map.Strict as Map
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Word (Word64)
+import           GHC.Exts (IsList (..))
 
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
@@ -36,8 +36,7 @@ genJsonForTxMetadata mapping =
     Aeson.object
       <$> Gen.list
         (Range.linear 0 (fromIntegral sz))
-        ( (,)
-            <$> (Aeson.fromString . show <$> Gen.word64 Range.constantBounded)
+        ( ((,) . Aeson.fromString . show <$> Gen.word64 Range.constantBounded)
             <*> genJsonForTxMetadataValue mapping
         )
 
@@ -167,7 +166,7 @@ genJsonForTxMetadataValue TxMetadataJsonDetailedSchema = genJsonValue
 genTxMetadata :: Gen TxMetadata
 genTxMetadata =
   Gen.sized $ \sz ->
-    TxMetadata . Map.fromList
+    TxMetadata . fromList
       <$> Gen.list
         (Range.linear 0 (fromIntegral sz))
         ( (,)

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -175,9 +175,6 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Gen.QuickCheck as Q
 import qualified Hedgehog.Range as Range
 
-{- HLINT ignore "Reduce duplication" -}
-{- HLINT ignore "Use let" -}
-
 genAddressByron :: Gen (Address ByronAddr)
 genAddressByron =
   makeByronAddress
@@ -978,7 +975,7 @@ genProtocolParameters era = do
   protocolParamPoolPledgeInfluence <- genRationalInt64
   protocolParamMonetaryExpansion <- genRational
   protocolParamTreasuryCut <- genRational
-  protocolParamCostModels <- pure mempty
+  let protocolParamCostModels = mempty
   -- TODO: Babbage figure out how to deal with
   -- asymmetric cost model JSON instances
   protocolParamPrices <- Gen.maybe genExecutionUnitPrices

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -97,8 +97,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.IP (IPv4, IPv6)
 import           Data.Maybe
-import qualified Data.Sequence.Strict as Seq
-import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -610,10 +608,10 @@ toShelleyPoolParams
             (Ledger.boundRational stakePoolMargin)
       , Ledger.ppRewardAccount = toShelleyStakeAddr stakePoolRewardAccount
       , Ledger.ppOwners =
-          Set.fromList
+          fromList
             [kh | StakeKeyHash kh <- stakePoolOwners]
       , Ledger.ppRelays =
-          Seq.fromList
+          fromList
             (map toShelleyStakePoolRelay stakePoolRelays)
       , Ledger.ppMetadata =
           toShelleyPoolMetadata

--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -32,9 +32,9 @@ import qualified Cardano.Ledger.Keys as L
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
-import qualified Data.Set as Set
 import           Data.Text (Text)
 import qualified Data.Text as Text
+import           GHC.Exts (IsList (..))
 
 -- | Construct a balanced transaction.
 -- See Cardano.Api.Convenience.Query.queryStateForBalancedTx for a
@@ -120,7 +120,7 @@ renderNotScriptLockedTxInsError (ScriptLockedTxIns txins) =
 
 notScriptLockedTxIns :: [TxIn] -> UTxO era -> Either ScriptLockedTxInsError ()
 notScriptLockedTxIns collTxIns (UTxO utxo) = do
-  let onlyCollateralUTxOs = Map.restrictKeys utxo $ Set.fromList collTxIns
+  let onlyCollateralUTxOs = Map.restrictKeys utxo $ fromList collTxIns
       scriptLockedTxIns =
         filter (\(_, TxOut aInEra _ _ _) -> not $ isKeyAddress aInEra) $ Map.assocs onlyCollateralUTxOs
   if null scriptLockedTxIns

--- a/cardano-api/internal/Cardano/Api/Convenience/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Query.hs
@@ -54,9 +54,8 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
-import qualified Data.Set as Set
 import           Data.Text (Text)
-import           GHC.Exts (IsString (..))
+import           GHC.Exts (IsList (..), IsString (..))
 
 data QueryConvenienceError
   = AcqFailure AcquiringFailure
@@ -122,12 +121,12 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
     requireShelleyBasedEra era
       & onNothing (left ByronEraNotSupported)
 
-  let stakeCreds = Set.fromList $ mapMaybe filterUnRegCreds certs
-      drepCreds = Set.fromList $ mapMaybe filterUnRegDRepCreds certs
+  let stakeCreds = fromList $ mapMaybe filterUnRegCreds certs
+      drepCreds = fromList $ mapMaybe filterUnRegDRepCreds certs
 
   -- Query execution
   utxo <-
-    lift (queryUtxo sbe (QueryUTxOByTxIn (Set.fromList allTxIns)))
+    lift (queryUtxo sbe (QueryUTxOByTxIn (fromList allTxIns)))
       & onLeft (left . QceUnsupportedNtcVersion)
       & onLeft (left . QueryEraMismatch)
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -715,7 +715,7 @@ evaluateTransactionExecutionUnitsShelley sbe systemstart epochInfo (LedgerProtoc
         (Either (L.TransactionScriptFailure (ShelleyLedgerEra era)) (EvalTxExecutionUnitsLog, Alonzo.ExUnits))
     -> Map ScriptWitnessIndex (Either ScriptExecutionError (EvalTxExecutionUnitsLog, ExecutionUnits))
   fromLedgerScriptExUnitsMap aOnwards exmap =
-    Map.fromList
+    fromList
       [ ( toScriptIndex aOnwards rdmrptr
         , bimap (fromAlonzoScriptExecutionError aOnwards) (second fromAlonzoExUnits) exunitsOrFailure
         )
@@ -1349,7 +1349,7 @@ createFakeUTxO sbe txbodycontent totalAdaInUTxO =
             txOuts txbodycontent
    in -- Take one txin and one txout. Replace the out value with totalAdaInUTxO
       -- Return an empty UTxO if there are no txins or txouts
-      UTxO $ Map.fromList $ zip singleTxIn singleTxOut
+      UTxO $ fromList $ zip singleTxIn singleTxOut
 
 updateTxOut :: ShelleyBasedEra era -> Coin -> TxOut CtxUTxO era -> TxOut CtxUTxO era
 updateTxOut sbe updatedValue txout =
@@ -1567,7 +1567,7 @@ substituteExecutionUnits
 
       return $
         Just
-          (Featured era (TxVotingProcedures vProcedures (BuildTxWith $ Map.fromList substitutedExecutionUnits)))
+          (Featured era (TxVotingProcedures vProcedures (BuildTxWith $ fromList substitutedExecutionUnits)))
 
     mapScriptWitnessesProposals
       :: Maybe (Featured ConwayEraOnwards era (TxProposalProcedures build era))
@@ -1592,7 +1592,7 @@ substituteExecutionUnits
         Just
           ( Featured
               era
-              (TxProposalProcedures osetProposalProcedures (BuildTxWith $ Map.fromList substitutedExecutionUnits))
+              (TxProposalProcedures osetProposalProcedures (BuildTxWith $ fromList substitutedExecutionUnits))
           )
 
     mapScriptWitnessesMinting
@@ -1605,7 +1605,7 @@ substituteExecutionUnits
           value
           (BuildTxWith witnesses)
         ) =
-        -- TxMintValue supported value $ BuildTxWith $ Map.fromList
+        -- TxMintValue supported value $ BuildTxWith $ fromList
         let mappedScriptWitnesses
               :: [(PolicyId, Either (TxBodyErrorAutoBalance era) (ScriptWitness WitCtxMint era))]
             mappedScriptWitnesses =
@@ -1619,7 +1619,7 @@ substituteExecutionUnits
          in do
               final <- traverseScriptWitnesses mappedScriptWitnesses
               Right . TxMintValue supported value . BuildTxWith $
-                Map.fromList final
+                fromList final
 
 traverseScriptWitnesses
   :: [(a, Either (TxBodyErrorAutoBalance era) (ScriptWitness ctx era))]

--- a/cardano-api/internal/Cardano/Api/Governance/Poll.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Poll.hs
@@ -68,6 +68,7 @@ import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Builder as Text.Builder
 import           Data.Word (Word64)
 import           Formatting (build, sformat)
+import           GHC.Exts (IsList (..))
 
 -- | Associated metadata label as defined in CIP-0094
 pollMetadataLabel :: Word64
@@ -124,7 +125,7 @@ instance HasTypeProxy GovernancePoll where
 instance AsTxMetadata GovernancePoll where
   asTxMetadata GovernancePoll{govPollQuestion, govPollAnswers, govPollNonce} =
     makeTransactionMetadata $
-      Map.fromList
+      fromList
         [
           ( pollMetadataLabel
           , TxMetaMap $
@@ -220,7 +221,7 @@ instance HasTypeProxy GovernancePollAnswer where
 instance AsTxMetadata GovernancePollAnswer where
   asTxMetadata GovernancePollAnswer{govAnsPoll, govAnsChoice} =
     makeTransactionMetadata $
-      Map.fromList
+      fromList
         [
           ( pollMetadataLabel
           , TxMetaMap

--- a/cardano-api/internal/Cardano/Api/LedgerState.hs
+++ b/cardano-api/internal/Cardano/Api/LedgerState.hs
@@ -199,7 +199,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Short as BSS
-import           Data.Foldable
+import           Data.Foldable (asum)
 import           Data.IORef
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
@@ -219,6 +219,7 @@ import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Word
 import qualified Data.Yaml as Yaml
 import           Formatting.Buildable (build)
+import           GHC.Exts (IsList (..))
 import           Lens.Micro
 import           Network.TypedProtocol.Pipelined (Nat (..))
 import           System.FilePath
@@ -1885,7 +1886,7 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
         slotRangeOfInterest pp' =
           Set.filter
             (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp' ^. Core.ppDG))
-            $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
+            $ fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
     caseShelleyToAlonzoOrBabbageEraOnwards
       ( const
@@ -1999,7 +2000,7 @@ currentEpochEligibleLeadershipSlots sbe sGen eInfo pp ptclState poolid (VrfSigni
         slotRangeOfInterest pp' =
           Set.filter
             (not . Ledger.isOverlaySlot firstSlotOfEpoch (pp' ^. Core.ppDG))
-            $ Set.fromList [firstSlotOfEpoch .. lastSlotofEpoch]
+            $ fromList [firstSlotOfEpoch .. lastSlotofEpoch]
 
     caseShelleyToAlonzoOrBabbageEraOnwards
       ( const

--- a/cardano-api/internal/Cardano/Api/Orphans.hs
+++ b/cardano-api/internal/Cardano/Api/Orphans.hs
@@ -86,11 +86,14 @@ import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Short as SBS
 import           Data.Data (Data)
 import           Data.Kind (Constraint, Type)
+import           Data.ListMap (ListMap)
+import qualified Data.ListMap as ListMap
 import           Data.Maybe.Strict (StrictMaybe (..))
 import           Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Text
 import           Data.Typeable (Typeable)
+import           GHC.Exts (IsList (..))
 import           GHC.Generics
 import           GHC.Stack (HasCallStack)
 import           GHC.TypeLits
@@ -571,3 +574,9 @@ parsePlutusParamName t =
     Nothing -> fail $ "Cannot parse cost model parameter name: " <> T.unpack t
 
 deriving instance Show V2.ParamName
+
+-- TODO upstream to cardano-ledger
+instance IsList (ListMap k a) where
+  type Item (ListMap k a) = (k, a)
+  fromList = ListMap.fromList
+  toList = ListMap.toList

--- a/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/internal/Cardano/Api/ProtocolParameters.hs
@@ -18,9 +18,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 
-{- HLINT ignore "Redundant ==" -}
-{- HLINT ignore "Use mapM" -}
+{-# HLINT ignore "Redundant ==" #-}
 
 -- | The various Cardano protocol parameters, including:
 --
@@ -1016,7 +1016,7 @@ toAlonzoCostModels
   -> Either ProtocolParametersConversionError Alonzo.CostModels
 toAlonzoCostModels m = do
   f <- mapM conv $ toList m
-  Right $ Plutus.mkCostModels $ Map.fromList f
+  Right $ Plutus.mkCostModels $ fromList f
  where
   conv
     :: (AnyPlutusScriptVersion, CostModel)
@@ -1029,7 +1029,7 @@ fromAlonzoCostModels
   :: Plutus.CostModels
   -> Map AnyPlutusScriptVersion CostModel
 fromAlonzoCostModels cModels =
-  Map.fromList
+  fromList
     . map (bimap fromAlonzoScriptLanguage fromAlonzoCostModel)
     $ toList
     $ Plutus.costModelsValid cModels
@@ -1091,7 +1091,7 @@ makeShelleyUpdateProposal params genesisKeyHashes =
   -- TODO decide how to handle parameter validation
   --     for example we need to validate the Rational values can convert
   --     into the UnitInterval type ok.
-  UpdateProposal (Map.fromList [(kh, params) | kh <- genesisKeyHashes])
+  UpdateProposal (fromList [(kh, params) | kh <- genesisKeyHashes])
 
 -- ----------------------------------------------------------------------------
 -- Conversion functions: updates to ledger types

--- a/cardano-api/internal/Cardano/Api/Query.hs
+++ b/cardano-api/internal/Cardano/Api/Query.hs
@@ -380,7 +380,7 @@ instance
   parseJSON = withObject "UTxO" $ \hm -> do
     let l = toList $ KeyMap.toHashMapText hm
     res <- mapM toTxIn l
-    pure . UTxO $ Map.fromList res
+    pure . UTxO $ fromList res
    where
     toTxIn :: (Text, Aeson.Value) -> Parser (TxIn, TxOut CtxUTxO era)
     toTxIn (txinText, txOutVal) = do
@@ -473,7 +473,7 @@ toShelleyAddrSet
   -> Set AddressAny
   -> Set (Shelley.Addr Consensus.StandardCrypto)
 toShelleyAddrSet era =
-  Set.fromList
+  fromList
     . map toShelleyAddr
     -- Ignore any addresses that are not appropriate for the era,
     -- e.g. Shelley addresses in the Byron era, as these would not
@@ -489,7 +489,7 @@ toLedgerUTxO
 toLedgerUTxO sbe (UTxO utxo) =
   shelleyBasedEraConstraints sbe
     $ Shelley.UTxO
-      . Map.fromList
+      . fromList
       . map (bimap toShelleyTxIn (toShelleyTxOut sbe))
       . toList
     $ utxo
@@ -502,7 +502,7 @@ fromLedgerUTxO
 fromLedgerUTxO sbe (Shelley.UTxO utxo) =
   shelleyBasedEraConstraints sbe
     $ UTxO
-      . Map.fromList
+      . fromList
       . map (bimap fromShelleyTxIn (fromShelleyTxOut sbe))
       . toList
     $ utxo
@@ -513,7 +513,7 @@ fromShelleyPoolDistr
 fromShelleyPoolDistr =
   -- TODO: write an appropriate property to show it is safe to use
   -- Map.fromListAsc or to use Map.mapKeysMonotonic
-  Map.fromList
+  fromList
     . map (bimap StakePoolKeyHash Consensus.individualPoolStake)
     . toList
     . Consensus.unPoolDistr
@@ -528,7 +528,7 @@ fromShelleyDelegations =
   -- Map.fromListAsc or to use Map.mapKeysMonotonic
   -- In this case it may not be: the Ord instances for Shelley.Credential
   -- do not match the one for StakeCredential
-  Map.fromList
+  fromList
     . map (bimap fromShelleyStakeCredential StakePoolKeyHash)
     . toList
 
@@ -538,7 +538,7 @@ fromShelleyRewardAccounts
 fromShelleyRewardAccounts =
   -- TODO: write an appropriate property to show it is safe to use
   -- Map.fromListAsc or to use Map.mapKeysMonotonic
-  Map.fromList
+  fromList
     . map (first fromShelleyStakeCredential)
     . toList
 

--- a/cardano-api/internal/Cardano/Api/Rewards.hs
+++ b/cardano-api/internal/Cardano/Api/Rewards.hs
@@ -14,7 +14,6 @@ import qualified Data.Aeson.Types as Aeson
 import           Data.List (nub)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import qualified Data.Vector as Vector
 import           GHC.Exts (IsList (..))
 
 -- | A mapping of Shelley reward accounts to both the stake pool that they
@@ -27,7 +26,7 @@ newtype DelegationsAndRewards
 instance ToJSON DelegationsAndRewards where
   toJSON delegsAndRwds =
     Aeson.Array
-      . Vector.fromList
+      . fromList
       . map delegAndRwdToJson
       $ mergeDelegsAndRewards delegsAndRwds
    where

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -158,10 +158,8 @@ import qualified Data.ByteString.Lazy as LBS
 import           Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as SBS
 import           Data.Either.Combinators (maybeToRight)
-import           Data.Foldable (toList)
 import           Data.Functor
 import           Data.Scientific (toBoundedInteger)
-import qualified Data.Sequence.Strict as Seq
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -169,6 +167,7 @@ import qualified Data.Text.Encoding as Text
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Data.Typeable (Typeable)
 import           Data.Vector (Vector)
+import           GHC.Exts (IsList (..))
 import           Numeric.Natural (Natural)
 
 -- ----------------------------------------------------------------------------
@@ -1241,9 +1240,9 @@ toShelleyMultiSig = go
   go :: SimpleScript -> Either MultiSigError (Shelley.MultiSig (ShelleyLedgerEra ShelleyEra))
   go (RequireSignature (PaymentKeyHash kh)) =
     return $ Shelley.RequireSignature (Shelley.asWitness kh)
-  go (RequireAllOf s) = mapM go s <&> Shelley.RequireAllOf . Seq.fromList
-  go (RequireAnyOf s) = mapM go s <&> Shelley.RequireAnyOf . Seq.fromList
-  go (RequireMOf m s) = mapM go s <&> Shelley.RequireMOf m . Seq.fromList
+  go (RequireAllOf s) = mapM go s <&> Shelley.RequireAllOf . fromList
+  go (RequireAnyOf s) = mapM go s <&> Shelley.RequireAnyOf . fromList
+  go (RequireMOf m s) = mapM go s <&> Shelley.RequireMOf m . fromList
   go _ = Left MultiSigErrorTimelockNotsupported
 
 -- | Conversion for the 'Shelley.MultiSig' language used by the Shelley era.
@@ -1272,9 +1271,9 @@ toAllegraTimelock = go
   go :: SimpleScript -> Timelock.Timelock era
   go (RequireSignature (PaymentKeyHash kh)) =
     Shelley.RequireSignature (Shelley.asWitness kh)
-  go (RequireAllOf s) = Shelley.RequireAllOf (Seq.fromList (map go s))
-  go (RequireAnyOf s) = Shelley.RequireAnyOf (Seq.fromList (map go s))
-  go (RequireMOf m s) = Shelley.RequireMOf m (Seq.fromList (map go s))
+  go (RequireAllOf s) = Shelley.RequireAllOf (fromList (map go s))
+  go (RequireAnyOf s) = Shelley.RequireAnyOf (fromList (map go s))
+  go (RequireMOf m s) = Shelley.RequireMOf m (fromList (map go s))
   go (RequireTimeBefore t) = Allegra.RequireTimeExpire t
   go (RequireTimeAfter t) = Allegra.RequireTimeStart t
 

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -88,7 +88,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as Text.Lazy
-import qualified Data.Vector as Vector
 import           Data.Word
 import           GHC.Exts (IsList (..))
 
@@ -402,7 +401,7 @@ scriptDataToJsonNoSchema = conv . getScriptData
         Aeson.String s
     | otherwise =
         Aeson.String (bytesPrefix <> Text.decodeLatin1 (Base16.encode bs))
-  conv (ScriptDataList vs) = Aeson.Array (Vector.fromList (map conv vs))
+  conv (ScriptDataList vs) = Aeson.Array (fromList (map conv vs))
   conv (ScriptDataMap kvs) =
     Aeson.object
       [ (convKey k, conv v)
@@ -410,9 +409,9 @@ scriptDataToJsonNoSchema = conv . getScriptData
       ]
   conv (ScriptDataConstructor n vs) =
     Aeson.Array $
-      Vector.fromList
+      fromList
         [ Aeson.Number (fromInteger n)
-        , Aeson.Array (Vector.fromList (map conv vs))
+        , Aeson.Array (fromList (map conv vs))
         ]
 
   -- Script data allows any value as a key, not just string as JSON does.
@@ -522,18 +521,18 @@ scriptDataToJsonDetailedSchema = conv . getScriptData
   conv (ScriptDataList vs) =
     singleFieldObject "list"
       . Aeson.Array
-      $ Vector.fromList (map conv vs)
+      $ fromList (map conv vs)
   conv (ScriptDataMap kvs) =
     singleFieldObject "map"
       . Aeson.Array
-      $ Vector.fromList
+      $ fromList
         [ Aeson.object [("k", conv k), ("v", conv v)]
         | (k, v) <- kvs
         ]
   conv (ScriptDataConstructor n vs) =
     Aeson.object
       [ ("constructor", Aeson.Number (fromInteger n))
-      , ("fields", Aeson.Array (Vector.fromList (map conv vs)))
+      , ("fields", Aeson.Array (fromList (map conv vs)))
       ]
 
   singleFieldObject name v = Aeson.object [(name, v)]
@@ -642,7 +641,7 @@ instance Error ScriptDataJsonSchemaError where
         [ "JSON object does not match the schema.\nExpected a single field named "
         , "\"int\", \"bytes\", \"list\" or \"map\".\n"
         , "Unexpected object field(s): "
-        , pretty (LBS.unpack (Aeson.encode (KeyMap.fromList $ first Aeson.fromText <$> v)))
+        , pretty (LBS.unpack (Aeson.encode (fromList @Aeson.Object $ first Aeson.fromText <$> v)))
         ]
     ScriptDataJsonBadMapPair v ->
       mconcat

--- a/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseBech32.hs
@@ -26,7 +26,6 @@ import           Data.ByteString (ByteString)
 import           Data.Data (Data)
 import qualified Data.List as List
 import           Data.Set (Set)
-import qualified Data.Set as Set
 import           Data.Text (Text)
 import           GHC.Exts (IsList (..))
 
@@ -64,7 +63,7 @@ deserialiseFromBech32 asType bech32Str = do
   let actualPrefix = Bech32.humanReadablePartToText prefix
       permittedPrefixes = bech32PrefixesPermitted asType
   guard (actualPrefix `elem` permittedPrefixes)
-    ?! Bech32UnexpectedPrefix actualPrefix (Set.fromList permittedPrefixes)
+    ?! Bech32UnexpectedPrefix actualPrefix (fromList permittedPrefixes)
 
   payload <-
     Bech32.dataPartToBytes dataPart
@@ -120,7 +119,7 @@ deserialiseAnyOfFromBech32 types bech32Str = do
 
   permittedPrefixes :: Set Text
   permittedPrefixes =
-    Set.fromList $
+    fromList $
       concat
         [ bech32PrefixesPermitted ttoken
         | FromSomeType ttoken _f <- types

--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -116,7 +116,6 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe
 import qualified Data.Set as Set
 import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
-import qualified Data.Vector as Vector
 import           GHC.Exts (IsList (..))
 import           Lens.Micro
 
@@ -829,7 +828,7 @@ makeSignedByronTransaction witnesses txbody =
   Byron.annotateTxAux $
     Byron.mkTxAux
       (unAnnotated txbody)
-      (Vector.fromList [w | ByronKeyWitness w <- witnesses])
+      (fromList [w | ByronKeyWitness w <- witnesses])
 
 -- order of signing keys must match txins
 signByronTransaction
@@ -922,14 +921,14 @@ makeSignedTransaction
       L.mkBasicTx txbody
         & L.witsTxL
           .~ ( L.mkBasicTxWits
-                & L.addrTxWitsL .~ Set.fromList [w | ShelleyKeyWitness _ w <- witnesses]
+                & L.addrTxWitsL .~ fromList [w | ShelleyKeyWitness _ w <- witnesses]
                 & L.scriptTxWitsL
-                  .~ Map.fromList
+                  .~ fromList
                     [ (Ledger.hashScript @ledgerera sw, sw)
                     | sw <- txscripts
                     ]
                 & L.bootAddrTxWitsL
-                  .~ Set.fromList [w | ShelleyBootstrapWitness _ w <- witnesses]
+                  .~ fromList [w | ShelleyBootstrapWitness _ w <- witnesses]
              )
         & L.auxDataTxL .~ maybeToStrictMaybe txmetadata
 

--- a/cardano-api/internal/Cardano/Api/TxMetadata.hs
+++ b/cardano-api/internal/Cardano/Api/TxMetadata.hs
@@ -83,7 +83,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.Lazy as Text.Lazy
 import qualified Data.Text.Lazy.Builder as Text.Builder
-import qualified Data.Vector as Vector
 import           Data.Word
 import           GHC.Exts (IsList (..))
 
@@ -439,7 +438,7 @@ metadataFromJson schema =
     -- The top level has to be an object
     -- with unsigned integer (decimal or hex) keys
     Aeson.Object m ->
-      fmap (TxMetadata . Map.fromList)
+      fmap (TxMetadata . fromList)
         . mapM (uncurry metadataKeyPairFromJson)
         $ toList m
     _ -> Left TxMetadataJsonToplevelNotMap
@@ -520,7 +519,7 @@ metadataValueToJsonNoSchema = conv
           <> Text.decodeLatin1 (Base16.encode bs)
       )
   conv (TxMetaText txt) = Aeson.String txt
-  conv (TxMetaList vs) = Aeson.Array (Vector.fromList (map conv vs))
+  conv (TxMetaList vs) = Aeson.Array (fromList (map conv vs))
   conv (TxMetaMap kvs) =
     Aeson.object
       [ (convKey k, conv v)
@@ -635,11 +634,11 @@ metadataValueToJsonDetailedSchema = conv
   conv (TxMetaList vs) =
     singleFieldObject "list"
       . Aeson.Array
-      $ Vector.fromList (map conv vs)
+      $ fromList (map conv vs)
   conv (TxMetaMap kvs) =
     singleFieldObject "map"
       . Aeson.Array
-      $ Vector.fromList
+      $ fromList
         [ Aeson.object [("k", conv k), ("v", conv v)]
         | (k, v) <- kvs
         ]

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -294,7 +294,7 @@ fromMaryValue :: MaryValue StandardCrypto -> Value
 fromMaryValue (MaryValue (L.Coin lovelace) other) =
   Value $
     -- TODO: write QC tests to show it's ok to use Map.fromAscList here
-    Map.fromList $
+    fromList $
       [(AdaAssetId, Quantity lovelace) | lovelace /= 0]
         ++ [ (AssetId (fromMaryPolicyID pid) (fromMaryAssetName name), Quantity q)
            | (pid, name, q) <- Mary.flattenMultiAsset other

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Genesis.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Genesis.hs
@@ -22,8 +22,8 @@ import           Cardano.Ledger.Shelley.Genesis (emptyGenesisStaking)
 import           Cardano.Slotting.Slot (EpochSize (..))
 
 import           Data.ListMap (ListMap (ListMap))
-import qualified Data.Map.Strict as Map
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import           GHC.Exts (IsList (..))
 import           Lens.Micro
 
 import           Test.Cardano.Ledger.Shelley.Utils (unsafeBoundRational)
@@ -48,7 +48,7 @@ exampleShelleyGenesis =
           & ppMaxBBSizeL .~ 65535
           & ppMaxBHSizeL .~ 65535
     , sgGenDelegs =
-        Map.fromList
+        fromList
           [
             ( genesisVerKeyHash
             , GenDelegPair delegVerKeyHash delegVrfKeyHash

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/ProtocolParameters.hs
@@ -30,8 +30,8 @@ import           Data.ByteString.Lazy (ByteString)
 import           Data.Functor.Identity (Identity)
 import           Data.Int (Int64)
 import           Data.Map (Map)
-import qualified Data.Map as M
 import           Data.Proxy (Proxy (..))
+import           GHC.Exts (IsList (..))
 
 import           Hedgehog (Property, property, success)
 import qualified Hedgehog.Extras.Aeson as H
@@ -99,12 +99,12 @@ legacyCardanoApiProtocolParameters =
     , protocolParamMinUTxOValue = Just $ Coin 3_000_000
     , protocolParamMinPoolCost = Coin 3_500_000
     , protocolParamMaxValueSize = Just 10
-    , protocolParamMaxTxSize = 3000
+    , protocolParamMaxTxSize = 3_000
     , protocolParamMaxTxExUnits = Just executionUnits
     , protocolParamMaxCollateralInputs = Just 10
-    , protocolParamMaxBlockHeaderSize = 1200
+    , protocolParamMaxBlockHeaderSize = 1_200
     , protocolParamMaxBlockExUnits = Just executionUnits2
-    , protocolParamMaxBlockBodySize = 5000
+    , protocolParamMaxBlockBodySize = 5_000
     , protocolParamExtraPraosEntropy = Just $ makePraosNonce "entropyEntropy"
     , protocolParamDecentralization = Just 0.52
     , protocolParamCostModels = costModels
@@ -120,7 +120,7 @@ legacyCardanoApiProtocolParameters =
 
   costModels :: Map AnyPlutusScriptVersion CostModel
   costModels =
-    M.fromList
+    fromList
       [ (AnyPlutusScriptVersion PlutusScriptV3, CostModel [1 .. numParams PlutusV3])
       , (AnyPlutusScriptVersion PlutusScriptV2, CostModel [1 .. numParams PlutusV2])
       , (AnyPlutusScriptVersion PlutusScriptV1, CostModel [1 .. numParams PlutusV1])
@@ -132,13 +132,13 @@ legacyCardanoApiProtocolParameters =
   executionUnits :: ExecutionUnits
   executionUnits =
     ExecutionUnits
-      { executionSteps = 4300
-      , executionMemory = 2300
+      { executionSteps = 4_300
+      , executionMemory = 2_300
       }
 
   executionUnits2 :: ExecutionUnits
   executionUnits2 =
     ExecutionUnits
-      { executionSteps = 5600
-      , executionMemory = 3400
+      { executionSteps = 5_600
+      , executionMemory = 3_400
       }

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -52,6 +52,7 @@ import qualified Data.Map as Map
 import           Data.Maybe (fromJust)
 import qualified Data.Set as Set
 import           Data.Text (Text)
+import           GHC.Exts (IsList (..))
 import           GHC.Stack (HasCallStack)
 
 import qualified Test.Hedgehog.Golden.ErrorMessage as ErrorMessage
@@ -329,7 +330,7 @@ test_TransactionValidityError =
     [
       ( "TransactionValidityCostModelError"
       , TransactionValidityCostModelError
-          (Map.fromList [(AnyPlutusScriptVersion PlutusScriptV2, costModel)])
+          (fromList [(AnyPlutusScriptVersion PlutusScriptV2, costModel)])
           string
       )
       -- TODO Implement this when we get access to data constructors of PastHorizon or its fields' types' constructors
@@ -387,7 +388,7 @@ test_TxBodyErrorAutoBalance =
       ( "TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap"
       , TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap
           (ScriptWitnessIndexTxIn 1)
-          (Map.fromList [(ScriptWitnessIndexTxIn 2, ExecutionUnits 1 1)])
+          (fromList [(ScriptWitnessIndexTxIn 2, ExecutionUnits 1 1)])
       )
     ]
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/EpochLeadership.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/EpochLeadership.hs
@@ -38,8 +38,8 @@ import           Ouroboros.Network.Block (Serialised (..))
 import qualified Data.Map as Map
 import           Data.Proxy (Proxy (..))
 import           Data.Ratio ((%))
-import qualified Data.Set as Set
 import           Data.Time.Clock (secondsToNominalDiffTime)
+import           GHC.Exts (IsList (..))
 
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras as H
@@ -94,7 +94,7 @@ test_currentEpochEligibleLeadershipSlots =
           VrfKeyHash hash3 = verificationKeyHash $ getVerificationKey vrskey3
           poolDistr :: PoolDistr StandardCrypto =
             PoolDistr $
-              Map.fromList
+              fromList
                 [
                   ( KeyHash "a2927c1e43974b036d8e6838d410279266946e8a094895cfc748c91d"
                   , IndividualPoolStake
@@ -132,7 +132,7 @@ test_currentEpochEligibleLeadershipSlots =
               currentEpoch
           expectedEligibleSlots = [SlotNo 406, SlotNo 432, SlotNo 437, SlotNo 443, SlotNo 484]
       eligibleSlots <- H.evalEither eEligibleSlots
-      eligibleSlots H.=== Set.fromList expectedEligibleSlots
+      eligibleSlots H.=== fromList expectedEligibleSlots
  where
   encodeProtocolState
     :: ToCBOR (Consensus.ChainDepState (ConsensusProtocol era))

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Metadata.hs
@@ -16,6 +16,7 @@ import           Data.ByteString (ByteString)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
 import           Data.Word (Word64)
+import           GHC.Exts (IsList (..))
 import           GHC.Stack
 import           Text.InterpolatedString.Perl6
 
@@ -38,7 +39,7 @@ prop_golden_1 =
   matchMetadata
     TxMetadataJsonNoSchema
     [q|{"0": 1}|]
-    (TxMetadata (Map.fromList [(0, TxMetaNumber 1)]))
+    (TxMetadata (fromList [(0, TxMetaNumber 1)]))
 
 prop_golden_2 :: Property
 prop_golden_2 =
@@ -194,7 +195,7 @@ prop_golden_9 =
     )
 
 txMetadataSingleton :: Word64 -> TxMetadataValue -> TxMetadata
-txMetadataSingleton n v = TxMetadata (Map.fromList [(n, v)])
+txMetadataSingleton n v = TxMetadata (fromList [(n, v)])
 
 matchMetadata
   :: HasCallStack


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `IsList(toList,fromList)` instead of specialised functions
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

That's a follow-up from https://github.com/IntersectMBO/cardano-api/pull/603 , where some references to concrete collections' `fromList` & `toList` were still left in the codebase.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
