### PR TITLE
Keep Coin as the user-facing name of functions

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -94,8 +94,8 @@ module Test.Gen.Cardano.Api.Typed
   , genTxInsReference
   , genTxMetadataInEra
   , genTxMintValue
-  , genCoin
-  , genPositiveCoin
+  , genLovelace
+  , genPositiveLovelace
   , genValue
   , genValueDefault
   , genVerificationKey
@@ -199,11 +199,11 @@ _genAddressInEraByron = byronAddressInEra <$> genAddressByron
 genKESPeriod :: Gen KESPeriod
 genKESPeriod = KESPeriod <$> Gen.word Range.constantBounded
 
-genCoin :: Gen L.Coin
-genCoin = L.Coin <$> Gen.integral (Range.linear 0 5000)
+genLovelace :: Gen L.Coin
+genLovelace = L.Coin <$> Gen.integral (Range.linear 0 5000)
 
-genPositiveCoin :: Gen L.Coin
-genPositiveCoin = L.Coin <$> Gen.integral (Range.linear 1 5000)
+genPositiveLovelace :: Gen L.Coin
+genPositiveLovelace = L.Coin <$> Gen.integral (Range.linear 1 5000)
 
 ----------------------------------------------------------------------------
 -- SimpleScript generators
@@ -632,7 +632,7 @@ genStakeAddressRequirements =
     )
     ( \w ->
         StakeAddrRegistrationConway w
-          <$> genCoin
+          <$> genLovelace
           <*> genStakeCredential
     )
 
@@ -737,10 +737,10 @@ genTxTotalCollateral :: CardanoEra era -> Gen (TxTotalCollateral era)
 genTxTotalCollateral =
   inEonForEra
     (pure TxTotalCollateralNone)
-    (\w -> TxTotalCollateral w <$> genPositiveCoin)
+    (\w -> TxTotalCollateral w <$> genPositiveLovelace)
 
 genTxFee :: ShelleyBasedEra era -> Gen (TxFee era)
-genTxFee w = TxFeeExplicit w <$> genCoin
+genTxFee w = TxFeeExplicit w <$> genLovelace
 
 genAddressInEraByron :: Gen (AddressInEra ByronEra)
 genAddressInEraByron = byronAddressInEra <$> genAddressByron
@@ -752,7 +752,7 @@ genTxByron = do
     <*> genTxBodyByron
 
 genTxOutValueByron :: Gen (TxOutValue ByronEra)
-genTxOutValueByron = TxOutValueByron <$> genPositiveCoin
+genTxOutValueByron = TxOutValueByron <$> genPositiveLovelace
 
 genTxOutByron :: Gen (TxOut CtxTx ByronEra)
 genTxOutByron =
@@ -979,12 +979,12 @@ genProtocolParameters era = do
   protocolParamMaxBlockHeaderSize <- genNat
   protocolParamMaxBlockBodySize <- genNat
   protocolParamMaxTxSize <- genNat
-  protocolParamTxFeeFixed <- genCoin
-  protocolParamTxFeePerByte <- genCoin
-  protocolParamMinUTxOValue <- Gen.maybe genCoin
-  protocolParamStakeAddressDeposit <- genCoin
-  protocolParamStakePoolDeposit <- genCoin
-  protocolParamMinPoolCost <- genCoin
+  protocolParamTxFeeFixed <- genLovelace
+  protocolParamTxFeePerByte <- genLovelace
+  protocolParamMinUTxOValue <- Gen.maybe genLovelace
+  protocolParamStakeAddressDeposit <- genLovelace
+  protocolParamStakePoolDeposit <- genLovelace
+  protocolParamMinPoolCost <- genLovelace
   protocolParamPoolRetireMaxEpoch <- genEpochInterval
   protocolParamStakePoolTargetNum <- genNat
   protocolParamPoolPledgeInfluence <- genRationalInt64
@@ -1000,7 +1000,7 @@ genProtocolParameters era = do
   protocolParamCollateralPercent <- Gen.maybe genNat
   protocolParamMaxCollateralInputs <- Gen.maybe genNat
   protocolParamUTxOCostPerByte <-
-    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genCoin)) era
+    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
 
   pure ProtocolParameters{..}
 
@@ -1016,12 +1016,12 @@ genProtocolParametersUpdate era = do
   protocolUpdateMaxBlockHeaderSize <- Gen.maybe genWord16
   protocolUpdateMaxBlockBodySize <- Gen.maybe genWord32
   protocolUpdateMaxTxSize <- Gen.maybe genWord32
-  protocolUpdateTxFeeFixed <- Gen.maybe genCoin
-  protocolUpdateTxFeePerByte <- Gen.maybe genCoin
-  protocolUpdateMinUTxOValue <- Gen.maybe genCoin
-  protocolUpdateStakeAddressDeposit <- Gen.maybe genCoin
-  protocolUpdateStakePoolDeposit <- Gen.maybe genCoin
-  protocolUpdateMinPoolCost <- Gen.maybe genCoin
+  protocolUpdateTxFeeFixed <- Gen.maybe genLovelace
+  protocolUpdateTxFeePerByte <- Gen.maybe genLovelace
+  protocolUpdateMinUTxOValue <- Gen.maybe genLovelace
+  protocolUpdateStakeAddressDeposit <- Gen.maybe genLovelace
+  protocolUpdateStakePoolDeposit <- Gen.maybe genLovelace
+  protocolUpdateMinPoolCost <- Gen.maybe genLovelace
   protocolUpdatePoolRetireMaxEpoch <- Gen.maybe genEpochInterval
   protocolUpdateStakePoolTargetNum <- Gen.maybe genNat
   protocolUpdatePoolPledgeInfluence <- Gen.maybe genRationalInt64
@@ -1037,7 +1037,7 @@ genProtocolParametersUpdate era = do
   protocolUpdateCollateralPercent <- Gen.maybe genNat
   protocolUpdateMaxCollateralInputs <- Gen.maybe genNat
   protocolUpdateUTxOCostPerByte <-
-    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genCoin)) era
+    inEonForEra @BabbageEraOnwards (pure Nothing) (const (Just <$> genLovelace)) era
 
   pure ProtocolParametersUpdate{..}
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -269,7 +269,7 @@ estimateBalancedTxBody
         availableUTxOValue =
           mconcat
             [ totalUTxOValue
-            , negateValue (coinToValue totalDeposits)
+            , negateValue (lovelaceToValue totalDeposits)
             ]
 
     let change = toLedgerValue w $ calculateChangeValue sbe availableUTxOValue txbodycontent1
@@ -338,7 +338,7 @@ estimateBalancedTxBody
             , txTotalCollateral = reqCol
             }
 
-    let fakeUTxO = createFakeUTxO sbe txbodycontent1 $ selectCoin availableUTxOValue
+    let fakeUTxO = createFakeUTxO sbe txbodycontent1 $ selectLovelace availableUTxOValue
         balance =
           evaluateTransactionBalance sbe pparams poolids stakeDelegDeposits drepDelegDeposits fakeUTxO txbody2
     -- check if the balance is positive or negative

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -969,7 +969,7 @@ txOutValueToLovelace tv =
 txOutValueToValue :: TxOutValue era -> Value
 txOutValueToValue tv =
   case tv of
-    TxOutValueByron l -> coinToValue l
+    TxOutValueByron l -> lovelaceToValue l
     TxOutValueShelleyBased sbe v -> fromLedgerValue sbe v
 
 prettyRenderTxOut :: TxOutInAnyEra -> Text
@@ -1781,7 +1781,7 @@ validateMintValue :: TxMintValue build era -> Either TxBodyError ()
 validateMintValue txMintValue =
   case txMintValue of
     TxMintNone -> return ()
-    TxMintValue _ v _ -> guard (selectCoin v == 0) ?! TxBodyMintAdaError
+    TxMintValue _ v _ -> guard (selectLovelace v == 0) ?! TxBodyMintAdaError
 
 inputIndexDoesNotExceedMax :: [(TxIn, a)] -> Either TxBodyError ()
 inputIndexDoesNotExceedMax txIns =
@@ -2264,8 +2264,8 @@ classifyRangeError :: TxOut CtxTx ByronEra -> TxBodyError
 classifyRangeError txout =
   case txout of
     TxOut (AddressInEra ByronAddressInAnyEra ByronAddress{}) (TxOutValueByron value) _ _
-      | value < 0 -> TxBodyOutputNegative (coinToQuantity value) (txOutInAnyEra ByronEra txout)
-      | otherwise -> TxBodyOutputOverflow (coinToQuantity value) (txOutInAnyEra ByronEra txout)
+      | value < 0 -> TxBodyOutputNegative (lovelaceToQuantity value) (txOutInAnyEra ByronEra txout)
+      | otherwise -> TxBodyOutputOverflow (lovelaceToQuantity value) (txOutInAnyEra ByronEra txout)
     TxOut (AddressInEra ByronAddressInAnyEra (ByronAddress _)) (TxOutValueShelleyBased w _) _ _ -> case w of {}
     TxOut (AddressInEra (ShelleyAddressInEra sbe) ShelleyAddress{}) _ _ _ -> case sbe of {}
 

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -99,16 +99,16 @@ import qualified Data.Text.Encoding as Text
 import           GHC.Exts (IsList (..))
 import           Lens.Micro ((%~))
 
-toByronLovelace :: L.Coin -> Maybe Byron.Lovelace
+toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
 toByronLovelace (L.Coin x) =
   case Byron.integerToLovelace x of
     Left _ -> Nothing
     Right x' -> Just x'
 
-fromByronLovelace :: Byron.Lovelace -> L.Coin
+fromByronLovelace :: Byron.Lovelace -> Lovelace
 fromByronLovelace = L.Coin . Byron.lovelaceToInteger
 
-fromShelleyDeltaLovelace :: L.DeltaCoin -> L.Coin
+fromShelleyDeltaLovelace :: L.DeltaCoin -> Lovelace
 fromShelleyDeltaLovelace (L.DeltaCoin d) = L.Coin d
 
 -- ----------------------------------------------------------------------------
@@ -128,10 +128,10 @@ instance Semigroup Quantity where
 instance Monoid Quantity where
   mempty = Quantity 0
 
-lovelaceToQuantity :: L.Coin -> Quantity
+lovelaceToQuantity :: Lovelace -> Quantity
 lovelaceToQuantity (L.Coin x) = Quantity x
 
-quantityToLovelace :: Quantity -> L.Coin
+quantityToLovelace :: Quantity -> Lovelace
 quantityToLovelace (Quantity x) = L.Coin x
 
 newtype PolicyId = PolicyId {unPolicyId :: ScriptHash}
@@ -247,18 +247,18 @@ negateLedgerValue sbe v =
 filterValue :: (AssetId -> Bool) -> Value -> Value
 filterValue p (Value m) = Value (Map.filterWithKey (\k _v -> p k) m)
 
-selectLovelace :: Value -> L.Coin
+selectLovelace :: Value -> Lovelace
 selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
 
-lovelaceToValue :: L.Coin -> Value
+lovelaceToValue :: Lovelace -> Value
 lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 
--- | Check if the 'Value' consists of /only/ 'L.Coin' and no other assets,
--- and if so then return the L.Coin.
+-- | Check if the 'Value' consists of /only/ 'Lovelace' and no other assets,
+-- and if so then return the Lovelace
 --
--- See also 'selectLovelace' to select the L.Coin quantity from the Value,
+-- See also 'selectLovelace' to select the Lovelace quantity from the Value,
 -- ignoring other assets.
-valueToLovelace :: Value -> Maybe L.Coin
+valueToLovelace :: Value -> Maybe Lovelace
 valueToLovelace v =
   case valueToList v of
     [] -> Just (L.Coin 0)
@@ -309,7 +309,7 @@ fromMaryValue (MaryValue (L.Coin lovelace) other) =
 
 -- | Calculate cost of making a UTxO entry for a given 'Value' and
 -- mininimum UTxO value derived from the 'ProtocolParameters'
-calcMinimumDeposit :: Value -> L.Coin -> L.Coin
+calcMinimumDeposit :: Value -> Lovelace -> Lovelace
 calcMinimumDeposit v =
   Mary.scaledMinDeposit (toMaryValue v)
 

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -27,6 +27,7 @@ module Cardano.Api.Value
   , calcMinimumDeposit
 
     -- ** Ada \/ L.Coin specifically
+  , Lovelace
   , quantityToLovelace
   , lovelaceToQuantity
   , selectLovelace
@@ -117,6 +118,9 @@ fromShelleyDeltaLovelace (L.DeltaCoin d) = L.Coin d
 newtype Quantity = Quantity Integer
   deriving stock Data
   deriving newtype (Eq, Ord, Num, Show, ToJSON, FromJSON)
+
+-- | A 'Coin' is a Lovelace.
+type Lovelace = L.Coin
 
 instance Semigroup Quantity where
   Quantity a <> Quantity b = Quantity (a + b)
@@ -249,9 +253,6 @@ selectLovelace = quantityToLovelace . flip selectAsset AdaAssetId
 lovelaceToValue :: L.Coin -> Value
 lovelaceToValue = Value . Map.singleton AdaAssetId . lovelaceToQuantity
 
-coinToValue :: L.Coin -> Value
-coinToValue = lovelaceToValue -- jky
-
 -- | Check if the 'Value' consists of /only/ 'L.Coin' and no other assets,
 -- and if so then return the L.Coin.
 --
@@ -286,7 +287,7 @@ toLedgerValue w = maryEraOnwardsConstraints w toMaryValue
 fromLedgerValue :: ShelleyBasedEra era -> L.Value (ShelleyLedgerEra era) -> Value
 fromLedgerValue sbe v =
   caseShelleyToAllegraOrMaryEraOnwards
-    (const (coinToValue v))
+    (const (lovelaceToValue v))
     (const (fromMaryValue v))
     sbe
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -248,6 +248,7 @@ module Cardano.Api
   , fromLedgerValue
 
     -- ** Ada \/ Lovelace within multi-asset values
+  , Lovelace
   , quantityToLovelace
   , lovelaceToQuantity
   , selectLovelace

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -248,15 +248,10 @@ module Cardano.Api
   , fromLedgerValue
 
     -- ** Ada \/ Lovelace within multi-asset values
-  , quantityToCoin
   , quantityToLovelace
-  , coinToQuantity
   , lovelaceToQuantity
-  , selectCoin
   , selectLovelace
-  , coinToValue
   , lovelaceToValue
-  , valueToCoin
   , valueToLovelace
 
     -- * Blocks


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `Lovelace` as a type synonym to `Coin`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Revert of https://github.com/IntersectMBO/cardano-api/pull/611
* A type synonym is added to show that the old `Lovelace` is now just the ledger's `Coin`

# How to trust this PR

1. Only adds a type synonym
2. Removes a private function
3. New type synonym is correctly exported

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff