### PR TITLE
Bump chap & hackage. Remove GHC 9.8 from GHA.

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6", "9.8", "9.10"]
+        ghc: ["8.10.7", "9.6", "9.10"]
         cabal: ["3.12"]
         sys:
           - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-07-30T01:49:10Z
-  , cardano-haskell-packages 2024-07-30T02:20:18Z
+  , hackage.haskell.org 2024-08-15T08:53:32Z
+  , cardano-haskell-packages 2024-08-15T10:40:33Z
 
 packages:
     cardano-api
@@ -44,17 +44,6 @@ test-show-details: direct
 
 -- Always write GHC env files, because they are needed for ghci.
 write-ghc-environment-files: always
-
-constraints:
-  , plutus-ledger-api ^>= 1.31
-
-allow-newer:
-  -- These are required due to the above.
-  , cardano-ledger-alonzo:plutus-ledger-api
-  , cardano-ledger-alonzo-test:plutus-ledger-api
-  , cardano-ledger-babbage:plutus-ledger-api
-  , cardano-ledger-binary:plutus-ledger-api
-  , cardano-ledger-conway:plutus-ledger-api
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1722231085,
-        "narHash": "sha256-IwLw5BCQNLIp9CJgtnGU5wrQ5dr1zZ5UhOFJTZPx3w8=",
+        "lastModified": 1723719216,
+        "narHash": "sha256-0RCMUZu1YthjOJUT6JHCfwxLZVobhTzx17nK7U745/I=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "843c3f288a53dd3f4f773413fc50201e003e0096",
+        "rev": "e4cfce4c4612111b0b51567cb4445a7740303f0e",
         "type": "github"
       },
       "original": {
@@ -205,11 +205,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1722817668,
-        "narHash": "sha256-J3K7hqhtwKZrMoXRsN+ENl5+REW3UlIaLsalIa0kDVE=",
+        "lastModified": 1723681836,
+        "narHash": "sha256-xM2vL6GdCRnBvxUbQrDjTfCbFKrtX+b/Uy0Eg3Z+XHg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "ee1d3454c8fd8124c1de1fb3df18c7d8bbf8ab61",
+        "rev": "227179361e9c1b2738aebab640fdf91e8846590b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bump chap & hackage
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Bump chap & hackage. Remove GHC 9.8 from GHA. 

`cardano-node` is not buildable with GHC 9.8 due to direct dependency on ghc in `locli` package, which pins `stm` version to a buggy 2.5.1. Thus it's not needed to test this version in CI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
