### PR TITLE
Improve plutus script failure error

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -123,6 +123,7 @@ library internal
     Cardano.Api.NetworkId
     Cardano.Api.OperationalCertificate
     Cardano.Api.Orphans
+    Cardano.Api.Plutus
     Cardano.Api.Pretty
     Cardano.Api.Protocol
     Cardano.Api.ProtocolParameters
@@ -161,6 +162,7 @@ library internal
     attoparsec,
     base16-bytestring >=1.0,
     base58-bytestring,
+    base64-bytestring,
     bech32 >=1.1.0,
     bytestring,
     cardano-binary,

--- a/cardano-api/internal/Cardano/Api/Plutus.hs
+++ b/cardano-api/internal/Cardano/Api/Plutus.hs
@@ -1,0 +1,54 @@
+module Cardano.Api.Plutus
+  ( DebugPlutusFailure (..)
+  , renderDebugPlutusFailure
+  )
+where
+
+import           Cardano.Api.Pretty
+
+import qualified Cardano.Ledger.Api as L
+import           Cardano.Ledger.Binary.Plain (serializeAsHexText)
+import qualified Cardano.Ledger.Plutus.Evaluate as Plutus
+import qualified Cardano.Ledger.Plutus.ExUnits as Plutus
+import qualified Cardano.Ledger.Plutus.Language as Plutus
+import qualified PlutusLedgerApi.V1 as Plutus
+
+import qualified Data.ByteString.Base64 as B64
+import           Data.ByteString.Short as BSS
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+
+data DebugPlutusFailure
+  = DebugPlutusFailure
+  { dpfEvaluationError :: Plutus.EvaluationError
+  , dpfScriptWithContext :: Plutus.PlutusWithContext L.StandardCrypto
+  , dpfExecutionUnits :: Plutus.ExUnits
+  , dpfExecutionLogs :: [Text]
+  }
+  deriving (Eq, Show)
+
+renderDebugPlutusFailure :: DebugPlutusFailure -> Text
+renderDebugPlutusFailure dpf =
+  let pwc = dpfScriptWithContext dpf
+      lang = case pwc of
+        Plutus.PlutusWithContext{Plutus.pwcScript = script} ->
+          either Plutus.plutusLanguage Plutus.plutusLanguage script
+
+      scriptArgs = case pwc of
+        Plutus.PlutusWithContext{Plutus.pwcArgs = args} ->
+          pretty args
+
+      evalError = dpfEvaluationError dpf
+      binaryScript = case pwc of
+        Plutus.PlutusWithContext{Plutus.pwcScript = scr} ->
+          let Plutus.Plutus bytes = either id Plutus.plutusFromRunnable scr
+           in Text.decodeUtf8 . B64.encode . BSS.fromShort $ Plutus.unPlutusBinary bytes
+   in Text.unlines
+        [ "Script hash: " <> serializeAsHexText (Plutus.pwcScriptHash pwc)
+        , "Script language: " <> Text.pack (show lang)
+        , "Protocol version: " <> Text.pack (show (Plutus.pwcProtocolVersion pwc))
+        , "Script arguments: " <> docToText scriptArgs
+        , "Script evaluation error: " <> docToText (pretty evalError)
+        , "Script base64 encoded bytes: " <> binaryScript
+        ]

--- a/cardano-api/internal/Cardano/Api/Plutus.hs
+++ b/cardano-api/internal/Cardano/Api/Plutus.hs
@@ -1,3 +1,9 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Cardano.Api.Plutus
   ( DebugPlutusFailure (..)
   , renderDebugPlutusFailure
@@ -50,5 +56,6 @@ renderDebugPlutusFailure dpf =
         , "Protocol version: " <> Text.pack (show (Plutus.pwcProtocolVersion pwc))
         , "Script arguments: " <> docToText scriptArgs
         , "Script evaluation error: " <> docToText (pretty evalError)
+        , "Script execution logs: " <> Text.unlines (dpfExecutionLogs dpf)
         , "Script base64 encoded bytes: " <> binaryScript
         ]

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -30,6 +30,7 @@ module Test.Golden.ErrorsSpec
 where
 
 import           Cardano.Api
+import           Cardano.Api.Plutus
 import           Cardano.Api.Shelley
 
 import           Cardano.Binary as CBOR
@@ -38,6 +39,7 @@ import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Ledger
 import qualified Cardano.Ledger.Api.Era as Ledger
 import qualified Cardano.Ledger.Coin as L
 import           Cardano.Ledger.Crypto (StandardCrypto)
+import qualified Cardano.Ledger.Plutus.ExUnits as Plutus
 import qualified Cardano.Ledger.Plutus.Language as Plutus
 import qualified PlutusCore.Evaluation.Machine.CostModelInterface as Plutus
 import qualified PlutusLedgerApi.Common as Plutus hiding (PlutusV2)
@@ -271,8 +273,13 @@ test_ScriptExecutionError =
     , ("ScriptErrorTxInWithoutDatum", ScriptErrorTxInWithoutDatum txin1)
     , ("ScriptErrorWrongDatum", ScriptErrorWrongDatum hashScriptData1)
     ,
-      ( "ScriptErrorEvaluationFailed"
-      , ScriptErrorEvaluationFailed Plutus.CostModelParameterMismatch (replicate 5 text)
+      ( "ScriptErrorEvaluationFailed" -- InvalidReturnValue
+      , ScriptErrorEvaluationFailed $
+          DebugPlutusFailure
+            Plutus.CostModelParameterMismatch
+            undefined
+            (Plutus.ExUnits 1 1)
+            (replicate 5 text)
       )
     , ("ScriptErrorExecutionUnitsOverflow", ScriptErrorExecutionUnitsOverflow)
     ,


### PR DESCRIPTION
```
Command failed: transaction build  Error: The following scripts have execution failures:
the script for transaction input 0 (in ascending order of the TxIds) failed with: 
Script hash: 581cc61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50
Script language: PlutusV3
Protocol version: Version 10
Script arguments: ScriptInfo: SpendingScript (TxOutRef {txOutRefId = 96704f71aca3eee50fcfcaf9fabd467b08dfa38f6d0bf58bce9fe5746d3b0d4e, txOutRefIdx = 0}) (Just (Datum {getDatum = I 0}))
TxInfo:
  TxId: 8c2a0a6267f7f2ecb300283f17bcacbcf5b32783a917c4422f159108fa333248
  Inputs: [ 96704f71aca3eee50fcfcaf9fabd467b08dfa38f6d0bf58bce9fe5746d3b0d4e!0 -> - Value {getValue = Map {unMap = [(,Map {unMap = [("",5000000)]})]}} addressed to
                                                                                    ScriptCredential: c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50 (no staking credential)
                                                                                    with datum
                                                                                    datum hash:  03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
                                                                                    with referenceScript
                                                                                     ]
  Reference inputs: []
  Outputs: [ - Value {getValue = Map {unMap = [(,Map {unMap = [("",2000000)]}),(c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50,Map {unMap = [("MillarCoin",5)]})]}} addressed to
               PubKeyCredential: 0675134e2e5cc7525652feae99055743ed8056c52040923a9914afc5 (no staking credential)
               with datum
               no datum
               with referenceScript

           , - Value {getValue = Map {unMap = [(,Map {unMap = [("",1000000)]})]}} addressed to
               PubKeyCredential: 0675134e2e5cc7525652feae99055743ed8056c52040923a9914afc5 (no staking credential)
               with datum
               datum hash:  ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25
               with referenceScript

           , - Value {getValue = Map {unMap = [(,Map {unMap = [("",15000005000000)]})]}} addressed to
               PubKeyCredential: 7a2ac9050f5182c1755478bed1a3f6db7f7fd2b28c0734a63dc17f06 (no staking credential)
               with datum
               no datum
               with referenceScript
                ]
  Fee: 0
  Value minted: Value {getValue = Map {unMap = [(c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50,Map {unMap = [("MillarCoin",5)]})]}}
  TxCerts: [ TxCertRegStaking (ScriptCredential c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50) (Just 400000) ]
  Wdrl: []
  Valid range: (-∞ , +∞)
  Signatories: []
  Redeemers: [ ( Spending (TxOutRef {txOutRefId = 96704f71aca3eee50fcfcaf9fabd467b08dfa38f6d0bf58bce9fe5746d3b0d4e, txOutRefIdx = 0})
             , 0 )
             , ( Minting c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50
             , 0 )
             , ( Certifying 0 (TxCertRegStaking (ScriptCredential c61bfa1c138524b69f378bc69504322f39289ce554d549db4d1e2b50) (Just 400000))
             , 0 ) ]
  Datums: [ ( 03170a2e7597b7b7e3d84c05391d139a62b157e78786d8c082f29dcf4c111314
          , 0 )
          , ( ee155ace9c40292074cb6aff8c9ccdd273c81648ff1149ef36bcea6ebb8a3e25
          , 1 ) ]
  Votes: []
  Proposal Procedures: []
  Current Treasury Amount: 
  Treasury Donation: 
Redeemer:
  0
Script evaluation error: An error has occurred:
The machine terminated because of an error, either from a built-in function or from an explicit use of 'error'.
Script execution logs: PT5

Script base64 encoded bytes: WQ5wAQAAMjIzIjMiMyIyMjIyMjIyMjIyMjIyJTNVM1NTUyMjJTNTM1c0ZuHSAAACATASEyMjIyMjMyIhIzMAEAQAMAIyMjJTNTM1c0ZuHSAAACAbAaEyMjIyMjIyMjIyMjIyMjIyMzMzMzMzIzMjMjMiIiIiIiIiIhIzMzMz...
```

# Changelog

```yaml
- description: |
    Improve plutus script failure error
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
