### PR TITLE
Expose remaining functions and types from `cardano-ledger-*` required by `cardano-cli`

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -764,7 +764,7 @@ genTxOutByron =
     <*> pure ReferenceScriptNone
 
 -- | Partial! It will throw if the generated transaction body is invalid.
-genTxBodyByron :: HasCallStack => Gen (L.Annotated L.Tx ByteString)
+genTxBodyByron :: HasCallStack => Gen (L.Annotated Byron.Tx ByteString)
 genTxBodyByron = do
   txIns <-
     map (,BuildTxWith (KeyWitness KeyWitnessForSpending)) <$> Gen.list (Range.constant 1 10) genTxIn

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -46,24 +46,27 @@ module Cardano.Api.ReexposeLedger
   , Coin (..)
   , EraPParams (..)
   , Era (..)
-  , ExUnits (..)
+  , EraTxOut
   , Network (..)
   , PoolCert (..)
   , PParams (..)
   , PParamsUpdate
+  , TxId (..)
+  , TxIn (..)
   , Value
   , addDeltaCoin
   , castSafeHash
   , toDeltaCoin
   , toEraCBOR
   , fromEraCBOR
+  , ppMinFeeAL
   , ppMinUTxOValueL
-  , unData
   -- Conway
   , Anchor (..)
   , Delegatee (..)
   , DRep (..)
   , DRepState (..)
+  , ConwayPlutusPurpose (..)
   , ConwayTxCert (..)
   , ConwayDelegCert (..)
   , ConwayEraTxCert (..)
@@ -91,7 +94,6 @@ module Cardano.Api.ReexposeLedger
   -- Byron
   , Annotated (..)
   , byronProtVer
-  , Byron.Tx (..)
   , ByteSpan (..)
   , Decoder
   , fromCBOR
@@ -107,12 +109,24 @@ module Cardano.Api.ReexposeLedger
   -- Babbage
   , CoinPerByte (..)
   -- Alonzo
+  , AlonzoEraTxBody (..)
+  , AlonzoEraScript (..)
+  , AlonzoEraTxWits (..)
+  , AlonzoPlutusPurpose (..)
+  , AsIx (..)
   , CoinPerWord (..)
+  , Data (..)
+  , ExUnits (..)
   , Prices (..)
   , CostModels
   , AlonzoGenesis
   , AsIxItem (..)
+  , EraGov
+  , EraTx (witsTxL, bodyTxL)
+  , Tx
   , ppPricesL
+  , unData
+  , unRedeemers
   -- Base
   , boundRational
   , unboundRational
@@ -132,6 +146,7 @@ module Cardano.Api.ReexposeLedger
   , UnitInterval
   , mkVersion
   , NonNegativeInterval
+  , txIxToInt
   -- Crypto
   , hashToBytes
   , hashFromBytes
@@ -147,12 +162,14 @@ module Cardano.Api.ReexposeLedger
   )
 where
 
-import qualified Cardano.Chain.UTxO as Byron
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
-import           Cardano.Ledger.Alonzo.Core (AsIxItem (AsIxItem), CoinPerWord (..),
-                   PParamsUpdate (..), ppPricesL)
+import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBody (..),
+                   AlonzoEraTxWits (..), AsIx (..), AsIxItem (AsIxItem), CoinPerWord (..), EraGov,
+                   EraTx (bodyTxL, witsTxL), PParamsUpdate (..), Tx, ppPricesL)
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
-import           Cardano.Ledger.Alonzo.Scripts (CostModels, Prices (..))
+import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), CostModels, ExUnits (..),
+                   Prices (..))
+import           Cardano.Ledger.Api (unRedeemers)
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
                    pattern DelegStakeTxCert, pattern DelegTxCert, pattern GenesisDelegTxCert,
                    pattern MirTxCert, pattern RegDRepTxCert, pattern RegDepositDelegTxCert,
@@ -163,8 +180,8 @@ import           Cardano.Ledger.Babbage.Core (CoinPerByte (..))
 import           Cardano.Ledger.BaseTypes (AnchorData (..), DnsName, EpochInterval (..),
                    Network (..), NonNegativeInterval, ProtVer (..), StrictMaybe (..), UnitInterval,
                    Url, boundRational, dnsToText, hashAnchorData, maybeToStrictMaybe, mkVersion,
-                   portToWord16, strictMaybeToMaybe, textToDns, textToUrl, unboundRational,
-                   urlToText)
+                   portToWord16, strictMaybeToMaybe, textToDns, textToUrl, txIxToInt,
+                   unboundRational, urlToText)
 import           Cardano.Ledger.Binary (Annotated (..), ByteSpan (..), byronProtVer, fromCBOR,
                    serialize', slice, toCBOR, toPlainDecoder)
 import           Cardano.Ledger.Binary.Plain (Decoder)
@@ -178,17 +195,17 @@ import           Cardano.Ledger.Conway.Governance (Anchor (..), GovActionId (..)
                    ProposalProcedure (..), Vote (..), Voter (..), VotingProcedure (..),
                    VotingProcedures (..))
 import           Cardano.Ledger.Conway.PParams (UpgradeConwayPParams (..))
+import           Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import           Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayEraTxCert (..),
                    ConwayGovCert (..), ConwayTxCert (..), Delegatee (..), pattern UpdateDRepTxCert)
-import           Cardano.Ledger.Core (Era (..), EraPParams (..), PParams (..), PoolCert (..), Value,
-                   fromEraCBOR, ppMinUTxOValueL, toEraCBOR)
+import           Cardano.Ledger.Core (Era (..), EraPParams (..), EraTxOut, PParams (..),
+                   PoolCert (..), Value, fromEraCBOR, ppMinFeeAL, ppMinUTxOValueL, toEraCBOR)
 import           Cardano.Ledger.Credential (Credential (..), credToText)
 import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import           Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
 import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VKey (..),
                    hashWithSerialiser)
-import           Cardano.Ledger.Plutus (ExUnits (..))
-import           Cardano.Ledger.Plutus.Data (unData)
+import           Cardano.Ledger.Plutus.Data (Data (..), unData)
 import           Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))
 import           Cardano.Ledger.SafeHash (SafeHash, castSafeHash, extractHash, unsafeMakeSafeHash)
 import           Cardano.Ledger.Shelley.API (AccountState (..), GenDelegPair (..),
@@ -199,4 +216,5 @@ import           Cardano.Ledger.Shelley.LedgerState (PState (..))
 import           Cardano.Ledger.Shelley.TxCert (EraTxCert (..), GenesisDelegCert (..), MIRCert (..),
                    MIRPot (..), MIRTarget (..), ShelleyDelegCert (..), ShelleyEraTxCert (..),
                    ShelleyTxCert (..))
+import           Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import           Cardano.Slotting.Slot (EpochNo (..))

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -98,6 +98,9 @@ module Cardano.Api.ReexposeLedger
   , toPlainDecoder
   -- Shelley
   , secondsToNominalDiffTimeMicro
+  , AccountState (..)
+  , NewEpochState (..)
+  , ShelleyGenesisStaking (..)
   -- Babbage
   , CoinPerByte (..)
   -- Alonzo
@@ -183,9 +186,10 @@ import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VK
                    hashWithSerialiser)
 import           Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))
 import           Cardano.Ledger.SafeHash (SafeHash, extractHash, unsafeMakeSafeHash)
-import           Cardano.Ledger.Shelley.API (GenDelegPair (..), StakeReference (..), WitVKey (..),
-                   hashKey, hashVerKeyVRF)
-import           Cardano.Ledger.Shelley.Genesis (secondsToNominalDiffTimeMicro)
+import           Cardano.Ledger.Shelley.API (AccountState (..), GenDelegPair (..),
+                   NewEpochState (..), StakeReference (..), WitVKey (..), hashKey, hashVerKeyVRF)
+import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesisStaking (..),
+                   secondsToNominalDiffTimeMicro)
 import           Cardano.Ledger.Shelley.LedgerState (PState (..))
 import           Cardano.Ledger.Shelley.TxCert (EraTxCert (..), GenesisDelegCert (..), MIRCert (..),
                    MIRPot (..), MIRTarget (..), ShelleyDelegCert (..), ShelleyEraTxCert (..),

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -46,16 +46,19 @@ module Cardano.Api.ReexposeLedger
   , Coin (..)
   , EraPParams (..)
   , Era (..)
+  , ExUnits (..)
   , Network (..)
   , PoolCert (..)
   , PParams (..)
   , PParamsUpdate
   , Value
   , addDeltaCoin
+  , castSafeHash
   , toDeltaCoin
   , toEraCBOR
   , fromEraCBOR
   , ppMinUTxOValueL
+  , unData
   -- Conway
   , Anchor (..)
   , Delegatee (..)
@@ -184,8 +187,10 @@ import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import           Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
 import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VKey (..),
                    hashWithSerialiser)
+import           Cardano.Ledger.Plutus (ExUnits (..))
+import           Cardano.Ledger.Plutus.Data (unData)
 import           Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))
-import           Cardano.Ledger.SafeHash (SafeHash, extractHash, unsafeMakeSafeHash)
+import           Cardano.Ledger.SafeHash (SafeHash, castSafeHash, extractHash, unsafeMakeSafeHash)
 import           Cardano.Ledger.Shelley.API (AccountState (..), GenDelegPair (..),
                    NewEpochState (..), StakeReference (..), WitVKey (..), hashKey, hashVerKeyVRF)
 import           Cardano.Ledger.Shelley.Genesis (ShelleyGenesisStaking (..),

--- a/cardano-api/src/Cardano/Api/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Byron.hs
@@ -138,6 +138,7 @@ module Cardano.Api.Byron
   , ATxAux (..)
   , CompactTxIn
   , CompactTxOut
+  , Tx (..)
   , TxIn (..)
   , TxOut (..)
   , UTxO (..)
@@ -154,14 +155,14 @@ module Cardano.Api.Byron
   )
 where
 
-import           Cardano.Api hiding (Address, Certificate, Lovelace, NetworkMagic, TxIn, TxOut,
-                   UTxO (..))
+import           Cardano.Api hiding (Address, Certificate, Lovelace, NetworkMagic, Tx (..), TxIn,
+                   TxOut, UTxO (..))
 import           Cardano.Api.Keys.Byron
 import           Cardano.Api.NetworkId hiding (NetworkMagic)
 import           Cardano.Api.SerialiseLedgerCddl
 import           Cardano.Api.SpecialByron
 import           Cardano.Api.Tx.Body hiding (TxIn, TxOut)
-import           Cardano.Api.Tx.Sign hiding (ATxAux (..))
+import           Cardano.Api.Tx.Sign hiding (ATxAux (..), Tx (..))
 import           Cardano.Api.Value hiding (Lovelace)
 
 import           Cardano.Chain.Block (decCBORABlockOrBoundary)
@@ -181,6 +182,6 @@ import           Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
 import           Cardano.Chain.Update (ApplicationName (..), InstallerHash (..), NumSoftwareVersion,
                    Proposal, ProtocolParameters (..), ProtocolVersion (..), SoftforkRule (..),
                    SoftwareVersion (..), SystemTag (..), Vote, checkApplicationName, checkSystemTag)
-import           Cardano.Chain.UTxO (ATxAux (..), CompactTxIn, CompactTxOut, TxIn (..), TxOut (..),
-                   UTxO (..), defaultUTxOConfiguration, fromCompactTxIn, fromCompactTxOut,
-                   genesisUtxo)
+import           Cardano.Chain.UTxO (ATxAux (..), CompactTxIn, CompactTxOut, Tx (..), TxIn (..),
+                   TxOut (..), UTxO (..), defaultUTxOConfiguration, fromCompactTxIn,
+                   fromCompactTxOut, genesisUtxo)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Expose transitive dependencies from `cardano-ledger` needed by `cardano-cli`
    Breaking change: `Cardano.Api.Ledger` no longer exports Byron's `Tx` but it is now exported in `Cardano.Api.Byron`
  type:
  - breaking       # the API has changed in a breaking way
```

# Context

As part of the work targeted at addressing issues pointed out in https://github.com/IntersectMBO/cardano-api/issues/608, this PR aims to provide `cardano-cli` with everything it needs from ledger.

# How to trust this PR

Make sure it is just a refactoring.

Look at it in conjunction with: https://github.com/IntersectMBO/cardano-cli/pull/941

Take advantage that there are one commit for `shelley`, one for `core`, and one for `api` (same for the corresponding PR in cardano-cli)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
