### PR TITLE
Add new types to CDDL list and test forward compatibility of `deserialiseTxLedgerCddl`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -338,6 +338,7 @@ test-suite cardano-api-test
     tasty,
     tasty-hedgehog,
     tasty-quickcheck,
+    text,
     time,
 
   other-modules:

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -12,6 +12,7 @@
 module Cardano.Api.SerialiseLedgerCddl
   ( TextEnvelopeCddlError (..)
   , FromSomeTypeCDDL (..)
+  , cddlTypeToEra
 
     -- * Reading one of several transaction or
 
@@ -315,32 +316,33 @@ deserialiseFromTextEnvelopeCddlAnyOf types teCddl =
 -- will make it easier to keep track of the different Cddl descriptions via
 -- a single sum data type.
 cddlTypeToEra :: Text -> Either TextEnvelopeCddlError AnyShelleyBasedEra
-cddlTypeToEra = \case
-  "TxSignedShelley" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
-  "Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
-  "Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
-  "Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
-  "Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
-  "Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
-  "Witnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
-  "Witnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
-  "Witnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
-  "Witnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
-  "Witnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
-  "Witnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
-  "Unwitnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
-  "Unwitnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
-  "Unwitnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
-  "Unwitnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
-  "Unwitnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
-  "Unwitnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
-  "TxWitness ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
-  "TxWitness AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
-  "TxWitness MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
-  "TxWitness AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
-  "TxWitness BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
-  "TxWitness ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
-  unknownCddlType -> Left $ TextEnvelopeCddlErrUnknownType unknownCddlType
+cddlTypeToEra =
+  \case
+    "TxSignedShelley" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
+    "Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
+    "Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
+    "Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
+    "Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
+    "Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Witnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
+    "Witnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
+    "Witnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
+    "Witnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
+    "Witnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
+    "Witnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Unwitnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
+    "Unwitnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
+    "Unwitnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
+    "Unwitnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
+    "Unwitnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
+    "Unwitnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "TxWitness ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
+    "TxWitness AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
+    "TxWitness MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
+    "TxWitness AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
+    "TxWitness BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
+    "TxWitness ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    unknownCddlType -> Left $ TextEnvelopeCddlErrUnknownType unknownCddlType
 
 readFileTextEnvelopeCddlAnyOf
   :: [FromSomeTypeCDDL TextEnvelope b]

--- a/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
+++ b/cardano-api/internal/Cardano/Api/SerialiseLedgerCddl.hs
@@ -316,6 +316,12 @@ deserialiseFromTextEnvelopeCddlAnyOf types teCddl =
 -- a single sum data type.
 cddlTypeToEra :: Text -> Either TextEnvelopeCddlError AnyShelleyBasedEra
 cddlTypeToEra = \case
+  "TxSignedShelley" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
+  "Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
+  "Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
+  "Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
+  "Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
+  "Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
   "Witnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
   "Witnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
   "Witnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/CBOR.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/CBOR.hs
@@ -33,6 +33,10 @@ import           Test.Tasty.Hedgehog (testProperty)
 -- TODO: Need to add PaymentExtendedKey roundtrip tests however
 -- we can't derive an Eq instance for Crypto.HD.XPrv
 
+-- This is the same test as prop_roundtrip_witness_CBOR but uses the
+-- new function `serialiseTxLedgerCddl` instead of the deprecated
+-- `serialiseToTextEnvelope`. `deserialiseTxLedgerCddl` must be
+-- compatible with both during the transition.
 prop_forward_compatibility_txbody_CBOR :: Property
 prop_forward_compatibility_txbody_CBOR = H.property $ do
   AnyShelleyBasedEra era <- H.noteShowM . H.forAll $ Gen.element [minBound .. maxBound]


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added new types to CDDL and added test for forward compatibility of `deserialiseTxLedgerCddl`
# uncomment types applicable to the change:
  type:
  - bugfix         # fixes a defect
  - test           # fixes/modifies tests
```

# Context

There was an issue with transactions created using the non-deprecated function `serialiseToTextEnvelope` as alternative to `serialiseTxLedgerCddl`. Because the implementation in `cardano-cli` still doesn't accept it.

This PR adds a test ensuring the `deserialiseTxLedgerCddl` function is compatible with `serialiseToTextEnvelope`.

It also adds the new types to the list of `cddlTypeToEra` conversion function, this is necessary for the corresponding fix in `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/892

# How to trust this PR

The change is small. Probably just make sure you agree with the direction of the change.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
