### PR TITLE
Remove experimental code leak in Cardano.Api non-experimental modules

### DIFF
--- a/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
@@ -16,7 +16,7 @@ where
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra
-import           Cardano.Api.Experimental.Eras
+import           Cardano.Api.Eras
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Script
 import           Cardano.Api.Tx.Body


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove experimental code exposure in `Cardano.Api` non-experimental modules
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR reverts:
- https://github.com/IntersectMBO/cardano-api/commit/03a956c1fe0718775a1650a0577160a0c6f4e00b

Removes exposure of types and functions from `Cardano.Api.Experimental` through other `Cardano.Api` modules.

Fixes https://github.com/IntersectMBO/cardano-api/issues/675

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
