### PR TITLE
Expose functions and types from `cardano-ledger-alonzo` and `cardano-ledger-byron` required by cardano-cli

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -251,6 +251,7 @@ library
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,
+    cardano-ledger-byron,
     cryptonite,
     deepseq,
     memory,

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -87,15 +87,15 @@ module Cardano.Api.ReexposeLedger
   , csCommitteeCredsL
   -- Byron
   , Annotated (..)
-  , Byron.Tx (..)
   , byronProtVer
-  , serialize'
-  , toPlainDecoder
-  , toCBOR
-  , fromCBOR
+  , Byron.Tx (..)
   , ByteSpan (..)
-  , slice
   , Decoder
+  , fromCBOR
+  , serialize'
+  , slice
+  , toCBOR
+  , toPlainDecoder
   -- Shelley
   , secondsToNominalDiffTimeMicro
   -- Babbage

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -105,6 +105,7 @@ module Cardano.Api.ReexposeLedger
   , Prices (..)
   , CostModels
   , AlonzoGenesis
+  , AsIxItem (..)
   , ppPricesL
   -- Base
   , boundRational
@@ -142,7 +143,8 @@ where
 
 import qualified Cardano.Chain.UTxO as Byron
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
-import           Cardano.Ledger.Alonzo.Core (CoinPerWord (..), PParamsUpdate (..), ppPricesL)
+import           Cardano.Ledger.Alonzo.Core (AsIxItem (AsIxItem), CoinPerWord (..),
+                   PParamsUpdate (..), ppPricesL)
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Alonzo.Scripts (CostModels, Prices (..))
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,

--- a/cardano-api/internal/Cardano/Api/SpecialByron.hs
+++ b/cardano-api/internal/Cardano/Api/SpecialByron.hs
@@ -27,7 +27,7 @@ import qualified Cardano.Binary as Binary
 import           Cardano.Chain.Common (LovelacePortion, TxFeePolicy)
 import           Cardano.Chain.Slotting
 import           Cardano.Chain.Update (AProposal (aBody, annotation), InstallerHash,
-                   ProposalBody (ProposalBody), ProtocolParametersUpdate (..), ProtocolVersion,
+                   ProposalBody (ProposalBody), ProtocolParametersUpdate (..), ProtocolVersion (..),
                    SoftforkRule, SoftwareVersion, SystemTag, UpId, mkVote, recoverUpId,
                    recoverVoteId, signProposal)
 import qualified Cardano.Chain.Update as Update

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -180,7 +180,7 @@ module Cardano.Api
     -- * Payment addresses
 
     -- | Constructing and inspecting normal payment addresses
-  , Address
+  , Address (..)
   , ByronAddr
   , ShelleyAddr
   , NetworkId (..)

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -14,24 +14,10 @@ module Cardano.Api.Byron
     -- * Hashes
   , Hash (..)
 
-    -- * Payment addresses
-
-    -- | Constructing and inspecting Byron payment addresses
-  , Address (ByronAddress)
+    -- * Network identifier
   , NetworkId (Mainnet, Testnet)
 
-    -- * Building transactions
-
-    -- | Constructing and inspecting transactions
-  , TxId (TxId)
-  , TxIn (TxIn)
-  , TxOut (TxOut)
-  , TxIx (TxIx)
-
     -- * Signing transactions
-
-    -- | Creating transaction witnesses one by one, or all in one go.
-  , ATxAux (..)
 
     -- ** Incremental signing and separate witnesses
   , KeyWitness (ByronKeyWitness)
@@ -56,9 +42,6 @@ module Cardano.Api.Byron
 
     -- *** Local state query
   , LocalStateQueryClient (..)
-
-    -- * Address
-  , NetworkMagic (..)
 
     -- * Update Proposal
   , ByronUpdateProposal (..)
@@ -87,15 +70,117 @@ module Cardano.Api.Byron
     -- * Serialization
   , serializeByronTx
   , writeByronTxFileTextEnvelopeCddl
+
+    -- * Byron ledger re-exports
+
+    -- ** Address components
+  , AddrAttributes (..)
+  , Address
+  , KeyHash
+  , addressDetailedF
+  , addressF
+  , addressHash
+  , checkVerKeyAddress
+  , decodeAddressBase58
+  , mkAttributes
+
+    -- ** Lovelace handling
+  , Lovelace
+  , LovelacePortion
+  , lovelacePortionToRational
+  , mkKnownLovelace
+  , rationalToLovelacePortion
+
+    -- ** Genesis configuration and AVVM
+  , Config (..)
+  , FakeAvvmOptions (..)
+  , GeneratedSecrets (..)
+  , GenesisAvvmBalances (..)
+  , GenesisData (..)
+  , GenesisDataError (..)
+  , GenesisDataGenerationError (..)
+  , GenesisDelegation (..)
+  , GenesisDelegationError
+  , GenesisHash (..)
+  , GenesisInitializer (..)
+  , GenesisSpec (..)
+  , NetworkMagic (..)
+  , PoorSecret (..)
+  , TestnetBalanceOptions (..)
+  , TxFeePolicy (..)
+  , TxSizeLinear (..)
+  , generateGenesisData
+  , mkGenesisDelegation
+  , mkGenesisSpec
+  , readGenesisData
+
+    -- ** Updates
+  , ApplicationName (..)
+  , InstallerHash (..)
+  , NumSoftwareVersion
+  , Proposal
+  , ProtocolParameters (..)
+  , ProtocolVersion (..)
+  , SoftforkRule (..)
+  , SoftwareVersion (..)
+  , SystemTag (..)
+  , Vote
+  , checkApplicationName
+  , checkSystemTag
+
+    -- ** Blocks, slots, and epochs
+  , BlockCount (..)
+  , EpochNumber (..)
+  , SlotNumber (..)
+  , decCBORABlockOrBoundary
+
+    -- ** UTxO components
+  , ATxAux (..)
+  , CompactTxIn
+  , CompactTxOut
+  , TxIn (..)
+  , TxOut (..)
+  , UTxO (..)
+  , defaultUTxOConfiguration
+  , fromCompactTxIn
+  , fromCompactTxOut
+  , genesisUtxo
+
+    -- ** Delegation
+  , ACertificate (..)
+  , Certificate
+  , isValid
+  , signCertificate
   )
 where
 
-import           Cardano.Api
-import           Cardano.Api.Address
+import           Cardano.Api hiding (Address, Certificate, Lovelace, NetworkMagic, TxIn, TxOut,
+                   UTxO (..))
 import           Cardano.Api.Keys.Byron
-import           Cardano.Api.NetworkId
+import           Cardano.Api.NetworkId hiding (NetworkMagic)
 import           Cardano.Api.SerialiseLedgerCddl
 import           Cardano.Api.SpecialByron
-import           Cardano.Api.Tx.Body
-import           Cardano.Api.Tx.Sign
-import           Cardano.Api.Value
+import           Cardano.Api.Tx.Body hiding (TxIn, TxOut)
+import           Cardano.Api.Tx.Sign hiding (ATxAux (..))
+import           Cardano.Api.Value hiding (Lovelace)
+
+import           Cardano.Chain.Block (decCBORABlockOrBoundary)
+import           Cardano.Chain.Common (AddrAttributes (..), Address, BlockCount (..), KeyHash,
+                   Lovelace, LovelacePortion, NetworkMagic (..), TxFeePolicy (..),
+                   TxSizeLinear (..), addressDetailedF, addressF, addressHash, checkVerKeyAddress,
+                   decodeAddressBase58, lovelacePortionToRational, mkAttributes, mkKnownLovelace,
+                   rationalToLovelacePortion)
+import           Cardano.Chain.Delegation (ACertificate (..), Certificate, isValid, signCertificate)
+import           Cardano.Chain.Genesis (Config (..), FakeAvvmOptions (..), GeneratedSecrets (..),
+                   GenesisAvvmBalances (..), GenesisData (..), GenesisDataError (..),
+                   GenesisDataGenerationError (..), GenesisDelegation (..), GenesisDelegationError,
+                   GenesisHash (..), GenesisInitializer (..), GenesisSpec (..), PoorSecret (..),
+                   TestnetBalanceOptions (..), generateGenesisData, mkGenesisDelegation,
+                   mkGenesisSpec, readGenesisData)
+import           Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
+import           Cardano.Chain.Update (ApplicationName (..), InstallerHash (..), NumSoftwareVersion,
+                   Proposal, ProtocolParameters (..), ProtocolVersion (..), SoftforkRule (..),
+                   SoftwareVersion (..), SystemTag (..), Vote, checkApplicationName, checkSystemTag)
+import           Cardano.Chain.UTxO (ATxAux (..), CompactTxIn, CompactTxOut, TxIn (..), TxOut (..),
+                   UTxO (..), defaultUTxOConfiguration, fromCompactTxIn, fromCompactTxOut,
+                   genesisUtxo)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -19,7 +19,7 @@ import           Cardano.Api.Fees
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as L
 import           Cardano.Api.Script
-import           Cardano.Api.Shelley (Address (..), LedgerProtocolParameters (..))
+import           Cardano.Api.Shelley (LedgerProtocolParameters (..))
 
 import qualified Cardano.Ledger.Alonzo.Core as L
 import qualified Cardano.Ledger.Coin as L


### PR DESCRIPTION
### Note to self: write API changes in changelog before merging

# Changelog

```yaml
- description: |
    Exposed functions and types from cardano-ledger-alonzo, and cardano-ledger-byron required by cardano-cli.
    Breaking changes:
      * `Address` type and its constructor `ByronAddress` are no longer exported by `Cardano.Api.Byron`, but they are both exported by `Cardano.Api` now, together with `ShelleyAddress` constructor.
      * The types `TxId`, `TxIn`, `TxOut`, and `TxIx`, with their constructors are no longer exported by `Cardano.Api.Byron`.
  type:
  - breaking       # the API has changed in a breaking way
  - refactoring     # QoL changes
```

# Context

As part of the work targeted at addressing issues pointed out in https://github.com/IntersectMBO/cardano-api/issues/608, this PR aims to provide `cardano-cli` with everything it needs from ledger (in this PR `alonzo` and `byron` parts),

# How to trust this PR

Make sure it is just a refactoring for `cardano-cli`.

Make sure the way new things are exposed is sensible.

Look at it in conjunction with: https://github.com/IntersectMBO/cardano-cli/pull/920

Most commits are linked 1 to 1 with commits in the `cardano-cli` PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
