### PR TITLE
Draft the new, definite textEnvelopeType for Tx

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for cardano-api
 
+## 9.4.0.0 - UNRELEASED
+
+- **BREAKING** Text envelope type of `Tx era` is now always using the new `Witnessed Tx` prefix.
+
 ## 9.3.0.0
 - Upgrade `cardano-ledger-*`, `ouroboros-consensus-cardano`, `ouroboros-network-api`, `plutus-core` and `plutus-ledger-api`.
   (feature, breaking)

--- a/cardano-api/internal/Cardano/Api/Tx/Sign.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Sign.hs
@@ -280,13 +280,14 @@ getTxBody (ShelleyTx sbe tx) =
 
 instance IsShelleyBasedEra era => HasTextEnvelope (Tx era) where
   textEnvelopeType _ =
-    case shelleyBasedEra :: ShelleyBasedEra era of
-      ShelleyBasedEraShelley -> "TxSignedShelley"
-      ShelleyBasedEraAllegra -> "Tx AllegraEra"
-      ShelleyBasedEraMary -> "Tx MaryEra"
-      ShelleyBasedEraAlonzo -> "Tx AlonzoEra"
-      ShelleyBasedEraBabbage -> "Tx BabbageEra"
-      ShelleyBasedEraConway -> "Tx ConwayEra"
+    "Witnessed Tx" <>
+      case shelleyBasedEra :: ShelleyBasedEra era of
+        ShelleyBasedEraShelley -> "ShelleyEra"
+        ShelleyBasedEraAllegra -> "AllegraEra"
+        ShelleyBasedEraMary -> "MaryEra"
+        ShelleyBasedEraAlonzo -> "AlonzoEra"
+        ShelleyBasedEraBabbage -> "BabbageEra"
+        ShelleyBasedEraConway -> "ConwayEra"
 
 -- ----------------------------------------------------------------------------
 -- Transaction bodies


### PR DESCRIPTION
All transactions are now serialized and deserialized as 'Witnessed' transactions using the Ledger binary format.

# Changelog

```yaml
- description: |
    **BREAKING** Text envelope type of `Tx era` is now always using the new `Witnessed Tx` prefix.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Draft for the transaction envelope type that a cardano-api transaction should have going forward. Before, only `serialiseTxLedgerCddl` would produce the correctly parseable `Witnessed Tx ConwayEra` for example. However, that function is deprecated and we should fix the `serialiseToTextEnvelope` invocation for `Tx era` directly.

# How to trust this PR

There are probably several things missing and this is just a draft for how I, as a user, would want the cardano-api/-cli to operate (using a single `Witnessed Tx <era>` type).

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
