### PR TITLE
Make `IsXXXBasedEra` a class hierarchy

### DIFF
--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -111,7 +111,7 @@ allegraEraOnwardsToShelleyBasedEra = \case
   AllegraEraOnwardsBabbage -> ShelleyBasedEraBabbage
   AllegraEraOnwardsConway -> ShelleyBasedEraConway
 
-class IsAllegraBasedEra era where
+class IsShelleyBasedEra era => IsAllegraBasedEra era where
   allegraBasedEra :: AllegraEraOnwards era
 
 instance IsAllegraBasedEra AllegraEra where

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.AlonzoEraOnwards
   )
 where
 
+import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -119,7 +120,7 @@ alonzoEraOnwardsToShelleyBasedEra = \case
   AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
   AlonzoEraOnwardsConway -> ShelleyBasedEraConway
 
-class IsAlonzoBasedEra era where
+class IsMaryBasedEra era => IsAlonzoBasedEra era where
   alonzoBasedEra :: AlonzoEraOnwards era
 
 instance IsAlonzoBasedEra AlonzoEra where

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.BabbageEraOnwards
   )
 where
 
+import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -113,7 +114,7 @@ babbageEraOnwardsToShelleyBasedEra = \case
   BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
   BabbageEraOnwardsConway -> ShelleyBasedEraConway
 
-class IsBabbageBasedEra era where
+class IsAlonzoBasedEra era => IsBabbageBasedEra era where
   babbageBasedEra :: BabbageEraOnwards era
 
 instance IsBabbageBasedEra BabbageEra where

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -120,7 +120,7 @@ conwayEraOnwardsToBabbageEraOnwards :: ConwayEraOnwards era -> BabbageEraOnwards
 conwayEraOnwardsToBabbageEraOnwards = \case
   ConwayEraOnwardsConway -> BabbageEraOnwardsConway
 
-class IsConwayBasedEra era where
+class IsBabbageBasedEra era => IsConwayBasedEra era where
   conwayBasedEra :: ConwayEraOnwards era
 
 instance IsConwayBasedEra ConwayEra where

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.MaryEraOnwards
   )
 where
 
+import           Cardano.Api.Eon.AllegraEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -111,7 +112,7 @@ maryEraOnwardsToShelleyBasedEra = \case
   MaryEraOnwardsBabbage -> ShelleyBasedEraBabbage
   MaryEraOnwardsConway -> ShelleyBasedEraConway
 
-class IsMaryBasedEra era where
+class IsAllegraBasedEra era => IsMaryBasedEra era where
   maryBasedEra :: MaryEraOnwards era
 
 instance IsMaryBasedEra MaryEra where


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Make `IsXXXBasedEra` a class hierarchy
  type:
  - compatible
```

# Context

The PR makes `IsXXXBasedEra` a class hierarchy of one era being based of the next. I was surprised it's not the case in the code; I need to create a lot of dummy proofs like 
```
maryFromAlonzo :: IsAlonzoBasedEra era => (IsMaryBasedEra era => a) -> a
```
in my projects. 

# How to trust this PR

It's a QOL improvement, just explicitly states a true fact of eras forming a chain.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
