### PR TITLE
Adapt user-facing functions' names to Lovelace->Coin renaming

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -93,8 +93,8 @@ module Test.Gen.Cardano.Api.Typed
   , genTxInsReference
   , genTxMetadataInEra
   , genTxMintValue
-  , genLovelace
-  , genPositiveLovelace
+  , genCoin
+  , genPositiveCoin
   , genValue
   , genValueDefault
   , genVerificationKey
@@ -197,11 +197,11 @@ _genAddressInEraByron = byronAddressInEra <$> genAddressByron
 genKESPeriod :: Gen KESPeriod
 genKESPeriod = KESPeriod <$> Gen.word Range.constantBounded
 
-genLovelace :: Gen L.Coin
-genLovelace = L.Coin <$> Gen.integral (Range.linear 0 5000)
+genCoin :: Gen L.Coin
+genCoin = L.Coin <$> Gen.integral (Range.linear 0 5000)
 
-genPositiveLovelace :: Gen L.Coin
-genPositiveLovelace = L.Coin <$> Gen.integral (Range.linear 1 5000)
+genPositiveCoin :: Gen L.Coin
+genPositiveCoin = L.Coin <$> Gen.integral (Range.linear 1 5000)
 
 ----------------------------------------------------------------------------
 -- SimpleScript generators
@@ -631,7 +631,7 @@ genStakeAddressRequirements =
     )
     ( \w ->
         StakeAddrRegistrationConway w
-          <$> genLovelace
+          <$> genCoin
           <*> genStakeCredential
     )
 
@@ -736,10 +736,10 @@ genTxTotalCollateral :: CardanoEra era -> Gen (TxTotalCollateral era)
 genTxTotalCollateral =
   inEonForEra
     (pure TxTotalCollateralNone)
-    (\w -> TxTotalCollateral w <$> genPositiveLovelace)
+    (\w -> TxTotalCollateral w <$> genPositiveCoin)
 
 genTxFee :: ShelleyBasedEra era -> Gen (TxFee era)
-genTxFee w = TxFeeExplicit w <$> genLovelace
+genTxFee w = TxFeeExplicit w <$> genCoin
 
 genAddressInEraByron :: Gen (AddressInEra ByronEra)
 genAddressInEraByron = byronAddressInEra <$> genAddressByron
@@ -751,7 +751,7 @@ genTxByron = do
     <*> genTxBodyByron
 
 genTxOutValueByron :: Gen (TxOutValue ByronEra)
-genTxOutValueByron = TxOutValueByron <$> genPositiveLovelace
+genTxOutValueByron = TxOutValueByron <$> genPositiveCoin
 
 genTxOutByron :: Gen (TxOut CtxTx ByronEra)
 genTxOutByron =
@@ -964,12 +964,12 @@ genProtocolParameters era = do
   protocolParamMaxBlockHeaderSize <- genNat
   protocolParamMaxBlockBodySize <- genNat
   protocolParamMaxTxSize <- genNat
-  protocolParamTxFeeFixed <- genLovelace
-  protocolParamTxFeePerByte <- genLovelace
-  protocolParamMinUTxOValue <- Gen.maybe genLovelace
-  protocolParamStakeAddressDeposit <- genLovelace
-  protocolParamStakePoolDeposit <- genLovelace
-  protocolParamMinPoolCost <- genLovelace
+  protocolParamTxFeeFixed <- genCoin
+  protocolParamTxFeePerByte <- genCoin
+  protocolParamMinUTxOValue <- Gen.maybe genCoin
+  protocolParamStakeAddressDeposit <- genCoin
+  protocolParamStakePoolDeposit <- genCoin
+  protocolParamMinPoolCost <- genCoin
   protocolParamPoolRetireMaxEpoch <- genEpochInterval
   protocolParamStakePoolTargetNum <- genNat
   protocolParamPoolPledgeInfluence <- genRationalInt64
@@ -985,7 +985,7 @@ genProtocolParameters era = do
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
   protocolParamUTxOCostPerByte <-
-    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
+    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genCoin)) era
 
   pure ProtocolParameters{..}
 
@@ -1001,12 +1001,12 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxBlockHeaderSize <- Gen.maybe genWord16
   protocolUpdateMaxBlockBodySize <- Gen.maybe genWord32
   protocolUpdateMaxTxSize <- Gen.maybe genWord32
-  protocolUpdateTxFeeFixed <- Gen.maybe genLovelace
-  protocolUpdateTxFeePerByte <- Gen.maybe genLovelace
-  protocolUpdateMinUTxOValue <- Gen.maybe genLovelace
-  protocolUpdateStakeAddressDeposit <- Gen.maybe genLovelace
-  protocolUpdateStakePoolDeposit <- Gen.maybe genLovelace
-  protocolUpdateMinPoolCost <- Gen.maybe genLovelace
+  protocolUpdateTxFeeFixed <- Gen.maybe genCoin
+  protocolUpdateTxFeePerByte <- Gen.maybe genCoin
+  protocolUpdateMinUTxOValue <- Gen.maybe genCoin
+  protocolUpdateStakeAddressDeposit <- Gen.maybe genCoin
+  protocolUpdateStakePoolDeposit <- Gen.maybe genCoin
+  protocolUpdateMinPoolCost <- Gen.maybe genCoin
   protocolUpdatePoolRetireMaxEpoch <- Gen.maybe genEpochInterval
   protocolUpdateStakePoolTargetNum <- Gen.maybe genNat
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
@@ -1022,7 +1022,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateCollateralPercent <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
   protocolUpdateUTxOCostPerByte <-
-    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
+    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genCoin)) era
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -272,7 +272,7 @@ estimateBalancedTxBody
         availableUTxOValue =
           mconcat
             [ totalUTxOValue
-            , negateValue (lovelaceToValue totalDeposits)
+            , negateValue (coinToValue totalDeposits)
             ]
 
     let change = toLedgerValue w $ calculateChangeValue sbe availableUTxOValue txbodycontent1
@@ -341,7 +341,7 @@ estimateBalancedTxBody
             , txTotalCollateral = reqCol
             }
 
-    let fakeUTxO = createFakeUTxO sbe txbodycontent1 $ selectLovelace availableUTxOValue
+    let fakeUTxO = createFakeUTxO sbe txbodycontent1 $ selectCoin availableUTxOValue
         balance =
           evaluateTransactionBalance sbe pparams poolids stakeDelegDeposits drepDelegDeposits fakeUTxO txbody2
     -- check if the balance is positive or negative

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -952,7 +952,7 @@ txOutValueToLovelace tv =
 txOutValueToValue :: TxOutValue era -> Value
 txOutValueToValue tv =
   case tv of
-    TxOutValueByron l -> lovelaceToValue l
+    TxOutValueByron l -> coinToValue l
     TxOutValueShelleyBased sbe v -> fromLedgerValue sbe v
 
 prettyRenderTxOut :: TxOutInAnyEra -> Text
@@ -1683,7 +1683,7 @@ validateMintValue :: TxMintValue build era -> Either TxBodyError ()
 validateMintValue txMintValue =
   case txMintValue of
     TxMintNone -> return ()
-    TxMintValue _ v _ -> guard (selectLovelace v == 0) ?! TxBodyMintAdaError
+    TxMintValue _ v _ -> guard (selectCoin v == 0) ?! TxBodyMintAdaError
 
 inputIndexDoesNotExceedMax :: [(TxIn, a)] -> Either TxBodyError ()
 inputIndexDoesNotExceedMax txIns =
@@ -2171,8 +2171,8 @@ classifyRangeError :: TxOut CtxTx ByronEra -> TxBodyError
 classifyRangeError txout =
   case txout of
     TxOut (AddressInEra ByronAddressInAnyEra ByronAddress{}) (TxOutValueByron value) _ _
-      | value < 0 -> TxBodyOutputNegative (lovelaceToQuantity value) (txOutInAnyEra ByronEra txout)
-      | otherwise -> TxBodyOutputOverflow (lovelaceToQuantity value) (txOutInAnyEra ByronEra txout)
+      | value < 0 -> TxBodyOutputNegative (coinToQuantity value) (txOutInAnyEra ByronEra txout)
+      | otherwise -> TxBodyOutputOverflow (coinToQuantity value) (txOutInAnyEra ByronEra txout)
     TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _)) (TxOutValueShelleyBased w _) _ _ -> case w of {}
     TxOut (AddressInEra (ShelleyAddressInEra sbe) ShelleyAddress{}) _ _ _ -> case sbe of {}
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -247,10 +247,15 @@ module Cardano.Api
   , fromLedgerValue
 
     -- ** Ada \/ Lovelace within multi-asset values
+  , quantityToCoin
   , quantityToLovelace
+  , coinToQuantity
   , lovelaceToQuantity
+  , selectCoin
   , selectLovelace
+  , coinToValue
   , lovelaceToValue
+  , valueToCoin
   , valueToLovelace
 
     -- * Blocks


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecated some functions named `*Lovelace*`. Use the same ones with the `Coin` name instead (as advised in deprecation stanza).
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

As noticed by https://github.com/IntersectMBO/cardano-api/issues/607, when we removed the `Lovelace` type (and replaced it with the ledger's `Coin`), we did not adapt function names accordingly. This PR hence deprecates the `*Lovelace*` functions and advice to use the same ones with the `Coin` name instead.

Fixes https://github.com/IntersectMBO/cardano-api/issues/607

# How to trust this PR

* It's only renamings
* There are no `*Lovelace*` user-facing names anymore that are not deprecated
* The new `*Coin*` functions are correctly exported

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff