### PR TITLE
Update `main` references in GHA

### DIFF
--- a/.github/bin/check-git-dependencies
+++ b/.github/bin/check-git-dependencies
@@ -46,7 +46,7 @@ for row in $(cat tmp/repositories.json | jq -r '.[] | @base64'); do
     branches > branches.txt
 
     commits branches.txt | grep "$tag" || (
-      printf "Commit $tag from $location is not on the main branch or any release branches\n" >> "$base/tmp/dep-repo-result"
+      printf "Commit $tag from $location is not on the master branch or any release branches\n" >> "$base/tmp/dep-repo-result"
       printf "Branches searched:"
       cat branches.txt | sed 's|^|  |g'
     )
@@ -56,7 +56,7 @@ for row in $(cat tmp/repositories.json | jq -r '.[] | @base64'); do
 done
 
 if [ -f tmp/dep-repo-result ]; then
-  printf "${RED}Commits not on the main branch or any release branches detected in dependencies${NC}\n"
+  printf "${RED}Commits not on the master branch or any release branches detected in dependencies${NC}\n"
   printf "${YELLOW}"
   cat tmp/dep-repo-result
   printf "${NC}"

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -3,7 +3,7 @@ name: "Haddock documentation"
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:
@@ -58,7 +58,7 @@ jobs:
         path: ./haddocks.tgz
 
     - name: Deploy documentation to gh-pages 🚀
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,12 +4,12 @@ on:
   merge_group:
   pull_request:
   push:
-    # we need this to populate cache for `main` branch to make it available to the child branches, see
+    # we need this to populate cache for `master` branch to make it available to the child branches, see
     # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
     branches:
-      - main
+      - master
   # GH caches are removed when not accessed within 7 days - this schedule runs the job every 6 days making
-  # sure that we always have some caches on main
+  # sure that we always have some caches on master
   schedule:
     - cron: '0 0 */6 * *'
 

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
  
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to the `cardano-api` project
 
-Please see [cardano-cli's CONTRIBUTING.md](https://github.com/input-output-hk/cardano-cli/blob/main/CONTRIBUTING.md) file.
+Please see [cardano-cli's CONTRIBUTING.md](https://github.com/input-output-hk/cardano-cli/blob/master/CONTRIBUTING.md) file.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Development documentation can be found in [Cardano Node Wiki](https://github.com
 
 Haddock documentation is available at: https://cardano-api.cardano.intersectmbo.org/
 
-[![x86\_64-linux](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-api/main/x86_64-linux.required/shield&style=flat-square&label=x86_64-linux)](https://ci.iog.io/job/IntersectMBO-cardano-api/main/x86_64-linux.required)
-[![x86\_64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-api/main/x86_64-darwin.required/shield&style=flat-square&label=x86_64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-api/main/x86_64-darwin.required)
-[![GHA Build](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-api/haskell.yml?branch=main&label=GHA%20Build&style=flat-square)](https://github.com/IntersectMBO/cardano-api/actions/workflows/haskell.yml?query=branch%3Amain)
-[![Haddock](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-api/github-page.yml?branch=main&label=Haddocks&style=flat-square)](https://github.com/IntersectMBO/cardano-api/actions/workflows/github-page.yml?query=branch%3Amain)
+[![x86\_64-linux](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-api/master/x86_64-linux.required/shield&style=flat-square&label=x86_64-linux)](https://ci.iog.io/job/IntersectMBO-cardano-api/master/x86_64-linux.required)
+[![x86\_64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-api/master/x86_64-darwin.required/shield&style=flat-square&label=x86_64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-api/master/x86_64-darwin.required)
+[![GHA Build](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-api/haskell.yml?branch=master&label=GHA%20Build&style=flat-square)](https://github.com/IntersectMBO/cardano-api/actions/workflows/haskell.yml?query=branch%3Amaster)
+[![Haddock](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-api/github-page.yml?branch=master&label=Haddocks&style=flat-square)](https://github.com/IntersectMBO/cardano-api/actions/workflows/github-page.yml?query=branch%3Amaster)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,7 @@ After deciding on the version number, set the correct `version` field in all cab
 
 ### Changelog preparation
 The changelog preparation workflow is using `cardano-updates` to gather all information and produce the changelog in markdown format.
-The full documentation for scripts is located in [`cardano-updates` repository](https://github.com/IntersectMBO/cardano-updates/blob/main/scripts/README.md).
+The full documentation for scripts is located in [`cardano-updates` repository](https://github.com/IntersectMBO/cardano-updates/blob/master/scripts/README.md).
 
 This part requires user to have the following tools installed on your local machine:
 * https://github.com/cli/cli
@@ -92,7 +92,7 @@ In order to generate changelog files in markdown format use the following steps:
     >You can sort all tags ascendingly using: `git show-ref --tags --dereference | sort -V -t '/' -k 3,3`
 
 1. Add generated changelog in the previous step to `CHANGELOG.md` file in respective cabal package in `cardano-api` repository, near the top of the file, adding a new section for the version being prepared, for example: `## 8.3.0.0`.
-    After doing that, create a PR from a new branch back to `main`.
+    After doing that, create a PR from a new branch back to `master`.
     Make sure that the release PR contains:
     * updated changelogs
     * bumped version fields in cabal files
@@ -100,7 +100,7 @@ In order to generate changelog files in markdown format use the following steps:
 >:high_brightness: **Note**
 >
 >Usually the release PR should only contain a changelog update and a version bump.
->If you are making a release which aims to contain everything from `main` branch, there should be no additional code changes in the release PR.
+>If you are making a release which aims to contain everything from `master` branch, there should be no additional code changes in the release PR.
 >An exception to that would be a release with a backported fix for example, where the release PR should contain required code changes too.
 
 >:bulb: **Tip**
@@ -140,7 +140,7 @@ Briefly speaking, it requires executing of the following steps:
 
     After package gets released, you can check the released version at: https://chap.intersectmbo.org/all-package-versions/ and update the version in the dependant packages, in their cabal files, for example: `cardano-api ^>= 8.3`
     Don't forget to bump the CHaP index in cabal.project and flake.lock too.
-    See [`CONTRIBUTING.md` section on updating dependencies](https://github.com/IntersectMBO/cardano-cli/blob/main/CONTRIBUTING.md#updating-dependencies) how to to do so.
+    See [`CONTRIBUTING.md` section on updating dependencies](https://github.com/IntersectMBO/cardano-cli/blob/master/CONTRIBUTING.md#updating-dependencies) how to to do so.
 
 >:bulb: **Tip**
 >
@@ -207,7 +207,7 @@ If it is already set to the current date, you can add a suffix to it - the impor
 This issue happens due to frequent cache collisions in the [`cabal-cache`](https://github.com/haskell-works/cabal-cache).
 
 ## References
-1. https://github.com/input-output-hk/cardano-updates/tree/main/scripts
+1. https://github.com/input-output-hk/cardano-updates/tree/master/scripts
 1. https://github.com/IntersectMBO/cardano-ledger/blob/master/RELEASING.md
 1. https://chap.intersectmbo.org/index.html
 1. https://input-output-hk.github.io/cardano-engineering-handbook/policy/haskell/packaging/versioning.html

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,4 +15,4 @@ Please provide a clear and concise description of the vulnerability, including:
 If you have developed any code or utilities that can help demonstrate the suspected
 vulnerability, please mention them in your email but ***DO NOT*** attempt to include them as
 attachments as this may cause your Email to be blocked by spam filters.
-See the security file in the [Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/SECURITY.md).
+See the security file in the [Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/master/SECURITY.md).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix dependencies to `main` in GHA
  type:
  - maintenance
```

# Context

This follows up on the renaming of the default branch from `main` to `master`.

# How to trust this PR

If the CI passes it will be a great sign.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
