### PR TITLE
Fix datum conversion in 'fromShelleyTxOut' when using 'ShelleyBasedEraAlonzo' as input

### DIFF
--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Ledger.hs
@@ -14,6 +14,7 @@ import           Cardano.Ledger.Api.Tx.Address
 import           Cardano.Ledger.Crypto
 import           Cardano.Ledger.SafeHash
 
+import           Control.Monad
 import           Control.Monad.Identity
 
 import           Test.Gen.Cardano.Api.Typed
@@ -63,6 +64,12 @@ prop_roundtrip_scriptdata_plutusdata = H.property $ do
   sd <- getScriptData <$> forAll genHashableScriptData
   H.tripping sd toPlutusData (Identity . fromPlutusData)
 
+prop_roundtrip_ledger_txout :: Property
+prop_roundtrip_ledger_txout = H.property $ do
+  forM_ [minBound .. maxBound] $ \(AnyShelleyBasedEra era) -> do
+    txOut <- forAll $ genTxOutUTxOContext era
+    txOut H.=== fromShelleyTxOut era (toShelleyTxOut era txOut)
+
 -- -----------------------------------------------------------------------------
 
 tests :: TestTree
@@ -72,4 +79,5 @@ tests =
     [ testProperty "roundtrip Address CBOR" prop_roundtrip_Address_CBOR
     , testProperty "roundtrip ScriptData" prop_roundtrip_scriptdata_plutusdata
     , testProperty "script data bytes preserved" prop_original_scriptdata_bytes_preserved
+    , testProperty "roundtrip Ledger TxOut" prop_roundtrip_ledger_txout
     ]


### PR DESCRIPTION
Fix datum conversion in 'fromShelleyTxOut' when using 'ShelleyBasedEraAlonzo' as input

# Changelog

```yaml
- description: |
    Fix datum conversion in 'fromShelleyTxOut' when using 'ShelleyBasedEraAlonzo' as input
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
