### PR TITLE
Experimental API: remove redundant type families and functions

### DIFF
--- a/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
+++ b/cardano-api/internal/Cardano/Api/Convenience/Construction.hs
@@ -17,8 +17,6 @@ where
 import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eon.ShelleyBasedEra
-import           Cardano.Api.Eon.ShelleyToAlonzoEra
-import           Cardano.Api.Eras
 import           Cardano.Api.Experimental.Eras
 import           Cardano.Api.Experimental.Tx
 import           Cardano.Api.Fees
@@ -96,10 +94,7 @@ constructBalancedTx
     let alternateKeyWits = map (makeKeyWitness availableEra unsignedTx) shelleyWitSigningKeys
         signedTx = signTx availableEra [] alternateKeyWits unsignedTx
 
-    caseShelleyToAlonzoOrBabbageEraOnwards
-      (Left . TxBodyErrorDeprecatedEra . DeprecatedEra . shelleyToAlonzoEraToShelleyBasedEra)
-      (\w -> return $ ShelleyTx sbe $ obtainShimConstraints w signedTx)
-      sbe
+    return $ ShelleyTx sbe $ obtainCommonConstraints availableEra signedTx
 
 data TxInsExistError
   = TxInsDoNotExist [TxIn]

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -9,8 +9,6 @@ module Cardano.Api.Experimental
   , signTx
   , convertTxBodyToUnsignedTx
   , EraCommonConstraints
-  , EraShimConstraints
-  , obtainShimConstraints
   , obtainCommonConstraints
   , hashTxBody
   , evaluateTransactionExecutionUnitsShelley
@@ -18,15 +16,13 @@ module Cardano.Api.Experimental
   , BabbageEra
   , ConwayEra
   , Era (..)
+  , IsEra (..)
+  , Some (..)
   , LedgerEra
-  , IsEra
-  , ApiEraToLedgerEra
-  , ExperimentalEraToApiEra
-  , ApiEraToExperimentalEra
   , DeprecatedEra (..)
-  , useEra
   , eraToSbe
   , babbageEraOnwardsToEra
+  , eraToBabbageEraOnwards
   , sbeToEra
   )
 where

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Typed/TxBody.hs
@@ -239,7 +239,7 @@ prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.pr
         address
         Nothing
   -- the correct amount with manual balancing of assets
-  335_729 === feeWithTxoutAsset
+  335_475 === feeWithTxoutAsset
 
   -- autobalanced body has assets and ADA in the change txout
   (BalancedTxBody balancedContent _ _ fee) <-


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix current treasury value in transaction building: default to `Nothing` instead of `0`.
    Experimental API: remove redundant type families and functions #625 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
Removes redundant type families - we don't need them for marking the experimental API eras and the old eras.

Fixes the default value for current treasury value in transaction building.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
