### PR TITLE
Expose functions and types from `ouroboros-*` required by `cardano-cli`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -129,6 +129,7 @@ library internal
     Cardano.Api.Query
     Cardano.Api.Query.Expr
     Cardano.Api.Query.Types
+    Cardano.Api.ReexposeConsensus
     Cardano.Api.ReexposeLedger
     Cardano.Api.ReexposeNetwork
     Cardano.Api.Rewards
@@ -238,6 +239,7 @@ library
     Cardano.Api.ChainSync.Client
     Cardano.Api.ChainSync.ClientPipelined
     Cardano.Api.Compatible
+    Cardano.Api.Consensus
     Cardano.Api.Crypto.Ed25519Bip32
     Cardano.Api.Experimental
     Cardano.Api.Ledger

--- a/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
@@ -1,17 +1,29 @@
 module Cardano.Api.ReexposeConsensus
   ( ByronBlock
+  , ChainDepState
   , GenTx (..)
   , EraMismatch (..)
+  , PastHorizonException
   , PraosProtocolSupportsNode
   , PraosProtocolSupportsNodeCrypto
   , ShelleyGenesisStaking (..)
   , byronIdTx
+  , condense
   , getOpCertCounters
+  , interpreterToEpochInfo
+  , unsafeExtendSafeZone
+  , txId
   )
 where
 
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..), byronIdTx)
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import           Ouroboros.Consensus.HardFork.History.EpochInfo (interpreterToEpochInfo)
+import           Ouroboros.Consensus.HardFork.History.Qry (PastHorizonException,
+                   unsafeExtendSafeZone)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
+import           Ouroboros.Consensus.Protocol.Abstract (ChainDepState)
 import           Ouroboros.Consensus.Protocol.Praos.Common (PraosProtocolSupportsNode,
                    PraosProtocolSupportsNodeCrypto, getOpCertCounters)
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
+import           Ouroboros.Consensus.Util.Condense (condense)

--- a/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
@@ -1,0 +1,4 @@
+module Cardano.Api.ReexposeConsensus (PraosProtocolSupportsNode, PraosProtocolSupportsNodeCrypto, getOpCertCounters) where
+
+import           Ouroboros.Consensus.Protocol.Praos.Common (PraosProtocolSupportsNode,
+                   PraosProtocolSupportsNodeCrypto, getOpCertCounters)

--- a/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeConsensus.hs
@@ -1,4 +1,17 @@
-module Cardano.Api.ReexposeConsensus (PraosProtocolSupportsNode, PraosProtocolSupportsNodeCrypto, getOpCertCounters) where
+module Cardano.Api.ReexposeConsensus
+  ( ByronBlock
+  , GenTx (..)
+  , EraMismatch (..)
+  , PraosProtocolSupportsNode
+  , PraosProtocolSupportsNodeCrypto
+  , ShelleyGenesisStaking (..)
+  , byronIdTx
+  , getOpCertCounters
+  )
+where
 
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..), byronIdTx)
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import           Ouroboros.Consensus.Protocol.Praos.Common (PraosProtocolSupportsNode,
                    PraosProtocolSupportsNodeCrypto, getOpCertCounters)
+import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))

--- a/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
@@ -1,3 +1,4 @@
-module Cardano.Api.ReexposeNetwork (Target (..)) where
+module Cardano.Api.ReexposeNetwork (Target (..), SubmitResult (..)) where
 
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
+import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))

--- a/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeNetwork.hs
@@ -1,4 +1,5 @@
-module Cardano.Api.ReexposeNetwork (Target (..), SubmitResult (..)) where
+module Cardano.Api.ReexposeNetwork (Target (..), Serialised (..), SubmitResult (..)) where
 
+import           Ouroboros.Network.Block (Serialised (..))
 import           Ouroboros.Network.Protocol.LocalStateQuery.Type (Target (..))
 import           Ouroboros.Network.Protocol.LocalTxSubmission.Type (SubmitResult (..))

--- a/cardano-api/src/Cardano/Api/Consensus.hs
+++ b/cardano-api/src/Cardano/Api/Consensus.hs
@@ -1,0 +1,6 @@
+module Cardano.Api.Consensus
+  ( module Cardano.Api.ReexposeConsensus
+  )
+where
+
+import           Cardano.Api.ReexposeConsensus


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Exposed functions and types from `ouroboros-*` required by `cardano-cli`.
  type:
  - compatible
```

# Context

As part of the work targeted at addressing issues pointed out in https://github.com/IntersectMBO/cardano-api/issues/608, this PR aims to provide `cardano-cli` with everything it needs from consensus and network.

# How to trust this PR

Make sure it is just a refactoring for cardano-cli.

Make sure the way new things are exposed is sensible.

Look at it in conjunction with: https://github.com/IntersectMBO/cardano-cli/pull/957

Most commits are linked 1 to 1 with commits in the cardano-cli PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
