### PR TITLE
Expose `EraTxWits`, `TxDats`, and functions for converting datums and scripts to JSON

### DIFF
--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -121,7 +121,10 @@ module Cardano.Api.ReexposeLedger
   , Data (..)
   , EraTxWits (..)
   , ExUnits (..)
+  , Language
+  , Plutus
   , Prices (..)
+  , Script
   , CostModels
   , AlonzoGenesis
   , AsIxItem (..)
@@ -129,9 +132,15 @@ module Cardano.Api.ReexposeLedger
   , EraTx (witsTxL, bodyTxL)
   , Tx
   , TxDats (..)
+  , getNativeScript
+  , languageToText
+  , plutusBinary
+  , plutusScriptLanguage
   , ppPricesL
   , unData
   , unRedeemers
+  , serializeAsHexText
+  , showTimelock
   -- Base
   , boundRational
   , unboundRational
@@ -168,12 +177,13 @@ module Cardano.Api.ReexposeLedger
 where
 
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
+import           Cardano.Ledger.Allegra.Scripts (showTimelock)
 import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBody (..),
                    AlonzoEraTxWits (..), AsIx (..), AsIxItem (AsIxItem), CoinPerWord (..), EraGov,
                    EraTx (bodyTxL, witsTxL), EraTxWits (..), PParamsUpdate (..), Tx, ppPricesL)
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), CostModels, ExUnits (..),
-                   Prices (..))
+                   Prices (..), Script, plutusScriptLanguage)
 import           Cardano.Ledger.Alonzo.TxWits (TxDats (..))
 import           Cardano.Ledger.Api (Constitution (..), GovAction (..), unRedeemers)
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
@@ -182,7 +192,7 @@ import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
                    pattern RegDepositTxCert, pattern RegPoolTxCert, pattern RegTxCert,
                    pattern ResignCommitteeColdTxCert, pattern RetirePoolTxCert,
                    pattern UnRegDRepTxCert, pattern UnRegDepositTxCert, pattern UnRegTxCert)
-import           Cardano.Ledger.Babbage.Core (CoinPerByte (..))
+import           Cardano.Ledger.Babbage.Core (CoinPerByte (..), getNativeScript)
 import           Cardano.Ledger.BaseTypes (AnchorData (..), DnsName, EpochInterval (..),
                    Network (..), NonNegativeInterval, ProtVer (..), StrictMaybe (..), UnitInterval,
                    Url, boundRational, dnsToText, hashAnchorData, maybeToStrictMaybe, mkVersion,
@@ -190,7 +200,7 @@ import           Cardano.Ledger.BaseTypes (AnchorData (..), DnsName, EpochInterv
                    unboundRational, urlToText)
 import           Cardano.Ledger.Binary (Annotated (..), ByteSpan (..), byronProtVer, fromCBOR,
                    serialize', slice, toCBOR, toPlainDecoder)
-import           Cardano.Ledger.Binary.Plain (Decoder)
+import           Cardano.Ledger.Binary.Plain (Decoder, serializeAsHexText)
 import           Cardano.Ledger.CertState (DRepState (..), csCommitteeCredsL)
 import           Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
 import           Cardano.Ledger.Conway.Core (DRepVotingThresholds (..), PoolVotingThresholds (..),
@@ -212,6 +222,7 @@ import           Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drep
 import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VKey (..),
                    hashWithSerialiser)
 import           Cardano.Ledger.Plutus.Data (Data (..), unData)
+import           Cardano.Ledger.Plutus.Language (Language, Plutus, languageToText, plutusBinary)
 import           Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))
 import           Cardano.Ledger.SafeHash (SafeHash, castSafeHash, extractHash, unsafeMakeSafeHash)
 import           Cardano.Ledger.Shelley.API (AccountState (..), GenDelegPair (..),

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -119,6 +119,7 @@ module Cardano.Api.ReexposeLedger
   , AsIx (..)
   , CoinPerWord (..)
   , Data (..)
+  , EraTxWits (..)
   , ExUnits (..)
   , Prices (..)
   , CostModels
@@ -168,7 +169,7 @@ where
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
 import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBody (..),
                    AlonzoEraTxWits (..), AsIx (..), AsIxItem (AsIxItem), CoinPerWord (..), EraGov,
-                   EraTx (bodyTxL, witsTxL), PParamsUpdate (..), Tx, ppPricesL)
+                   EraTx (bodyTxL, witsTxL), EraTxWits (..), PParamsUpdate (..), Tx, ppPricesL)
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), CostModels, ExUnits (..),
                    Prices (..))

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -128,6 +128,7 @@ module Cardano.Api.ReexposeLedger
   , EraGov
   , EraTx (witsTxL, bodyTxL)
   , Tx
+  , TxDats (..)
   , ppPricesL
   , unData
   , unRedeemers
@@ -173,6 +174,7 @@ import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBo
 import           Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis)
 import           Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), CostModels, ExUnits (..),
                    Prices (..))
+import           Cardano.Ledger.Alonzo.TxWits (TxDats (..))
 import           Cardano.Ledger.Api (Constitution (..), GovAction (..), unRedeemers)
 import           Cardano.Ledger.Api.Tx.Cert (pattern AuthCommitteeHotKeyTxCert,
                    pattern DelegStakeTxCert, pattern DelegTxCert, pattern GenesisDelegTxCert,

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -259,7 +259,7 @@ fromPlutusData (PlutusAPI.List xs) =
 fromPlutusData (PlutusAPI.I n) = ScriptDataNumber n
 fromPlutusData (PlutusAPI.B bs) = ScriptDataBytes bs
 
--- | Friendly script JSON
+-- | Create a friendly JSON out of a script
 friendlyScript :: AlonzoEraOnwardsConstraints era => Script (ShelleyLedgerEra era) -> Aeson.Value
 friendlyScript script = Aeson.Object $
   KeyMap.fromList $
@@ -281,7 +281,7 @@ friendlyScript script = Aeson.Object $
     , ("script", Aeson.String $ serializeAsHexText $ plutusBinary plutusScript)
     ]
 
--- | Friendly dats JSON
+-- | Create a friendly JSON out of a datum
 friendlyDatum
   :: AlonzoEraOnwardsConstraints era => Alonzo.Data (ShelleyLedgerEra era) -> Aeson.Value
 friendlyDatum (Alonzo.Data datum) = Aeson.String (T.pack $ show datum)

--- a/cardano-api/internal/Cardano/Api/ScriptData.hs
+++ b/cardano-api/internal/Cardano/Api/ScriptData.hs
@@ -17,6 +17,7 @@ module Cardano.Api.ScriptData
   , unsafeHashableScriptData
   , ScriptData (..)
   , friendlyScript
+  , friendlyDatum
 
     -- * Validating metadata
   , validateScriptData
@@ -65,6 +66,7 @@ import qualified Cardano.Crypto.Hash.Class as Crypto
 import           Cardano.Ledger.Allegra.Scripts (showTimelock)
 import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..))
 import           Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage)
+import qualified Cardano.Ledger.Api as Alonzo
 import           Cardano.Ledger.Binary.Plain (serializeAsHexText)
 import           Cardano.Ledger.Core (Era, EraScript (..), Script)
 import           Cardano.Ledger.Plutus (Language)
@@ -278,6 +280,11 @@ friendlyScript script = Aeson.Object $
     , ("plutus version", Aeson.String $ languageToText language)
     , ("script", Aeson.String $ serializeAsHexText $ plutusBinary plutusScript)
     ]
+
+-- | Friendly dats JSON
+friendlyDatum
+  :: AlonzoEraOnwardsConstraints era => Alonzo.Data (ShelleyLedgerEra era) -> Aeson.Value
+friendlyDatum (Alonzo.Data datum) = Aeson.String (T.pack $ show datum)
 
 -- ----------------------------------------------------------------------------
 -- Validate script data

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -548,6 +548,7 @@ module Cardano.Api
   , ScriptWitnessIndex (..)
   , renderScriptWitnessIndex
   , collectTxBodyScriptWitnesses
+  , friendlyDatum
   , friendlyScript
 
     -- ** Languages supported in each era

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -528,6 +528,7 @@ module Cardano.Api
   , eraOfScriptInEra
   , HasScriptLanguageInEra (..)
   , ToAlonzoScript (..)
+  , AlonzoEraOnwardsConstraints
 
     -- ** Use of a script in an era as a witness
   , WitCtxTxIn
@@ -548,8 +549,6 @@ module Cardano.Api
   , ScriptWitnessIndex (..)
   , renderScriptWitnessIndex
   , collectTxBodyScriptWitnesses
-  , friendlyDatum
-  , friendlyScript
 
     -- ** Languages supported in each era
   , ScriptLanguageInEra (..)

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -548,6 +548,7 @@ module Cardano.Api
   , ScriptWitnessIndex (..)
   , renderScriptWitnessIndex
   , collectTxBodyScriptWitnesses
+  , friendlyScript
 
     -- ** Languages supported in each era
   , ScriptLanguageInEra (..)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Exposed `Language`, `Plutus`, `Script`, `getNativeScript`, `languageToText`, `plutusBinary`, `plutusScriptLanguage`, `serializeAsHexText`, `showTimelock` in `Cardano.Api.Ledger`, and `AlonzoEraOnwardsConstraints` in `Cardano.Api`
  type:
  - feature
```

# Context

`friendlyTxBodyImpl` wasn't exposing information about `datums` nor `redeemers`. In order to address that, it is necessary to expose types through the `cardano-api` to be used by `cardano-cli`.

# How to trust this PR

I would look at the structure of the JSON that is generated mainly, and check whether the functions and types are exported in the right places. Also probably good to look at this PR in conjunction with https://github.com/IntersectMBO/cardano-cli/pull/977

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

