### PR TITLE
Refactor `TxMintValue`

### DIFF
--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -68,6 +68,7 @@ module Cardano.Api.Script
     -- ** Languages supported in each era
   , ScriptLanguageInEra (..)
   , scriptLanguageSupportedInEra
+  , sbeToSimpleScriptLanguageInEra
   , languageOfScriptLanguageInEra
   , eraOfScriptLanguageInEra
 
@@ -167,7 +168,7 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import           Data.Type.Equality (TestEquality (..), type (==), (:~:) (Refl))
+import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import           Data.Typeable (Typeable)
 import           Data.Vector (Vector)
 import           GHC.Exts (IsList (..))
@@ -581,18 +582,8 @@ scriptLanguageSupportedInEra
   -> Maybe (ScriptLanguageInEra lang era)
 scriptLanguageSupportedInEra era lang =
   case (era, lang) of
-    (ShelleyBasedEraShelley, SimpleScriptLanguage) ->
-      Just SimpleScriptInShelley
-    (ShelleyBasedEraAllegra, SimpleScriptLanguage) ->
-      Just SimpleScriptInAllegra
-    (ShelleyBasedEraMary, SimpleScriptLanguage) ->
-      Just SimpleScriptInMary
-    (ShelleyBasedEraAlonzo, SimpleScriptLanguage) ->
-      Just SimpleScriptInAlonzo
-    (ShelleyBasedEraBabbage, SimpleScriptLanguage) ->
-      Just SimpleScriptInBabbage
-    (ShelleyBasedEraConway, SimpleScriptLanguage) ->
-      Just SimpleScriptInConway
+    (sbe, SimpleScriptLanguage) ->
+      Just $ sbeToSimpleScriptLanguageInEra sbe
     (ShelleyBasedEraAlonzo, PlutusScriptLanguage PlutusScriptV1) ->
       Just PlutusScriptV1InAlonzo
     (ShelleyBasedEraBabbage, PlutusScriptLanguage PlutusScriptV1) ->
@@ -625,23 +616,33 @@ languageOfScriptLanguageInEra langInEra =
     PlutusScriptV2InConway -> PlutusScriptLanguage PlutusScriptV2
     PlutusScriptV3InConway -> PlutusScriptLanguage PlutusScriptV3
 
+sbeToSimpleScriptLanguageInEra
+  :: ShelleyBasedEra era
+  -> ScriptLanguageInEra SimpleScript' era
+sbeToSimpleScriptLanguageInEra = \case
+  ShelleyBasedEraShelley -> SimpleScriptInShelley
+  ShelleyBasedEraAllegra -> SimpleScriptInAllegra
+  ShelleyBasedEraMary -> SimpleScriptInMary
+  ShelleyBasedEraAlonzo -> SimpleScriptInAlonzo
+  ShelleyBasedEraBabbage -> SimpleScriptInBabbage
+  ShelleyBasedEraConway -> SimpleScriptInConway
+
 eraOfScriptLanguageInEra
   :: ScriptLanguageInEra lang era
   -> ShelleyBasedEra era
-eraOfScriptLanguageInEra langInEra =
-  case langInEra of
-    SimpleScriptInShelley -> ShelleyBasedEraShelley
-    SimpleScriptInAllegra -> ShelleyBasedEraAllegra
-    SimpleScriptInMary -> ShelleyBasedEraMary
-    SimpleScriptInAlonzo -> ShelleyBasedEraAlonzo
-    SimpleScriptInBabbage -> ShelleyBasedEraBabbage
-    SimpleScriptInConway -> ShelleyBasedEraConway
-    PlutusScriptV1InAlonzo -> ShelleyBasedEraAlonzo
-    PlutusScriptV1InBabbage -> ShelleyBasedEraBabbage
-    PlutusScriptV1InConway -> ShelleyBasedEraConway
-    PlutusScriptV2InBabbage -> ShelleyBasedEraBabbage
-    PlutusScriptV2InConway -> ShelleyBasedEraConway
-    PlutusScriptV3InConway -> ShelleyBasedEraConway
+eraOfScriptLanguageInEra = \case
+  SimpleScriptInShelley -> ShelleyBasedEraShelley
+  SimpleScriptInAllegra -> ShelleyBasedEraAllegra
+  SimpleScriptInMary -> ShelleyBasedEraMary
+  SimpleScriptInAlonzo -> ShelleyBasedEraAlonzo
+  SimpleScriptInBabbage -> ShelleyBasedEraBabbage
+  SimpleScriptInConway -> ShelleyBasedEraConway
+  PlutusScriptV1InAlonzo -> ShelleyBasedEraAlonzo
+  PlutusScriptV1InBabbage -> ShelleyBasedEraBabbage
+  PlutusScriptV1InConway -> ShelleyBasedEraConway
+  PlutusScriptV2InBabbage -> ShelleyBasedEraBabbage
+  PlutusScriptV2InConway -> ShelleyBasedEraConway
+  PlutusScriptV3InConway -> ShelleyBasedEraConway
 
 -- | Given a target era and a script in some language, check if the language is
 -- supported in that era, and if so return a 'ScriptInEra'.

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -228,7 +228,8 @@ instance HasTypeProxy PlutusScriptV3 where
 --
 data ScriptLanguage lang where
   SimpleScriptLanguage :: ScriptLanguage SimpleScript'
-  PlutusScriptLanguage :: PlutusScriptVersion lang -> ScriptLanguage lang
+  PlutusScriptLanguage
+    :: IsPlutusScriptLanguage lang => PlutusScriptVersion lang -> ScriptLanguage lang
 
 deriving instance (Eq (ScriptLanguage lang))
 
@@ -285,7 +286,8 @@ instance Bounded AnyScriptLanguage where
 
 data AnyPlutusScriptVersion where
   AnyPlutusScriptVersion
-    :: PlutusScriptVersion lang
+    :: IsPlutusScriptLanguage lang
+    => PlutusScriptVersion lang
     -> AnyPlutusScriptVersion
 
 deriving instance (Show AnyPlutusScriptVersion)
@@ -407,7 +409,8 @@ data Script lang where
     :: !SimpleScript
     -> Script SimpleScript'
   PlutusScript
-    :: !(PlutusScriptVersion lang)
+    :: IsPlutusScriptLanguage lang
+    => !(PlutusScriptVersion lang)
     -> !(PlutusScript lang)
     -> Script lang
 
@@ -721,7 +724,8 @@ data ScriptWitness witctx era where
     -> SimpleScriptOrReferenceInput SimpleScript'
     -> ScriptWitness witctx era
   PlutusScriptWitness
-    :: ScriptLanguageInEra lang era
+    :: IsPlutusScriptLanguage lang
+    => ScriptLanguageInEra lang era
     -> PlutusScriptVersion lang
     -> PlutusScriptOrReferenceInput lang
     -> ScriptDatum witctx

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -54,6 +54,7 @@ module Cardano.Api.Script
   , WitCtxMint
   , WitCtxStake
   , WitCtx (..)
+  , WitCtxMaybe (..)
   , ScriptWitness (..)
   , Witness (..)
   , KeyWitnessInCtx (..)
@@ -165,7 +166,7 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import           Data.Type.Equality (TestEquality (..), (:~:) (Refl))
+import           Data.Type.Equality (TestEquality (..), type (==), (:~:) (Refl))
 import           Data.Typeable (Typeable)
 import           Data.Vector (Vector)
 import           GHC.Exts (IsList (..))
@@ -688,20 +689,18 @@ data PlutusScriptOrReferenceInput lang
   | -- | Needed to construct the redeemer pointer map
     -- in the case of minting reference scripts where we don't
     -- have direct access to the script
-    PReferenceScript
-      TxIn
-      (Maybe ScriptHash)
+    PReferenceScript TxIn
   deriving (Eq, Show)
 
 data SimpleScriptOrReferenceInput lang
   = SScript SimpleScript
-  | SReferenceScript TxIn (Maybe ScriptHash)
+  | SReferenceScript TxIn
   deriving (Eq, Show)
 
 getScriptWitnessReferenceInput :: ScriptWitness witctx era -> Maybe TxIn
-getScriptWitnessReferenceInput (SimpleScriptWitness _ (SReferenceScript txIn _)) =
+getScriptWitnessReferenceInput (SimpleScriptWitness _ (SReferenceScript txIn)) =
   Just txIn
-getScriptWitnessReferenceInput (PlutusScriptWitness _ _ (PReferenceScript txIn _) _ _ _) =
+getScriptWitnessReferenceInput (PlutusScriptWitness _ _ (PReferenceScript txIn) _ _ _) =
   Just txIn
 getScriptWitnessReferenceInput (SimpleScriptWitness _ (SScript _)) = Nothing
 getScriptWitnessReferenceInput (PlutusScriptWitness _ _ (PScript _) _ _ _) = Nothing
@@ -804,9 +803,9 @@ scriptWitnessScript (SimpleScriptWitness SimpleScriptInConway (SScript script)) 
   Just $ ScriptInEra SimpleScriptInConway (SimpleScript script)
 scriptWitnessScript (PlutusScriptWitness langInEra version (PScript script) _ _ _) =
   Just $ ScriptInEra langInEra (PlutusScript version script)
-scriptWitnessScript (SimpleScriptWitness _ (SReferenceScript _ _)) =
+scriptWitnessScript (SimpleScriptWitness _ (SReferenceScript _)) =
   Nothing
-scriptWitnessScript (PlutusScriptWitness _ _ (PReferenceScript _ _) _ _ _) =
+scriptWitnessScript (PlutusScriptWitness _ _ (PReferenceScript _) _ _ _) =
   Nothing
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -1757,7 +1757,6 @@ validateTxBodyContent
     , txInsCollateral
     , txOuts
     , txProtocolParams
-    , txMintValue
     , txMetadata
     } =
     let witnesses = collectTxBodyScriptWitnesses sbe txBodContent

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -328,6 +328,7 @@ calcMinimumDeposit v =
 -- ----------------------------------------------------------------------------
 -- An alternative nested representation
 --
+-- TODO remove ? - it is now unused
 
 -- | An alternative nested representation for 'Value' that groups assets that
 -- share a 'PolicyId'.
@@ -358,7 +359,7 @@ valueToNestedRep v =
 
 valueFromNestedRep :: ValueNestedRep -> Value
 valueFromNestedRep (ValueNestedRep bundles) =
-  valueFromList
+  fromList
     [ (aId, q)
     | bundle <- bundles
     , (aId, q) <- case bundle of

--- a/cardano-api/internal/Cardano/Api/Value.hs
+++ b/cardano-api/internal/Cardano/Api/Value.hs
@@ -328,7 +328,6 @@ calcMinimumDeposit v =
 -- ----------------------------------------------------------------------------
 -- An alternative nested representation
 --
--- TODO remove ? - it is now unused
 
 -- | An alternative nested representation for 'Value' that groups assets that
 -- share a 'PolicyId'.

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -557,6 +557,7 @@ module Cardano.Api
     -- ** Languages supported in each era
   , ScriptLanguageInEra (..)
   , scriptLanguageSupportedInEra
+  , sbeToSimpleScriptLanguageInEra
   , languageOfScriptLanguageInEra
   , eraOfScriptLanguageInEra
 

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -537,15 +537,16 @@ module Cardano.Api
   , WitCtxMint
   , WitCtxStake
   , WitCtx (..)
-  , WitCtxMaybe (..)
   , ScriptWitness (..)
+  , getScriptWitnessScript
+  , getScriptWitnessReferenceInput
+  , getScriptWitnessReferenceInputOrScript
   , Witness (..)
   , KeyWitnessInCtx (..)
   , ScriptWitnessInCtx (..)
   , IsScriptWitnessInCtx (..)
   , ScriptDatum (..)
   , ScriptRedeemer
-  , scriptWitnessScript
 
     -- ** Inspecting 'ScriptWitness'es
   , AnyScriptWitness (..)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -368,6 +368,8 @@ module Cardano.Api
   , TxCertificates (..)
   , TxUpdateProposal (..)
   , TxMintValue (..)
+  , txMintValueToValue
+  , txMintValueToIndexed
   , TxVotingProcedures (..)
   , mkTxVotingProcedures
   , TxProposalProcedures (..)
@@ -535,6 +537,7 @@ module Cardano.Api
   , WitCtxMint
   , WitCtxStake
   , WitCtx (..)
+  , WitCtxMaybe (..)
   , ScriptWitness (..)
   , Witness (..)
   , KeyWitnessInCtx (..)

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -415,7 +415,6 @@ test_TxBodyError =
     , ("TxBodyOutputNegative", TxBodyOutputNegative 1 txOutInAnyEra1)
     , ("TxBodyOutputOverflow", TxBodyOutputOverflow 1 txOutInAnyEra1)
     , ("TxBodyMetadataError", TxBodyMetadataError [(1, TxMetadataBytesTooLong 2)])
-    , ("TxBodyMintAdaError", TxBodyMintAdaError)
     , ("TxBodyMissingProtocolParams", TxBodyMissingProtocolParams)
     , ("TxBodyInIxOverflow", TxBodyInIxOverflow txin1)
     ]

--- a/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Tx.Body.TxBodyError/TxBodyMintAdaError.txt
+++ b/cardano-api/test/cardano-api-golden/files/golden/errors/Cardano.Api.Tx.Body.TxBodyError/TxBodyMintAdaError.txt
@@ -1,1 +1,0 @@
-Transaction cannot mint ada, only non-ada assets

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -83,8 +83,7 @@ prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.pr
   let txMint =
         TxMintValue
           meo
-          [(AssetId policyId' "eeee", 1)]
-          (BuildTxWith [(policyId', plutusWitness)])
+          [(policyId', [("eeee", 1, BuildTxWith plutusWitness)])]
 
   -- tx body content without an asset in TxOut
   let content =
@@ -167,8 +166,7 @@ prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $
   let txMint =
         TxMintValue
           meo
-          [(AssetId policyId' "eeee", 1)]
-          (BuildTxWith [(policyId', plutusWitness)])
+          [(policyId', [("eeee", 1, BuildTxWith plutusWitness)])]
 
   let content =
         defaultTxBodyContent sbe


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `sbeToSimpleScriptLanguageInEra`, `getScriptWitnessScript`, `getScriptWitnessReferenceInput`, `getScriptWitnessReferenceInputOrScript` function
    Refactor `TxMintValue` to better represent minting state
    Propagate `IsPlutusLanguage` constraint to `ScriptLanguage lang`, `AnyPlutusScriptVersion`, `Script lang` and `ScriptWitness witctx era` types.
    Remove `Maybe ScriptHash` from `PReferenceScript` and `SReferenceScript`.

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Supersedes:
- https://github.com/IntersectMBO/cardano-api/pull/642

Fixes:
- https://github.com/IntersectMBO/cardano-api/issues/606

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
