### PR TITLE
Restore `aarch64` support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,8 @@
     supportedSystems = [
       "x86_64-linux"
       "x86_64-darwin"
-      # "aarch64-linux" - disable these temporarily because the build is broken
-      # "aarch64-darwin" - disable these temporarily because the build is broken
+      "aarch64-linux"
+      "aarch64-darwin"
     ];
 
     # see flake `variants` below for alternative compilers


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Restored `aarch64` support
  type:
  - maintenance
```

# Context

`cardano-cli` already has support `aarch64` and it depends on `cardano-api`, so I am not sure why this is disabled.

# How to trust this PR

If the CI passes I would trust it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
