### PR TITLE
Remove optparse-applicative-fork dependency, and functions depending on it

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -197,7 +197,6 @@ library internal
     microlens-aeson,
     mtl,
     network,
-    optparse-applicative-fork,
     ouroboros-consensus ^>=0.20,
     ouroboros-consensus-cardano ^>=0.19,
     ouroboros-consensus-diffusion ^>=0.17,

--- a/cardano-api/internal/Cardano/Api/Utils.hs
+++ b/cardano-api/internal/Cardano/Api/Utils.hs
@@ -22,7 +22,6 @@ module Cardano.Api.Utils
   , readFileBlocking
   , runParsecParser
   , textShow
-  , modifyWith
 
     -- ** CLI option parsing
   , unsafeBoundedRational
@@ -106,14 +105,6 @@ readFileBlocking path =
 
 textShow :: Show a => a -> Text
 textShow = Text.pack . show
-
--- | Aids type inference.  Use this function to ensure the value is a function
--- that modifies a value.
-modifyWith
-  :: ()
-  => (a -> a)
-  -> (a -> a)
-modifyWith = id
 
 -- | Convert Rational to a bounded rational. Throw an exception when the rational is out of bounds.
 unsafeBoundedRational

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -926,7 +926,6 @@ module Cardano.Api
   , chainPointToSlotNo
   , chainPointToHeaderHash
   , makeChainTip
-  , parseFilePath
   , writeSecrets
 
     -- * Convenience functions
@@ -948,9 +947,6 @@ module Cardano.Api
   , txInsExistInUTxO
   , notScriptLockedTxIns
   , textShow
-
-    -- ** CLI option parsing
-  , bounded
 
     -- ** Query expressions
   , queryAccountState


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removes the dependency to `optparse-applicative-fork`, as it is unused internally and not useful for users.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

API depends on optparse-applicative-fork [here](https://github.com/IntersectMBO/cardano-api/blob/bf84187ae986f9a2621c55b690638fe8bb2cb156/cardano-api/cardano-api.cabal#L200). This dependency is not really useful and in addition it's a [fork](https://github.com/input-output-hk/optparse-applicative/commit/7497a29cb998721a9068d5725d49461f2bba0e7a) we depend on, not on the [main version](https://github.com/pcapriotti/optparse-applicative).

# How to trust this PR

1. Code compiles.
2. CLI PR adapting to this change exists: https://github.com/IntersectMBO/cardano-cli/pull/894

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff