### PR TITLE
Extra `HashableScriptData` in `TxBody` for PK inputs and reference inputs with hashed datums.

### DIFF
--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -1535,7 +1535,7 @@ substituteExecutionUnits
         :: (ScriptWitness witctx era -> Either (TxBodyErrorAutoBalance era) (ScriptWitness witctx era))
         -> Witness witctx era
         -> Either (TxBodyErrorAutoBalance era) (Witness witctx era)
-      adjustWitness _ (KeyWitness ctx) = Right $ KeyWitness ctx
+      adjustWitness _ (KeyWitness ctx witness') = Right $ KeyWitness ctx witness'
       adjustWitness g (ScriptWitness ctx witness') = ScriptWitness ctx <$> g witness'
 
     mapScriptWitnessesCertificates

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -54,11 +54,13 @@ module Cardano.Api.Script
   , WitCtxStake
   , WitCtx (..)
   , ScriptWitness (..)
+  , PrivateKeyWitness (..)
   , Witness (..)
   , KeyWitnessInCtx (..)
   , ScriptWitnessInCtx (..)
   , IsScriptWitnessInCtx (..)
   , ScriptDatum (..)
+  , KeyDatum (..)
   , ScriptRedeemer
   , scriptWitnessScript
 
@@ -722,6 +724,15 @@ data ScriptWitness witctx era where
 
 deriving instance Show (ScriptWitness witctx era)
 
+data PrivateKeyWitness witctx era where
+  PrivateKeyWitness
+    :: KeyDatum witctx
+    -> PrivateKeyWitness witctx era
+
+deriving instance Show (PrivateKeyWitness witctx era)
+
+deriving instance Eq (PrivateKeyWitness witctx era)
+
 -- The GADT in the SimpleScriptWitness constructor requires a custom instance
 instance Eq (ScriptWitness witctx era) where
   (==)
@@ -773,6 +784,14 @@ deriving instance Eq (ScriptDatum witctx)
 
 deriving instance Show (ScriptDatum witctx)
 
+data KeyDatum witctx where
+  KeyDatumForTxIn :: Maybe HashableScriptData -> KeyDatum WitCtxTxIn
+  NoKeyDatumForStake :: KeyDatum WitCtxStake
+
+deriving instance Eq (KeyDatum witctx)
+
+deriving instance Show (KeyDatum witctx)
+
 -- We cannot always extract a script from a script witness due to reference scripts.
 -- Reference scripts exist in the UTxO, so without access to the UTxO we cannot
 -- retrieve the script.
@@ -803,6 +822,7 @@ scriptWitnessScript (PlutusScriptWitness _ _ (PReferenceScript _ _) _ _ _) =
 data Witness witctx era where
   KeyWitness
     :: KeyWitnessInCtx witctx
+    -> PrivateKeyWitness witctx era
     -> Witness witctx era
   ScriptWitness
     :: ScriptWitnessInCtx witctx


### PR DESCRIPTION
This PR aims to solve issue #600 by allowing users to provide instances of `HashableScriptData` for hashed datums located:
* in reference inputs
* in regular inputs owned by private keys

For now, these data can only be provided:
* in outputs
* in regular inputs owned by scripts

This contribution intends to be as little invasive as possible, and to respect the current way of handling the creation of the data map provided in the script context. The map is currently built by browsing through the relevant parts of the body content and retrieving the relevant data there. Thus, the idea here is not to create a new field in the body content, but instead to allow user to add additional `HashableScriptData` at two addition locations in the body content. 