### PR TITLE
Export the Committee record from the ledger, for use in the CLI

### DIFF
--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -63,6 +63,7 @@ module Cardano.Api.ReexposeLedger
   , ppMinUTxOValueL
   -- Conway
   , Anchor (..)
+  , Committee (..)
   , Delegatee (..)
   , DRep (..)
   , DRepState (..)
@@ -193,8 +194,8 @@ import           Cardano.Ledger.Conway.Core (DRepVotingThresholds (..), PoolVoti
                    dvtPPEconomicGroupL, dvtPPGovGroupL, dvtPPNetworkGroupL, dvtPPTechnicalGroupL,
                    dvtUpdateToConstitutionL)
 import           Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
-import           Cardano.Ledger.Conway.Governance (Anchor (..), GovActionId (..), GovState,
-                   ProposalProcedure (..), Vote (..), Voter (..), VotingProcedure (..),
+import           Cardano.Ledger.Conway.Governance (Anchor (..), Committee (..), GovActionId (..),
+                   GovState, ProposalProcedure (..), Vote (..), Voter (..), VotingProcedure (..),
                    VotingProcedures (..))
 import           Cardano.Ledger.Conway.PParams (UpgradeConwayPParams (..))
 import           Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Export the Committee record from the ledger, for use in the CLI
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Required for https://github.com/IntersectMBO/cardano-cli/issues/757
* That's this record: https://github.com/IntersectMBO/cardano-ledger//blob/4be8d27282383d6872ff7ee3bd1b4ee11985f4f3/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs#L532
* This type is used for declaring committee members in Conway's genesis file

# How to trust this PR

It's only a small export

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff