### PR TITLE
Expose symbols required by hash check in `transaction build` in `cardano-cli`

### DIFF
--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -66,6 +66,7 @@ module Cardano.Api.ReexposeLedger
   , Delegatee (..)
   , DRep (..)
   , DRepState (..)
+  , Constitution (..)
   , ConwayPlutusPurpose (..)
   , ConwayTxCert (..)
   , ConwayDelegCert (..)
@@ -74,6 +75,7 @@ module Cardano.Api.ReexposeLedger
   , ConwayGenesis (..)
   , UpgradeConwayPParams (..)
   , GovState
+  , GovAction (..)
   , GovActionId (..)
   , Vote (..)
   , Voter (..)
@@ -169,7 +171,7 @@ import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBo
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), CostModels, ExUnits (..),
                    Prices (..))
-import           Cardano.Ledger.Api (unRedeemers)
+import           Cardano.Ledger.Api (Constitution (..), GovAction (..), unRedeemers)
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
                    pattern DelegStakeTxCert, pattern DelegTxCert, pattern GenesisDelegTxCert,
                    pattern MirTxCert, pattern RegDRepTxCert, pattern RegDepositDelegTxCert,


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Exposed `GovAction` and `Constitution` types and constructors required by hash check in `transaction build` in `cardano-cli`
  type:
  - feature
```

# Context

Work to check anchor data in transactions being build with `transaction build` command of 
`cardano-cli` requires inspecting the `GovAction` and `Constitution` types, which are currently not exposed by `cardano-api` but by `cardano-ledger-api` (see branch [hash-check-in `cardano-cli` ](https://github.com/IntersectMBO/cardano-cli/tree/hash-check-in-transaction-build)). In order to avoid transitive dependencies, this PR exposes the required types and constructors.

# How to trust this PR

Tiny PR. I just would ensure it is right to export these, that they are not exported anywhere else, and that they are imported in the right way.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
