### PR TITLE
ValueParser: rename publicly exposed function names to indicate they are parsers

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -392,7 +392,7 @@ genLedgerValue w genAId genQuant =
 genValueDefault :: MaryEraOnwards era -> Gen (L.Value (ShelleyLedgerEra era))
 genValueDefault w = genLedgerValue w genAssetId genSignedNonZeroQuantity
 
-genValueForRole :: MaryEraOnwards era -> ValueRole -> Gen Value
+genValueForRole :: MaryEraOnwards era -> ParserValueRole -> Gen Value
 genValueForRole w =
   \case
     RoleMint ->

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -997,10 +997,10 @@ instance IsShelleyBasedEra era => FromJSON (TxOutValue era) where
     decodeAssets :: Aeson.Object -> Aeson.Parser [(AssetName, Quantity)]
     decodeAssets assetNameHm =
       let l = toList assetNameHm
-       in mapM (\(aName, q) -> (,) <$> parseAssetName aName <*> decodeQuantity q) l
+       in mapM (\(aName, q) -> (,) <$> parseKeyAsAssetName aName <*> decodeQuantity q) l
 
-    parseAssetName :: Aeson.Key -> Aeson.Parser AssetName
-    parseAssetName aName = runParsecParser assetName (Aeson.toText aName)
+    parseKeyAsAssetName :: Aeson.Key -> Aeson.Parser AssetName
+    parseKeyAsAssetName aName = runParsecParser parseAssetName (Aeson.toText aName)
 
     decodeQuantity :: Aeson.Value -> Aeson.Parser Quantity
     decodeQuantity (Aeson.Number sci) =

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -232,9 +232,9 @@ module Cardano.Api
   , AssetName (..)
   , AssetId (..)
   , Value
-  , ValueRole (..)
+  , ParserValueRole (..)
   , parseValue
-  , policyId
+  , parsePolicyId
   , selectAsset
   , valueFromList
   , valueToList

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -235,6 +235,10 @@ module Cardano.Api
   , ParserValueRole (..)
   , parseValue
   , parsePolicyId
+  , parseAssetName
+  , parseTxOutMultiAssetValue
+  , parseMintingMultiAssetValue
+  , parseUTxOValue
   , selectAsset
   , valueFromList
   , valueToList


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    ValueParser: rename publicly exposed function names to indicate they are parsers
    
    To adapt: prefix old function name by `parse` and everything should compile again.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Fixes https://github.com/IntersectMBO/cardano-api/issues/673
* Most functions in `ValueParser` that have a `-> Parser _` return type had nothing in their name indicating that they do so. Those functions' name now start with `parse`.

# How to trust this PR

It's only renamings

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff