### PR TITLE
Switch from cryptonite library to crypton

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -252,7 +252,7 @@ library
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,
     cardano-ledger-byron,
-    cryptonite,
+    crypton,
     deepseq,
     memory,
     nothunks,


### PR DESCRIPTION
The former library is deprecated in favor of the latter which is a drop in replacement.

Some of cardano-api's dependencies might still depend on the former but they will all be fixed eventually.

# Changelog

```yaml
- description: |
    Switch from cryptonite library to crypton
  type:
    - compatible     # the API has not changed
```

# Context

# How to trust this PR

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
