### PR TITLE
Use correct pattern for stake deregistration certs in Conway

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -526,12 +526,10 @@ filterUnRegCreds =
         Ledger.GenesisDelegTxCert{} -> Nothing
     ConwayCertificate cEra conwayCert -> conwayEraOnwardsConstraints cEra $
       case conwayCert of
-        Ledger.RegTxCert _ -> Nothing
-        Ledger.UnRegTxCert cred -> Just cred
         Ledger.RegPoolTxCert _ -> Nothing
         Ledger.RetirePoolTxCert _ _ -> Nothing
         Ledger.RegDepositTxCert _ _ -> Nothing
-        Ledger.UnRegDepositTxCert _ _ -> Nothing
+        Ledger.UnRegDepositTxCert cred _ -> Just cred
         Ledger.DelegTxCert _ _ -> Nothing
         Ledger.RegDepositDelegTxCert{} -> Nothing
         Ledger.AuthCommitteeHotKeyTxCert{} -> Nothing
@@ -539,6 +537,10 @@ filterUnRegCreds =
         Ledger.RegDRepTxCert{} -> Nothing
         Ledger.UnRegDRepTxCert{} -> Nothing
         Ledger.UpdateDRepTxCert{} -> Nothing
+        -- those are old shelley patterns
+        Ledger.RegTxCert _ -> Nothing
+        -- stake cred deregistration w/o deposit
+        Ledger.UnRegTxCert cred -> Just cred
 
 filterUnRegDRepCreds
   :: Certificate era -> Maybe (Ledger.Credential Ledger.DRepRole Ledger.StandardCrypto)
@@ -546,8 +548,6 @@ filterUnRegDRepCreds = \case
   ShelleyRelatedCertificate _ _ -> Nothing
   ConwayCertificate cEra conwayCert -> conwayEraOnwardsConstraints cEra $
     case conwayCert of
-      Ledger.RegTxCert _ -> Nothing
-      Ledger.UnRegTxCert _ -> Nothing
       Ledger.RegPoolTxCert _ -> Nothing
       Ledger.RetirePoolTxCert _ _ -> Nothing
       Ledger.RegDepositTxCert _ _ -> Nothing
@@ -559,6 +559,10 @@ filterUnRegDRepCreds = \case
       Ledger.RegDRepTxCert{} -> Nothing
       Ledger.UnRegDRepTxCert cred _ -> Just cred
       Ledger.UpdateDRepTxCert{} -> Nothing
+      -- those are old shelley patterns
+      Ledger.RegTxCert _ -> Nothing
+      -- stake cred deregistration w/o deposit
+      Ledger.UnRegTxCert _ -> Nothing
 
 -- ----------------------------------------------------------------------------
 -- Internal conversion functions

--- a/cardano-api/internal/Cardano/Api/Genesis.hs
+++ b/cardano-api/internal/Cardano/Api/Genesis.hs
@@ -171,6 +171,7 @@ shelleyGenesisDefaults =
           -- pot = tx_fees + ρ * remaining_reserves
           & ppRhoL .~ unsafeBR (1 % 10) -- How much of reserves goes into pot
           & ppTauL .~ unsafeBR (1 % 10) -- τ * remaining_reserves is sent to treasury every epoch
+          & ppKeyDepositL .~ 400000 -- require a non-zero deposit when registering keys
     , -- genesis keys and initial funds
       sgGenDelegs = M.empty
     , sgStaking = emptyGenesisStaking


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use correct stake deregistration certs in Conway
    Require 400,000 deposit when registering keys in `defaultShelleyGenesis`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This ledger change:
- https://github.com/IntersectMBO/cardano-ledger/commit/753929346a2707c45dd83d4c30d11806d5a84915#diff-be291f5db9f340104872a79db3fe1f8da0a181c9c998176e49abde0108f6f1c5L149

Has triggered this defect:
- https://github.com/IntersectMBO/cardano-cli/issues/942

Because we were using a pattern meant for older eras, for deregistration certificates in Conway.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
