### PR TITLE
Add mnemonic support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-03-03T01:12:46Z
+  , hackage.haskell.org 2025-03-17T12:01:29Z
   , cardano-haskell-packages 2025-03-03T04:46:42Z
 
 packages:

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -110,8 +110,11 @@ library
     base16-bytestring >=1.0,
     base58-bytestring,
     base64-bytestring,
+    basement,
     bech32 >=1.1.0,
     bytestring,
+    bytestring-trie,
+    cardano-addresses ^>=4.0.0,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,
@@ -139,6 +142,7 @@ library
     directory,
     either,
     errors,
+    extra,
     filepath,
     formatting,
     groups,
@@ -160,7 +164,7 @@ library
     ouroboros-network-framework,
     ouroboros-network-protocols,
     parsec,
-    plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.37,
+    plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.40,
     prettyprinter,
     prettyprinter-ansi-terminal,
     prettyprinter-configurable ^>=1.36,
@@ -221,6 +225,7 @@ library
     Cardano.Api.Internal.Json
     Cardano.Api.Internal.Keys.Byron
     Cardano.Api.Internal.Keys.Class
+    Cardano.Api.Internal.Keys.Mnemonics
     Cardano.Api.Internal.Keys.Praos
     Cardano.Api.Internal.Keys.Read
     Cardano.Api.Internal.Keys.Shelley
@@ -403,7 +408,7 @@ test-suite cardano-api-golden
     hedgehog-extras ^>=0.7,
     microlens,
     parsec,
-    plutus-core ^>=1.37,
+    plutus-core ^>=1.40,
     plutus-ledger-api,
     tasty,
     tasty-hedgehog,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -179,6 +179,22 @@ module Cardano.Api
   , castHash
   , renderSafeHashAsHex
 
+    -- * Mnemonics
+
+    -- | Functions for working with mnemonics
+    -- ** Mnemonics generation
+  , MnemonicSize (..)
+  , generateMnemonic
+
+    -- ** Key derivation from mnemonics
+  , MnemonicToSigningKeyError (..)
+  , signingKeyFromMnemonic
+  , signingKeyFromMnemonicWithPaymentKeyIndex
+
+    -- ** Mnemonic word queries
+  , findMnemonicWordsWithPrefix
+  , autocompleteMnemonicPrefix
+
     -- * Payment addresses
 
     -- | Constructing and inspecting normal payment addresses
@@ -1119,6 +1135,7 @@ import Cardano.Api.Internal.IPC.Monad
 import Cardano.Api.Internal.InMode
 import Cardano.Api.Internal.Keys.Byron
 import Cardano.Api.Internal.Keys.Class
+import Cardano.Api.Internal.Keys.Mnemonics
 import Cardano.Api.Internal.Keys.Read
 import Cardano.Api.Internal.Keys.Shelley
 import Cardano.Api.Internal.LedgerState

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Mnemonics.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Mnemonics.hs
@@ -1,0 +1,360 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Api.Internal.Keys.Mnemonics
+  ( MnemonicSize (..)
+  , generateMnemonic
+  , MnemonicToSigningKeyError (..)
+  , signingKeyFromMnemonic
+  , signingKeyFromMnemonicWithPaymentKeyIndex
+  , findMnemonicWordsWithPrefix
+  , autocompleteMnemonicPrefix
+  )
+where
+
+import Cardano.Api.Internal.Error (Error (..))
+import Cardano.Api.Internal.Keys.Class (Key (..))
+import Cardano.Api.Internal.Keys.Shelley
+  ( AsType
+  , CommitteeColdExtendedKey
+  , CommitteeHotExtendedKey
+  , DRepExtendedKey
+  , PaymentExtendedKey
+  , SigningKey (..)
+  , StakeExtendedKey
+  )
+
+import Cardano.Address.Derivation
+  ( Depth (..)
+  , DerivationType (..)
+  , HardDerivation (..)
+  , Index
+  , XPrv
+  , genMasterKeyFromMnemonic
+  , indexFromWord32
+  )
+import Cardano.Address.Style.Shelley
+  ( Role (..)
+  , Shelley (..)
+  , deriveCCColdPrivateKey
+  , deriveCCHotPrivateKey
+  , deriveDRepPrivateKey
+  )
+import Cardano.Crypto.Encoding.BIP39 (Dictionary (dictionaryIndexToWord))
+import Cardano.Mnemonic
+  ( MkSomeMnemonic (mkSomeMnemonic)
+  , MkSomeMnemonicError (..)
+  , SomeMnemonic
+  , entropyToMnemonic
+  , genEntropy
+  , mnemonicToText
+  )
+
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Data.Bifunctor (first)
+import Data.ByteString qualified as BS
+import Data.Either.Combinators (mapLeft, maybeToRight)
+import Data.Either.Extra (maybeToEither)
+import Data.Foldable (toList)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Trie (submap)
+import Data.Trie qualified as Trie
+import Data.Trie.Convenience qualified as Trie
+import Data.Word (Word32)
+import Prettyprinter (Doc, Pretty (..))
+
+import Basement.Compat.IsList qualified as Basement
+import Basement.String qualified as Basement
+import Crypto.Encoding.BIP39.English (english)
+
+-- | The size of a mnemonic sentence.
+-- The size is given in the number of words in the sentence.
+-- The allowed sizes are 12, 15, 18, 21, and 24.
+data MnemonicSize
+  = MS12
+  | MS15
+  | MS18
+  | MS21
+  | MS24
+  deriving (Eq, Show)
+
+-- | Generate a mnemonic sentence of the given size.
+generateMnemonic
+  :: MonadIO m
+  => MnemonicSize
+  -- ^ The size of the mnemonic sentence to generate.
+  -- Must be one of 12, 15, 18, 21, or 24.
+  -> m [Text]
+generateMnemonic MS12 = liftIO (mnemonicToText @12 . entropyToMnemonic <$> genEntropy)
+generateMnemonic MS15 = liftIO (mnemonicToText @15 . entropyToMnemonic <$> genEntropy)
+generateMnemonic MS18 = liftIO (mnemonicToText @18 . entropyToMnemonic <$> genEntropy)
+generateMnemonic MS21 = liftIO (mnemonicToText @21 . entropyToMnemonic <$> genEntropy)
+generateMnemonic MS24 = liftIO (mnemonicToText @24 . entropyToMnemonic <$> genEntropy)
+
+-- | Errors that can occur when converting a mnemonic sentence to a signing key
+data MnemonicToSigningKeyError
+  = InvalidMnemonicError String
+  | InvalidAccountNumberError Word32
+  | InvalidPaymentKeyNoError Word32
+  deriving (Eq, Show)
+
+-- For information about address derivation check:
+--  * https://cips.cardano.org/cip/CIP-1852
+--  * https://github.com/uniVocity/cardano-tutorials/blob/master/cardano-addresses.md#understanding-the-hd-wallet-address-format-bip-44
+--  * https://cips.cardano.org/cip/CIP-0105
+instance Error MnemonicToSigningKeyError where
+  prettyError :: MnemonicToSigningKeyError -> Doc ann
+  prettyError (InvalidMnemonicError str) = "Invalid mnemonic sentence: " <> pretty str
+  prettyError (InvalidAccountNumberError accNo) = "Invalid account number: " <> pretty accNo
+  prettyError (InvalidPaymentKeyNoError keyNo) = "Invalid payment key number: " <> pretty keyNo
+
+-- | Key roles that can be derived from a mnemonic sentence and only accept
+-- one key per account number.
+--
+-- We derive one key per account following the advice in https://cips.cardano.org/cip/CIP-0105:
+-- "Since it is best practice to use a single cryptographic key for a single purpose,
+-- we opt to keep DRep and committee keys separate from other keys in Cardano."
+--
+-- We still need to specify a payment key number for payment and stake keys,
+-- see 'IndexedSigningKeyFromRootKey' class for those roles (payment and stake keys).
+class SigningKeyFromRootKey keyrole where
+  -- | Derive an extended private key of the keyrole from an account extended private key
+  deriveSigningKeyFromAccount
+    :: AsType keyrole
+    -- ^ Type of the extended signing key to generate.
+    -> Shelley 'AccountK XPrv
+    -- ^ The account extended private key from which to derivate the private key for the keyrole.
+    -> SigningKey keyrole
+    -- ^ The derived extended signing key or the 'indexType' if it is 'Word32' and it is invalid.
+
+-- | Key roles that can be derived from a mnemonic sentence and accept multiple keys
+-- per account number. For other key roles (DRep, and committee keys), see 'SigningKeyFromRootKey'.
+class IndexedSigningKeyFromRootKey keyrole where
+  -- | Derive an extended private key of the keyrole from an account extended private key
+  deriveSigningKeyFromAccountWithPaymentKeyIndex
+    :: AsType keyrole
+    -- ^ Type of the extended signing key to generate.
+    -> Shelley 'AccountK XPrv
+    -- ^ The account extended private key from which to derivate the private key for the keyrole.
+    -> Word32
+    -- ^ The payment key number in the derivation path.
+    -> Either Word32 (SigningKey keyrole)
+    -- ^ The derived extended signing key or the 'indexType' if it is invalid.
+
+instance IndexedSigningKeyFromRootKey PaymentExtendedKey where
+  deriveSigningKeyFromAccountWithPaymentKeyIndex
+    :: AsType PaymentExtendedKey
+    -> Shelley 'AccountK XPrv
+    -> Word32
+    -> Either Word32 (SigningKey PaymentExtendedKey)
+  deriveSigningKeyFromAccountWithPaymentKeyIndex _ accK idx = do
+    payKeyIx <- maybeToEither idx $ indexFromWord32 @(Index 'Soft 'PaymentK) idx
+    return $ PaymentExtendedSigningKey $ getKey $ deriveAddressPrivateKey accK UTxOExternal payKeyIx
+
+instance IndexedSigningKeyFromRootKey StakeExtendedKey where
+  deriveSigningKeyFromAccountWithPaymentKeyIndex
+    :: AsType StakeExtendedKey
+    -> Shelley 'AccountK XPrv
+    -> Word32
+    -> Either Word32 (SigningKey StakeExtendedKey)
+  deriveSigningKeyFromAccountWithPaymentKeyIndex _ accK idx = do
+    payKeyIx <- maybeToEither idx $ indexFromWord32 @(Index 'Soft 'PaymentK) idx
+    return $ StakeExtendedSigningKey $ getKey $ deriveAddressPrivateKey accK Stake payKeyIx
+
+instance SigningKeyFromRootKey DRepExtendedKey where
+  deriveSigningKeyFromAccount
+    :: AsType DRepExtendedKey
+    -> Shelley 'AccountK XPrv
+    -> SigningKey DRepExtendedKey
+  deriveSigningKeyFromAccount _ accK =
+    DRepExtendedSigningKey $ getKey $ deriveDRepPrivateKey accK
+
+instance SigningKeyFromRootKey CommitteeColdExtendedKey where
+  deriveSigningKeyFromAccount
+    :: AsType CommitteeColdExtendedKey
+    -> Shelley 'AccountK XPrv
+    -> SigningKey CommitteeColdExtendedKey
+  deriveSigningKeyFromAccount _ accK =
+    CommitteeColdExtendedSigningKey $ getKey $ deriveCCColdPrivateKey accK
+
+instance SigningKeyFromRootKey CommitteeHotExtendedKey where
+  deriveSigningKeyFromAccount
+    :: AsType CommitteeHotExtendedKey
+    -> Shelley 'AccountK XPrv
+    -> SigningKey CommitteeHotExtendedKey
+  deriveSigningKeyFromAccount _ accK =
+    CommitteeHotExtendedSigningKey $ getKey $ deriveCCHotPrivateKey accK
+
+-- | Generate a signing key from a mnemonic sentence given a function that
+-- derives a key from an account extended key.
+signingKeyFromMnemonicWithDerivationFunction
+  :: (Shelley AccountK XPrv -> Either Word32 (SigningKey keyrole))
+  -- ^ Function to derive the signing key from the account key.
+  -> [Text]
+  -- ^ The mnemonic sentence. The length must be one of 12, 15, 18, 21, or 24.
+  -- Each element of the list must be a single word.
+  -> Word32
+  -- ^ The account number in the derivation path. First account is 0.
+  -> Either MnemonicToSigningKeyError (SigningKey keyrole)
+signingKeyFromMnemonicWithDerivationFunction derivationFunction mnemonicWords accNo = do
+  -- Convert raw types to the ones used in the cardano-addresses library
+  someMnemonic <- mapLeft InvalidMnemonicError $ wordsToSomeMnemonic mnemonicWords
+  accIx <-
+    maybeToRight (InvalidAccountNumberError accNo) $
+      indexFromWord32 @(Index 'Hardened 'AccountK) (0x80000000 + accNo)
+
+  -- Derive the rootk key
+  let rootK = genMasterKeyFromMnemonic someMnemonic mempty :: Shelley 'RootK XPrv
+      -- Derive the account key
+      accK = deriveAccountPrivateKey rootK accIx
+
+  -- Derive the extended private key
+  mapLeft InvalidPaymentKeyNoError $ derivationFunction accK
+ where
+  wordsToSomeMnemonic :: [Text] -> Either String SomeMnemonic
+  wordsToSomeMnemonic = mapLeft getMkSomeMnemonicError . mkSomeMnemonic @[12, 15, 18, 21, 24]
+
+-- | Generate a signing key from a mnemonic sentence for a key role that
+-- accepts several payment keys from an account number (extended payment and stake keys).
+-- For other key roles (DRep and committee keys), see 'signingKeyFromMnemonic'.
+--
+-- A derivation path is like a file path in a file system. It specifies the
+-- location of a key in the key tree. The path is a list of indices, one for each
+-- level of the tree. The indices are separated by a forward slash (/).
+-- In this function, we only ask for two indices: the account number and the
+-- payment key number. Each account can have multiple payment keys.
+--
+-- For more information about address derivation, check:
+--  * https://cips.cardano.org/cip/CIP-1852
+--  * https://github.com/uniVocity/cardano-tutorials/blob/master/cardano-addresses.md#understanding-the-hd-wallet-address-format-bip-44
+--  * https://cips.cardano.org/cip/CIP-0105
+signingKeyFromMnemonicWithPaymentKeyIndex
+  :: IndexedSigningKeyFromRootKey keyrole
+  => AsType keyrole
+  -- ^ Type of the extended signing key to generate.
+  -> [Text]
+  -- ^ The mnemonic sentence. The length must be one of 12, 15, 18, 21, or 24.
+  -- Each element of the list must be a single word.
+  -> Word32
+  -- ^ The account number in the derivation path. The first account is 0.
+  -> Word32
+  -- ^ The payment key number in the derivation path.
+  --
+  -- Consider that wallets following the BIP-44 standard only check 20 addresses
+  -- without transactions before giving up. For example, if you have a fresh wallet
+  -- and receive a payment on the address generated with address_index = 6, your
+  -- wallet may only display the money received on addresses from 0 to 26.
+  -- If you receive payment on an address with address_index = 30, the funds may not
+  -- be displayed to you even though it's on the blockchain. It will only appear
+  -- once there is a transaction in some address where address_index is between 10
+  -- and 29. The gap limit can be customized on some wallets, but increasing it
+  -- reduces synchronization performance.
+  -> Either MnemonicToSigningKeyError (SigningKey keyrole)
+signingKeyFromMnemonicWithPaymentKeyIndex keyRole mnemonicWords accNo payKeyNo = do
+  signingKeyFromMnemonicWithDerivationFunction
+    (\accK -> deriveSigningKeyFromAccountWithPaymentKeyIndex keyRole accK payKeyNo)
+    mnemonicWords
+    accNo
+
+-- | Generate a signing key from a mnemonic sentence for a key role that
+-- accepts only one payment key from an account number (DRep and committee keys).
+-- For other key roles (extended payment and stake keys), see 'signingKeyFromMnemonicWithPaymentKeyIndex'.
+--
+-- We derive one key per account following the advice in https://cips.cardano.org/cip/CIP-0105:
+-- "Since it is best practice to use a single cryptographic key for a single purpose,
+-- we opt to keep DRep and committee keys separate from other keys in Cardano."
+--
+-- A derivation path is like a file path in a file system. It specifies the
+-- location of a key in the key tree. The path is a list of indices, one for each
+-- level of the tree. The indices are separated by a forward slash (/).
+-- In this function we only ask for one index: the account number.
+--
+-- For more information about address derivation check:
+--  * https://cips.cardano.org/cip/CIP-1852
+--  * https://github.com/uniVocity/cardano-tutorials/blob/master/cardano-addresses.md#understanding-the-hd-wallet-address-format-bip-44
+--  * https://cips.cardano.org/cip/CIP-0105
+signingKeyFromMnemonic
+  :: SigningKeyFromRootKey keyrole
+  => AsType keyrole
+  -- ^ Type of the extended signing key to generate.
+  -> [Text]
+  -- ^ The mnemonic sentence. The length must be one of 12, 15, 18, 21, or 24.
+  -- Each element of the list must be a single word.
+  -> Word32
+  -- ^ The account number in the derivation path. First account is 0.
+  -> Either MnemonicToSigningKeyError (SigningKey keyrole)
+signingKeyFromMnemonic keyRole mnemonicWords accNo = do
+  signingKeyFromMnemonicWithDerivationFunction
+    (return . deriveSigningKeyFromAccount keyRole)
+    mnemonicWords
+    accNo
+
+-- | Obtain the list of all mnemonic words that start with the given prefix and their index in the dictionary.
+-- For example:
+-- >>> findMnemonicWordsWithPrefix "cha"
+-- [("chair",302),("chalk",303),("champion",304),("change",305),("chaos",306),("chapter",307),("charge",308),("chase",309),("chat",310)]
+findMnemonicWordsWithPrefix :: Text -> [(Text, Int)]
+findMnemonicWordsWithPrefix word = toList $ map (first decodeUtf8) $ Trie.toList matchingSubTrie
+ where
+  matchingSubTrie :: Trie.Trie Int
+  matchingSubTrie = submap (encodeUtf8 word) englishMnemonicTrie
+
+-- | Autocomplete the prefix of the mnemonic word as much as possible.
+-- In other words, find the longest common prefix for all the words
+-- that start with the given prefix.
+-- For example:
+-- >>> autocompleteMnemonicPrefix "ty"
+-- Just "typ"
+--
+-- Because "type" and "typical" are the only words that start with "ty".
+--
+-- >>> autocompleteMnemonicPrefix "vani"
+-- Just "vanish"
+--
+-- Because "vanish" is the only word that starts with "vani".
+--
+-- >>> autocompleteMnemonicPrefix "medo"
+-- Nothing
+--
+-- Because there are no words that start with "medo".
+autocompleteMnemonicPrefix :: Text -> Maybe Text
+autocompleteMnemonicPrefix word =
+  let subtrie = matchingSubTrie word englishMnemonicTrie
+      matches = toList $ map (first decodeUtf8) $ Trie.toList subtrie
+      numMatches = Trie.size subtrie
+   in case matches of
+        [] -> Nothing
+        (firstMatch, _) : _ -> expandWhileSameNumberOfMatches numMatches word (Text.drop (Text.length word) firstMatch) subtrie
+ where
+  matchingSubTrie :: Text -> Trie.Trie Int -> Trie.Trie Int
+  matchingSubTrie w = submap (encodeUtf8 w)
+
+  expandWhileSameNumberOfMatches :: Int -> Text -> Text -> Trie.Trie Int -> Maybe Text
+  expandWhileSameNumberOfMatches numMatches curPrefix potentialExtensions subTrie =
+    case Text.uncons potentialExtensions of
+      Nothing -> Just curPrefix
+      Just (newChar, remainingPotentialExtensions) ->
+        let potentialNewPrefix = Text.snoc curPrefix newChar
+            newSubTrie = matchingSubTrie potentialNewPrefix subTrie
+         in if Trie.size newSubTrie == numMatches
+              then
+                expandWhileSameNumberOfMatches numMatches potentialNewPrefix remainingPotentialExtensions newSubTrie
+              else Just curPrefix
+
+-- | Trie of English mnemonic words with their index.
+englishMnemonicTrie :: Trie.Trie Int
+englishMnemonicTrie =
+  Trie.fromListL
+    ( map
+        ( \i ->
+            (,fromEnum i) $
+              BS.pack . Basement.toList . Basement.toBytes Basement.UTF8 $
+                dictionaryIndexToWord english i
+        )
+        [minBound .. maxBound]
+    )

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Address.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Address.hs
@@ -6,8 +6,12 @@ module Test.Cardano.Api.Address
 where
 
 import Cardano.Api
+import Cardano.Api.Internal.Address (StakeCredential (StakeCredentialByKey))
 
+import Control.Monad (void)
 import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Word (Word32)
 
 import Test.Gen.Cardano.Api.Typed (genAddressByron, genAddressShelley)
 
@@ -15,6 +19,8 @@ import Test.Cardano.Api.Orphans ()
 
 import Hedgehog (Property)
 import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+import Hedgehog.Gen qualified as H
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
@@ -29,6 +35,127 @@ prop_roundtrip_shelley_address =
 prop_roundtrip_byron_address :: Property
 prop_roundtrip_byron_address =
   roundtrip_serialise_address (AsAddress AsByronAddr) genAddressByron
+
+prop_derive_key_from_mnemonic :: Property
+prop_derive_key_from_mnemonic = H.property $ do
+  ms <- H.forAll $ H.element [MS12, MS15, MS18, MS21, MS24]
+  mnemonic <- liftIO $ generateMnemonic ms
+  void $
+    H.evalEither $
+      signingKeyFromMnemonicWithPaymentKeyIndex AsStakeExtendedKey mnemonic 0 (0 :: Word32)
+  H.success
+
+exampleMnemonic :: [Text]
+exampleMnemonic =
+  [ "captain"
+  , "kick"
+  , "bundle"
+  , "address"
+  , "forest"
+  , "cube"
+  , "skirt"
+  , "pepper"
+  , "captain"
+  , "now"
+  , "crop"
+  , "matrix"
+  , "virus"
+  , "shallow"
+  , "bless"
+  , "throw"
+  , "spice"
+  , "smoke"
+  , "over"
+  , "proud"
+  , "minimum"
+  , "coconut"
+  , "virus"
+  , "suspect"
+  ]
+
+prop_mnemonic_word_query :: Property
+prop_mnemonic_word_query =
+  H.propertyOnce $
+    map fst (findMnemonicWordsWithPrefix "cha")
+      H.=== [ "chair"
+            , "chalk"
+            , "champion"
+            , "change"
+            , "chaos"
+            , "chapter"
+            , "charge"
+            , "chase"
+            , "chat"
+            ]
+
+prop_mnemonic_autocomplete_query :: Property
+prop_mnemonic_autocomplete_query = H.propertyOnce $ do
+  autocompleteMnemonicPrefix "ty" H.=== Just "typ"
+  autocompleteMnemonicPrefix "vani" H.=== Just "vanish"
+  autocompleteMnemonicPrefix "medo" H.=== Nothing
+  autocompleteMnemonicPrefix "enroll" H.=== Just "enroll"
+  autocompleteMnemonicPrefix "january" H.=== Nothing
+  autocompleteMnemonicPrefix "" H.=== Just ""
+
+prop_payment_derivation_is_accurate :: Property
+prop_payment_derivation_is_accurate = H.propertyOnce $ do
+  signingKey <-
+    H.evalEither $ signingKeyFromMnemonicWithPaymentKeyIndex AsPaymentExtendedKey exampleMnemonic 0 0
+  let verificationKey =
+        getVerificationKey (signingKey :: SigningKey PaymentExtendedKey)
+          :: VerificationKey PaymentExtendedKey
+      addr =
+        serialiseToBech32 $
+          makeShelleyAddress
+            Mainnet
+            ( PaymentCredentialByKey $
+                verificationKeyHash $
+                  castVerificationKey verificationKey
+            )
+            NoStakeAddress
+  addr H.=== "addr1v86y48z2h38ale0s9r2mfkaw7wp5ysyemnrp0azpy8z4ejg93879q"
+
+prop_stake_derivation_is_accurate :: Property
+prop_stake_derivation_is_accurate = H.propertyOnce $ do
+  signingKey <-
+    H.evalEither $ signingKeyFromMnemonicWithPaymentKeyIndex AsStakeExtendedKey exampleMnemonic 0 0
+  let verificationKey =
+        getVerificationKey (signingKey :: SigningKey StakeExtendedKey) :: VerificationKey StakeExtendedKey
+      addr =
+        serialiseToBech32 $
+          makeStakeAddress Mainnet $
+            StakeCredentialByKey $
+              verificationKeyHash $
+                castVerificationKey verificationKey
+  addr H.=== "stake1u97tzhttvsz5n6fej6g05trus39x5uvl0y0k56dyhsc23xcexrk27"
+
+prop_payment_with_stake_derivation_is_accurate :: Property
+prop_payment_with_stake_derivation_is_accurate = H.propertyOnce $ do
+  paymentSigningKey <-
+    H.evalEither $ signingKeyFromMnemonicWithPaymentKeyIndex AsPaymentExtendedKey exampleMnemonic 0 0
+  stakeSigningKey <-
+    H.evalEither $ signingKeyFromMnemonicWithPaymentKeyIndex AsStakeExtendedKey exampleMnemonic 0 0
+  let paymentVerificationKey =
+        getVerificationKey (paymentSigningKey :: SigningKey PaymentExtendedKey)
+          :: VerificationKey PaymentExtendedKey
+      stakeVerificationKey =
+        getVerificationKey (stakeSigningKey :: SigningKey StakeExtendedKey)
+          :: VerificationKey StakeExtendedKey
+      addr =
+        serialiseToBech32 $
+          makeShelleyAddress
+            Mainnet
+            ( PaymentCredentialByKey $
+                verificationKeyHash $
+                  castVerificationKey paymentVerificationKey
+            )
+            ( StakeAddressByValue $
+                StakeCredentialByKey $
+                  verificationKeyHash $
+                    castVerificationKey stakeVerificationKey
+            )
+  addr
+    H.=== "addr1q86y48z2h38ale0s9r2mfkaw7wp5ysyemnrp0azpy8z4ejtuk9wkkeq9f85nn95slgk8epz2dfce77gldf56f0ps4zds0dx2p0"
 
 -- -----------------------------------------------------------------------------
 
@@ -65,4 +192,12 @@ tests =
     , testProperty "roundtrip byron address" prop_roundtrip_byron_address
     , testProperty "roundtrip byron address JSON" prop_roundtrip_byron_address_JSON
     , testProperty "roundtrip shelley address JSON" prop_roundtrip_shelley_address_JSON
+    , testProperty "key derivation from random mnemonic" prop_derive_key_from_mnemonic
+    , testProperty "mnemonic word prefix query" prop_mnemonic_word_query
+    , testProperty "mnemonic word autocomplete query" prop_mnemonic_autocomplete_query
+    , testProperty "payment address from key derivation is accurate" prop_payment_derivation_is_accurate
+    , testProperty "stake address from key derivation is accurate" prop_stake_derivation_is_accurate
+    , testProperty
+        "payment address with stake from key derivation is accurate"
+        prop_payment_with_stake_derivation_is_accurate
     ]


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added support for generating mnemonics and for deriving payment and stake keys from mnemonics.
  type:
  - feature
```

# Context

Depends on release of `cardano-addresses` (https://github.com/IntersectMBO/cardano-addresses/pull/279)
Allows https://github.com/IntersectMBO/cardano-cli/pull/975.

# How to trust this PR

I would look at the tests. The hard-coded tests have been checked against existing wallets.
I have also tested that the derivation works by doing a prototype command in the `cardano-cli`.
Make sure you like the changes to the API. I have tried to keep them minimal.
Probably the most controversial bit are the instances I added, but they are not exposed. The reason I parametrised the index type is that for some types of keys that I haven't added yet (because I am waiting for a `cardano-addresses` release) the payment is not necessary, so I plan to set it to `()` in those.
Also make sure the documentation is good enough.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
