### PR TITLE
Implement Convert typeclass

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -71,6 +71,7 @@ library internal
     Cardano.Api.Eon.AlonzoEraOnwards
     Cardano.Api.Eon.BabbageEraOnwards
     Cardano.Api.Eon.ByronToAlonzoEra
+    Cardano.Api.Eon.Convert
     Cardano.Api.Eon.ConwayEraOnwards
     Cardano.Api.Eon.MaryEraOnwards
     Cardano.Api.Eon.ShelleyBasedEra

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -78,6 +78,7 @@ where
 
 import           Cardano.Api.Address
 import           Cardano.Api.DRepMetadata
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra
@@ -515,10 +516,10 @@ selectStakeCredentialWitness
 selectStakeCredentialWitness = \case
   ShelleyRelatedCertificate stbEra shelleyCert ->
     shelleyToBabbageEraConstraints stbEra $
-      getTxCertWitness (inject stbEra) shelleyCert
+      getTxCertWitness (convert stbEra) shelleyCert
   ConwayCertificate cEra conwayCert ->
     conwayEraOnwardsConstraints cEra $
-      getTxCertWitness (inject cEra) conwayCert
+      getTxCertWitness (convert cEra) conwayCert
 
 filterUnRegCreds
   :: Certificate era -> Maybe StakeCredential

--- a/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AllegraEraOnwards.hs
@@ -18,6 +18,7 @@ module Cardano.Api.Eon.AllegraEraOnwards
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -67,11 +68,11 @@ instance ToCardanoEra AllegraEraOnwards where
     AllegraEraOnwardsBabbage -> BabbageEra
     AllegraEraOnwardsConway -> ConwayEra
 
-instance Inject (AllegraEraOnwards era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert AllegraEraOnwards CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (AllegraEraOnwards era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert AllegraEraOnwards ShelleyBasedEra where
+  convert = \case
     AllegraEraOnwardsAllegra -> ShelleyBasedEraAllegra
     AllegraEraOnwardsMary -> ShelleyBasedEraMary
     AllegraEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
@@ -115,9 +116,9 @@ allegraEraOnwardsConstraints = \case
   AllegraEraOnwardsBabbage -> id
   AllegraEraOnwardsConway -> id
 
-{-# DEPRECATED allegraEraOnwardsToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED allegraEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 allegraEraOnwardsToShelleyBasedEra :: AllegraEraOnwards era -> ShelleyBasedEra era
-allegraEraOnwardsToShelleyBasedEra = inject
+allegraEraOnwardsToShelleyBasedEra = convert
 
 class IsShelleyBasedEra era => IsAllegraBasedEra era where
   allegraBasedEra :: AllegraEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/AlonzoEraOnwards.hs
@@ -18,6 +18,7 @@ module Cardano.Api.Eon.AlonzoEraOnwards
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
@@ -71,11 +72,11 @@ instance ToCardanoEra AlonzoEraOnwards where
     AlonzoEraOnwardsBabbage -> BabbageEra
     AlonzoEraOnwardsConway -> ConwayEra
 
-instance Inject (AlonzoEraOnwards era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert AlonzoEraOnwards CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (AlonzoEraOnwards era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert AlonzoEraOnwards ShelleyBasedEra where
+  convert = \case
     AlonzoEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
     AlonzoEraOnwardsBabbage -> ShelleyBasedEraBabbage
     AlonzoEraOnwardsConway -> ShelleyBasedEraConway
@@ -124,9 +125,9 @@ alonzoEraOnwardsConstraints = \case
   AlonzoEraOnwardsBabbage -> id
   AlonzoEraOnwardsConway -> id
 
-{-# DEPRECATED alonzoEraOnwardsToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED alonzoEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
-alonzoEraOnwardsToShelleyBasedEra = inject
+alonzoEraOnwardsToShelleyBasedEra = convert
 
 class IsMaryBasedEra era => IsAlonzoBasedEra era where
   alonzoBasedEra :: AlonzoEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/BabbageEraOnwards.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -21,6 +20,7 @@ module Cardano.Api.Eon.BabbageEraOnwards
 where
 
 import           Cardano.Api.Eon.AlonzoEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
@@ -70,14 +70,16 @@ instance ToCardanoEra BabbageEraOnwards where
     BabbageEraOnwardsBabbage -> BabbageEra
     BabbageEraOnwardsConway -> ConwayEra
 
-instance Inject (BabbageEraOnwards era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert BabbageEraOnwards CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (BabbageEraOnwards era) (ShelleyBasedEra era) where
-  inject = inject @(MaryEraOnwards era) . inject
+instance Convert BabbageEraOnwards ShelleyBasedEra where
+  convert = \case
+    BabbageEraOnwardsBabbage -> ShelleyBasedEraBabbage
+    BabbageEraOnwardsConway -> ShelleyBasedEraConway
 
-instance Inject (BabbageEraOnwards era) (MaryEraOnwards era) where
-  inject = \case
+instance Convert BabbageEraOnwards MaryEraOnwards where
+  convert = \case
     BabbageEraOnwardsBabbage -> MaryEraOnwardsBabbage
     BabbageEraOnwardsConway -> MaryEraOnwardsConway
 
@@ -124,9 +126,9 @@ babbageEraOnwardsConstraints = \case
   BabbageEraOnwardsBabbage -> id
   BabbageEraOnwardsConway -> id
 
-{-# DEPRECATED babbageEraOnwardsToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED babbageEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
-babbageEraOnwardsToShelleyBasedEra = inject
+babbageEraOnwardsToShelleyBasedEra = convert
 
 class IsAlonzoBasedEra era => IsBabbageBasedEra era where
   babbageBasedEra :: BabbageEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ByronToAlonzoEra.hs
@@ -15,6 +15,7 @@ module Cardano.Api.Eon.ByronToAlonzoEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eras.Core
 
 import           Data.Typeable (Typeable)
@@ -48,8 +49,8 @@ instance ToCardanoEra ByronToAlonzoEra where
     ByronToAlonzoEraMary -> MaryEra
     ByronToAlonzoEraAlonzo -> AlonzoEra
 
-instance Inject (ByronToAlonzoEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ByronToAlonzoEra CardanoEra where
+  convert = toCardanoEra
 
 type ByronToAlonzoEraConstraints era =
   ( IsCardanoEra era

--- a/cardano-api/internal/Cardano/Api/Eon/Convert.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/Convert.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.Api.Eon.Convert
+  ( Convert (..)
+  )
+where
+
+import           Data.Kind (Type)
+
+-- | The Convert class is aimed at exposing a single interface that lets us
+-- convert between eons. However this is generalizable to any injective
+-- relationship between types.
+class Convert (f :: a -> Type) (g :: a -> Type) where
+  convert :: forall era. f era -> g era

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -20,6 +20,7 @@ module Cardano.Api.Eon.ConwayEraOnwards
 where
 
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -67,15 +68,15 @@ instance ToCardanoEra ConwayEraOnwards where
   toCardanoEra = \case
     ConwayEraOnwardsConway -> ConwayEra
 
-instance Inject (ConwayEraOnwards era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ConwayEraOnwards CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ConwayEraOnwards era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ConwayEraOnwards ShelleyBasedEra where
+  convert = \case
     ConwayEraOnwardsConway -> ShelleyBasedEraConway
 
-instance Inject (ConwayEraOnwards era) (BabbageEraOnwards era) where
-  inject = \case
+instance Convert ConwayEraOnwards BabbageEraOnwards where
+  convert = \case
     ConwayEraOnwardsConway -> BabbageEraOnwardsConway
 
 type ConwayEraOnwardsConstraints era =
@@ -125,13 +126,13 @@ conwayEraOnwardsConstraints
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id
 
-{-# DEPRECATED conwayEraOnwardsToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED conwayEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 conwayEraOnwardsToShelleyBasedEra :: ConwayEraOnwards era -> ShelleyBasedEra era
-conwayEraOnwardsToShelleyBasedEra = inject
+conwayEraOnwardsToShelleyBasedEra = convert
 
-{-# DEPRECATED conwayEraOnwardsToBabbageEraOnwards "Use 'inject' instead." #-}
+{-# DEPRECATED conwayEraOnwardsToBabbageEraOnwards "Use 'convert' instead." #-}
 conwayEraOnwardsToBabbageEraOnwards :: ConwayEraOnwards era -> BabbageEraOnwards era
-conwayEraOnwardsToBabbageEraOnwards = inject
+conwayEraOnwardsToBabbageEraOnwards = convert
 
 class IsBabbageBasedEra era => IsConwayBasedEra era where
   conwayBasedEra :: ConwayEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/MaryEraOnwards.hs
@@ -19,6 +19,7 @@ module Cardano.Api.Eon.MaryEraOnwards
 where
 
 import           Cardano.Api.Eon.AllegraEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -68,11 +69,11 @@ instance ToCardanoEra MaryEraOnwards where
     MaryEraOnwardsBabbage -> BabbageEra
     MaryEraOnwardsConway -> ConwayEra
 
-instance Inject (MaryEraOnwards era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert MaryEraOnwards CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (MaryEraOnwards era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert MaryEraOnwards ShelleyBasedEra where
+  convert = \case
     MaryEraOnwardsMary -> ShelleyBasedEraMary
     MaryEraOnwardsAlonzo -> ShelleyBasedEraAlonzo
     MaryEraOnwardsBabbage -> ShelleyBasedEraBabbage
@@ -116,9 +117,9 @@ maryEraOnwardsConstraints = \case
   MaryEraOnwardsBabbage -> id
   MaryEraOnwardsConway -> id
 
-{-# DEPRECATED maryEraOnwardsToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED maryEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 maryEraOnwardsToShelleyBasedEra :: MaryEraOnwards era -> ShelleyBasedEra era
-maryEraOnwardsToShelleyBasedEra = inject
+maryEraOnwardsToShelleyBasedEra = convert
 
 class IsAllegraBasedEra era => IsMaryBasedEra era where
   maryBasedEra :: MaryEraOnwards era

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyBasedEra.hs
@@ -36,6 +36,7 @@ module Cardano.Api.Eon.ShelleyBasedEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
 import           Cardano.Api.Orphans ()
@@ -179,8 +180,8 @@ instance ToCardanoEra ShelleyBasedEra where
     ShelleyBasedEraBabbage -> BabbageEra
     ShelleyBasedEraConway -> ConwayEra
 
-instance Inject (ShelleyBasedEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyBasedEra CardanoEra where
+  convert = toCardanoEra
 
 -- | The class of eras that are based on Shelley. This allows uniform handling
 -- of Shelley-based eras, but also non-uniform by making case distinctions on

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyEraOnly.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.ShelleyEraOnly
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -60,11 +61,11 @@ instance ToCardanoEra ShelleyEraOnly where
   toCardanoEra = \case
     ShelleyEraOnlyShelley -> ShelleyEra
 
-instance Inject (ShelleyEraOnly era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyEraOnly CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ShelleyEraOnly era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ShelleyEraOnly ShelleyBasedEra where
+  convert = \case
     ShelleyEraOnlyShelley -> ShelleyBasedEraShelley
 
 type ShelleyEraOnlyConstraints era =
@@ -107,6 +108,6 @@ shelleyEraOnlyConstraints
 shelleyEraOnlyConstraints = \case
   ShelleyEraOnlyShelley -> id
 
-{-# DEPRECATED shelleyEraOnlyToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED shelleyEraOnlyToShelleyBasedEra "Use 'convert' instead." #-}
 shelleyEraOnlyToShelleyBasedEra :: ShelleyEraOnly era -> ShelleyBasedEra era
-shelleyEraOnlyToShelleyBasedEra = inject
+shelleyEraOnlyToShelleyBasedEra = convert

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAllegraEra.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.ShelleyToAllegraEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -63,11 +64,11 @@ instance ToCardanoEra ShelleyToAllegraEra where
     ShelleyToAllegraEraShelley -> ShelleyEra
     ShelleyToAllegraEraAllegra -> AllegraEra
 
-instance Inject (ShelleyToAllegraEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyToAllegraEra CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ShelleyToAllegraEra era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ShelleyToAllegraEra ShelleyBasedEra where
+  convert = \case
     ShelleyToAllegraEraShelley -> ShelleyBasedEraShelley
     ShelleyToAllegraEraAllegra -> ShelleyBasedEraAllegra
 
@@ -111,6 +112,6 @@ shelleyToAllegraEraConstraints = \case
   ShelleyToAllegraEraShelley -> id
   ShelleyToAllegraEraAllegra -> id
 
-{-# DEPRECATED shelleyToAllegraEraToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED shelleyToAllegraEraToShelleyBasedEra "Use 'convert' instead." #-}
 shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
-shelleyToAllegraEraToShelleyBasedEra = inject
+shelleyToAllegraEraToShelleyBasedEra = convert

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToAlonzoEra.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.ShelleyToAlonzoEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -65,11 +66,11 @@ instance ToCardanoEra ShelleyToAlonzoEra where
     ShelleyToAlonzoEraMary -> MaryEra
     ShelleyToAlonzoEraAlonzo -> AlonzoEra
 
-instance Inject (ShelleyToAlonzoEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyToAlonzoEra CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ShelleyToAlonzoEra era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ShelleyToAlonzoEra ShelleyBasedEra where
+  convert = \case
     ShelleyToAlonzoEraShelley -> ShelleyBasedEraShelley
     ShelleyToAlonzoEraAllegra -> ShelleyBasedEraAllegra
     ShelleyToAlonzoEraMary -> ShelleyBasedEraMary
@@ -115,4 +116,4 @@ shelleyToAlonzoEraConstraints = \case
   ShelleyToAlonzoEraAlonzo -> id
 
 shelleyToAlonzoEraToShelleyBasedEra :: ShelleyToAlonzoEra era -> ShelleyBasedEra era
-shelleyToAlonzoEraToShelleyBasedEra = inject
+shelleyToAlonzoEraToShelleyBasedEra = convert

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.ShelleyToBabbageEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -67,11 +68,11 @@ instance ToCardanoEra ShelleyToBabbageEra where
     ShelleyToBabbageEraAlonzo -> AlonzoEra
     ShelleyToBabbageEraBabbage -> BabbageEra
 
-instance Inject (ShelleyToBabbageEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyToBabbageEra CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ShelleyToBabbageEra era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ShelleyToBabbageEra ShelleyBasedEra where
+  convert = \case
     ShelleyToBabbageEraShelley -> ShelleyBasedEraShelley
     ShelleyToBabbageEraAllegra -> ShelleyBasedEraAllegra
     ShelleyToBabbageEraMary -> ShelleyBasedEraMary
@@ -117,6 +118,6 @@ shelleyToBabbageEraConstraints = \case
   ShelleyToBabbageEraAlonzo -> id
   ShelleyToBabbageEraBabbage -> id
 
-{-# DEPRECATED shelleyToBabbageEraToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED shelleyToBabbageEraToShelleyBasedEra "Use 'convert' instead." #-}
 shelleyToBabbageEraToShelleyBasedEra :: ShelleyToBabbageEra era -> ShelleyBasedEra era
-shelleyToBabbageEraToShelleyBasedEra = inject
+shelleyToBabbageEraToShelleyBasedEra = convert

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToMaryEra.hs
@@ -17,6 +17,7 @@ module Cardano.Api.Eon.ShelleyToMaryEra
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core
 import           Cardano.Api.Modes
@@ -63,11 +64,11 @@ instance ToCardanoEra ShelleyToMaryEra where
     ShelleyToMaryEraAllegra -> AllegraEra
     ShelleyToMaryEraMary -> MaryEra
 
-instance Inject (ShelleyToMaryEra era) (CardanoEra era) where
-  inject = toCardanoEra
+instance Convert ShelleyToMaryEra CardanoEra where
+  convert = toCardanoEra
 
-instance Inject (ShelleyToMaryEra era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert ShelleyToMaryEra ShelleyBasedEra where
+  convert = \case
     ShelleyToMaryEraShelley -> ShelleyBasedEraShelley
     ShelleyToMaryEraAllegra -> ShelleyBasedEraAllegra
     ShelleyToMaryEraMary -> ShelleyBasedEraMary
@@ -111,6 +112,6 @@ shelleyToMaryEraConstraints = \case
   ShelleyToMaryEraAllegra -> id
   ShelleyToMaryEraMary -> id
 
-{-# DEPRECATED shelleyToMaryEraToShelleyBasedEra "Use 'inject' instead." #-}
+{-# DEPRECATED shelleyToMaryEraToShelleyBasedEra "Use 'convert' instead." #-}
 shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
-shelleyToMaryEraToShelleyBasedEra = inject
+shelleyToMaryEraToShelleyBasedEra = convert

--- a/cardano-api/internal/Cardano/Api/Experimental/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Experimental/Eras.hs
@@ -33,6 +33,7 @@ module Cardano.Api.Experimental.Eras
 where
 
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra (ShelleyBasedEra (..), ShelleyLedgerEra)
 import qualified Cardano.Api.Eras as Api
 import           Cardano.Api.Eras.Core (BabbageEra, ConwayEra, Eon (..))
@@ -184,29 +185,29 @@ eraFromStringLike = \case
 -- instance IsEra ConwayEra where
 --   useEra = ConwayEra
 -- @
-{-# DEPRECATED eraToSbe "Use 'inject' instead." #-}
+{-# DEPRECATED eraToSbe "Use 'convert' instead." #-}
 eraToSbe
   :: Era era
   -> ShelleyBasedEra era
-eraToSbe = inject
+eraToSbe = convert
 
-instance Inject (Era era) (Api.CardanoEra era) where
-  inject = \case
+instance Convert Era Api.CardanoEra where
+  convert = \case
     BabbageEra -> Api.BabbageEra
     ConwayEra -> Api.ConwayEra
 
-instance Inject (Era era) (ShelleyBasedEra era) where
-  inject = \case
+instance Convert Era ShelleyBasedEra where
+  convert = \case
     BabbageEra -> ShelleyBasedEraBabbage
     ConwayEra -> ShelleyBasedEraConway
 
-instance Inject (Era era) (BabbageEraOnwards era) where
-  inject = \case
+instance Convert Era BabbageEraOnwards where
+  convert = \case
     BabbageEra -> BabbageEraOnwardsBabbage
     ConwayEra -> BabbageEraOnwardsConway
 
-instance Inject (BabbageEraOnwards era) (Era era) where
-  inject = \case
+instance Convert BabbageEraOnwards Era where
+  convert = \case
     BabbageEraOnwardsBabbage -> BabbageEra
     BabbageEraOnwardsConway -> ConwayEra
 
@@ -227,13 +228,13 @@ sbeToEra e@ShelleyBasedEraMary = throwError $ DeprecatedEra e
 sbeToEra e@ShelleyBasedEraAllegra = throwError $ DeprecatedEra e
 sbeToEra e@ShelleyBasedEraShelley = throwError $ DeprecatedEra e
 
-{-# DEPRECATED babbageEraOnwardsToEra "Use 'inject' instead." #-}
+{-# DEPRECATED babbageEraOnwardsToEra "Use 'convert' instead." #-}
 babbageEraOnwardsToEra :: BabbageEraOnwards era -> Era era
-babbageEraOnwardsToEra = inject
+babbageEraOnwardsToEra = convert
 
-{-# DEPRECATED eraToBabbageEraOnwards "Use 'inject' instead." #-}
+{-# DEPRECATED eraToBabbageEraOnwards "Use 'convert' instead." #-}
 eraToBabbageEraOnwards :: Era era -> BabbageEraOnwards era
-eraToBabbageEraOnwards = inject
+eraToBabbageEraOnwards = convert
 
 -------------------------------------------------------------------------
 

--- a/cardano-api/internal/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/internal/Cardano/Api/Experimental/Tx.hs
@@ -20,6 +20,7 @@ module Cardano.Api.Experimental.Tx
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras.Core (ToCardanoEra (toCardanoEra), forEraInEon)
 import           Cardano.Api.Experimental.Eras
@@ -63,7 +64,7 @@ makeUnsignedTx
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (UnsignedTx era)
 makeUnsignedTx era bc = obtainCommonConstraints era $ do
-  let sbe = inject era
+  let sbe = convert era
 
   -- cardano-api types
   let apiTxOuts = txOuts bc
@@ -139,7 +140,7 @@ eraSpecificLedgerTxBody
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (Ledger.TxBody (LedgerEra era))
 eraSpecificLedgerTxBody BabbageEra ledgerbody bc = do
-  let sbe = inject BabbageEra
+  let sbe = convert BabbageEra
 
   setUpdateProposal <- convTxUpdateProposal sbe (txUpdateProposal bc)
 

--- a/cardano-api/internal/Cardano/Api/Fees.hs
+++ b/cardano-api/internal/Cardano/Api/Fees.hs
@@ -52,6 +52,7 @@ import           Cardano.Api.Address
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
@@ -232,7 +233,7 @@ estimateBalancedTxBody
   totalUTxOValue = do
     -- Step 1. Substitute those execution units into the tx
 
-    let sbe = inject w
+    let sbe = convert w
     txbodycontent1 <-
       maryEraOnwardsConstraints w $
         first TxFeeEstimationScriptExecutionError $
@@ -1270,7 +1271,7 @@ calcReturnAndTotalCollateral
   -> (TxReturnCollateral CtxTx era, TxTotalCollateral era)
 calcReturnAndTotalCollateral _ _ _ TxInsCollateralNone _ _ _ _ = (TxReturnCollateralNone, TxTotalCollateralNone)
 calcReturnAndTotalCollateral w fee pp' TxInsCollateral{} txReturnCollateral txTotalCollateral cAddr totalAvailableCollateral = babbageEraOnwardsConstraints w $ do
-  let sbe = inject w
+  let sbe = convert w
       colPerc = pp' ^. Ledger.ppCollateralPercentageL
       -- We must first figure out how much lovelace we have committed
       -- as collateral and we must determine if we have enough lovelace at our

--- a/cardano-api/internal/Cardano/Api/Protocol.hs
+++ b/cardano-api/internal/Cardano/Api/Protocol.hs
@@ -98,7 +98,8 @@ instance
         (ProtocolParamsShelleyBased StandardCrypto)
         ProtVer
   protocolInfo (ProtocolInfoArgsShelley genesis paramsShelleyBased_ paramsShelley_) =
-    bimap inject (fmap $ map inject) $ protocolInfoShelley genesis paramsShelleyBased_ paramsShelley_
+    bimap inject (fmap $ map inject) $
+      protocolInfoShelley genesis paramsShelleyBased_ paramsShelley_
 
 instance
   Consensus.LedgerSupportsProtocol

--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -42,6 +42,7 @@ import           Cardano.Api.Address
 import           Cardano.Api.Block
 import           Cardano.Api.Certificate
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eras
@@ -164,7 +165,7 @@ queryPoolDistribution
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolDistribution era)))
 queryPoolDistribution era mPoolIds = do
-  let sbe = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolDistribution mPoolIds
 
 queryPoolState
@@ -179,7 +180,7 @@ queryPoolState
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedPoolState era)))
 queryPoolState era mPoolIds = do
-  let sbe = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryPoolState mPoolIds
 
 queryProtocolParameters
@@ -262,8 +263,7 @@ queryStakeAddresses sbe stakeCredentials networkId =
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeCredentials networkId
 
 queryStakeDelegDeposits
-  :: forall era block point r
-   . BabbageEraOnwards era
+  :: BabbageEraOnwards era
   -> Set StakeCredential
   -> LocalStateQueryExpr
       block
@@ -275,7 +275,7 @@ queryStakeDelegDeposits
 queryStakeDelegDeposits era stakeCreds
   | S.null stakeCreds = pure . pure $ pure mempty
   | otherwise = do
-      let sbe :: ShelleyBasedEra era = inject era
+      let sbe = convert era
       queryExpr $ QueryInEra . QueryInShelleyBasedEra sbe $ QueryStakeDelegDeposits stakeCreds
 
 queryStakeDistribution
@@ -332,7 +332,7 @@ queryStakeSnapshot
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (SerialisedStakeSnapshots era)))
 queryStakeSnapshot era mPoolIds = do
-  let sbe = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeSnapshot mPoolIds
 
 querySystemStart
@@ -366,7 +366,7 @@ queryConstitution
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (L.Constitution (ShelleyLedgerEra era))))
 queryConstitution era = do
-  let sbe = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryConstitution
 
 queryGovState
@@ -380,12 +380,11 @@ queryGovState
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (L.GovState (ShelleyLedgerEra era))))
 queryGovState era = do
-  let sbe = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGovState
 
 queryDRepState
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> Set (L.Credential L.DRepRole L.StandardCrypto)
   -- ^ An empty credentials set means that states for all DReps will be returned
   -> LocalStateQueryExpr
@@ -399,12 +398,11 @@ queryDRepState
           (Either EraMismatch (Map (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto)))
       )
 queryDRepState era drepCreds = do
-  let sbe :: ShelleyBasedEra era = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepState drepCreds
 
 queryDRepStakeDistribution
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> Set (L.DRep L.StandardCrypto)
   -- ^ An empty DRep set means that distributions for all DReps will be returned
   -> LocalStateQueryExpr
@@ -415,12 +413,11 @@ queryDRepStakeDistribution
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (Map (L.DRep L.StandardCrypto) L.Coin)))
 queryDRepStakeDistribution era dreps = do
-  let sbe = inject era :: ShelleyBasedEra era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryDRepStakeDistr dreps
 
 querySPOStakeDistribution
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> Set (L.KeyHash 'L.StakePool L.StandardCrypto)
   -- ^ An empty SPO key hash set means that distributions for all SPOs will be returned
   -> LocalStateQueryExpr
@@ -434,14 +431,13 @@ querySPOStakeDistribution
           (Either EraMismatch (Map (L.KeyHash 'L.StakePool L.StandardCrypto) L.Coin))
       )
 querySPOStakeDistribution era spos = do
-  let sbe = inject era :: ShelleyBasedEra era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QuerySPOStakeDistr spos
 
 -- | Returns info about committee members filtered by: cold credentials, hot credentials and statuses.
 -- If empty sets are passed as filters, then no filtering is done.
 queryCommitteeMembersState
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> Set (L.Credential L.ColdCommitteeRole L.StandardCrypto)
   -> Set (L.Credential L.HotCommitteeRole L.StandardCrypto)
   -> Set L.MemberStatus
@@ -453,14 +449,13 @@ queryCommitteeMembersState
       IO
       (Either UnsupportedNtcVersionError (Either EraMismatch (L.CommitteeMembersState L.StandardCrypto)))
 queryCommitteeMembersState era coldCreds hotCreds statuses = do
-  let sbe = inject era :: ShelleyBasedEra era
+  let sbe = convert era
   queryExpr $
     QueryInEra $
       QueryInShelleyBasedEra sbe (QueryCommitteeMembersState coldCreds hotCreds statuses)
 
 queryStakeVoteDelegatees
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> Set StakeCredential
   -> LocalStateQueryExpr
       block
@@ -473,12 +468,11 @@ queryStakeVoteDelegatees
           (Either EraMismatch (Map StakeCredential (L.DRep L.StandardCrypto)))
       )
 queryStakeVoteDelegatees era stakeCredentials = do
-  let sbe :: ShelleyBasedEra era = inject era
+  let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe $ QueryStakeVoteDelegatees stakeCredentials
 
 queryAccountState
-  :: forall era block point r
-   . ConwayEraOnwards era
+  :: ConwayEraOnwards era
   -> LocalStateQueryExpr
       block
       point
@@ -488,5 +482,5 @@ queryAccountState
       (Either UnsupportedNtcVersionError (Either EraMismatch L.AccountState))
 queryAccountState cOnwards =
   queryExpr $
-    QueryInEra . QueryInShelleyBasedEra (inject cOnwards :: ShelleyBasedEra era) $
+    QueryInEra . QueryInShelleyBasedEra (convert cOnwards) $
       QueryAccountState

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -193,6 +193,7 @@ import           Cardano.Api.Certificate
 import           Cardano.Api.Eon.AllegraEraOnwards
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
@@ -964,17 +965,19 @@ instance IsShelleyBasedEra era => FromJSON (TxOutValue era) where
     caseShelleyToAllegraOrMaryEraOnwards
       ( \shelleyToAlleg -> do
           ll <- o .: "lovelace"
+          let sbe = convert shelleyToAlleg
           pure $
-            shelleyBasedEraConstraints (inject shelleyToAlleg :: ShelleyBasedEra era) $
-              TxOutValueShelleyBased (inject shelleyToAlleg) $
-                A.mkAdaValue (inject shelleyToAlleg :: ShelleyBasedEra era) ll
+            shelleyBasedEraConstraints sbe $
+              TxOutValueShelleyBased sbe $
+                A.mkAdaValue sbe ll
       )
       ( \w -> do
           let l = toList o
+              sbe = convert w
           vals <- mapM decodeAssetId l
           pure $
-            shelleyBasedEraConstraints (inject w :: ShelleyBasedEra era) $
-              TxOutValueShelleyBased (inject w) $
+            shelleyBasedEraConstraints sbe $
+              TxOutValueShelleyBased sbe $
                 toLedgerValue w $
                   mconcat vals
       )
@@ -2081,7 +2084,7 @@ fromAlonzoTxOut w txdatums txOut =
       (fromAlonzoTxOutDatum w txdatums (txOut ^. L.dataHashTxOutL))
       ReferenceScriptNone
  where
-  sbe :: ShelleyBasedEra era = inject w
+  sbe :: ShelleyBasedEra era = convert w
 
 fromAlonzoTxOutDatum
   :: ()
@@ -2113,7 +2116,7 @@ fromBabbageTxOut w txdatums txout =
           SJust rScript -> fromShelleyScriptToReferenceScript shelleyBasedEra rScript
       )
  where
-  sbe :: ShelleyBasedEra era = inject w
+  sbe :: ShelleyBasedEra era = convert w
 
   -- NOTE: This is different to 'fromBabbageTxOutDatum' as it may resolve
   -- 'DatumHash' values using the datums included in the transaction.

--- a/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
@@ -13,10 +13,10 @@ module Cardano.Api.Tx.Compatible
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.Eon.ShelleyToBabbageEra
-import           Cardano.Api.Eras
 import           Cardano.Api.ProtocolParameters
 import           Cardano.Api.Script
 import           Cardano.Api.Tx.Body
@@ -67,7 +67,7 @@ createCompatibleSignedTx sbeF ins outs witnesses txFee' anyProtocolUpdate anyVot
   shelleyBasedEraConstraints sbeF $ do
     tx <- case anyProtocolUpdate of
       ProtocolUpdate shelleyToBabbageEra updateProposal -> do
-        let sbe = inject shelleyToBabbageEra
+        let sbe = convert shelleyToBabbageEra
 
         ledgerPParamsUpdate <- toLedgerUpdate sbe updateProposal
 
@@ -86,7 +86,7 @@ createCompatibleSignedTx sbeF ins outs witnesses txFee' anyProtocolUpdate anyVot
 
         return $ ShelleyTx sbe finalTx
       ProposalProcedures conwayOnwards proposalProcedures -> do
-        let sbe = inject conwayOnwards
+        let sbe = convert conwayOnwards
             proposals = convProposalProcedures proposalProcedures
             apiScriptWitnesses = scriptWitnessesProposing proposalProcedures
             ledgerScripts = convScripts apiScriptWitnesses

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Api.Transaction.Autobalance
 where
 
 import           Cardano.Api
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Fees
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as L
@@ -56,9 +57,9 @@ import           Test.Tasty.Hedgehog (testProperty)
 prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset :: Property
 prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.propertyOnce $ do
   let ceo = ConwayEraOnwardsConway
-      beo = inject ceo
-      meo = inject beo
-      sbe = inject ceo
+      beo = convert ceo
+      meo = convert beo
+      sbe = convert ceo
       era = toCardanoEra sbe
   aeo <- H.nothingFail $ forEraMaybeEon @AlonzoEraOnwards era
 
@@ -140,9 +141,9 @@ prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.pr
 prop_make_transaction_body_autobalance_multi_asset_collateral :: Property
 prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $ do
   let ceo = ConwayEraOnwardsConway
-      beo = inject ceo
-      sbe = inject beo
-      meo = inject beo
+      beo = convert ceo
+      sbe = convert beo
+      meo = convert beo
       era = toCardanoEra sbe
   aeo <- H.nothingFail $ forEraMaybeEon @AlonzoEraOnwards era
 
@@ -205,8 +206,8 @@ prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $
 prop_calcReturnAndTotalCollateral :: Property
 prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
   let beo = BabbageEraOnwardsConway
-      sbe = inject beo
-      era = inject beo
+      sbe = convert beo
+      era = convert beo
   feeCoin@(L.Coin fee) <- forAll genLovelace
   totalCollateral <- forAll $ genValueForTxOut sbe
   let totalCollateralAda = totalCollateral ^. L.adaAssetL sbe
@@ -308,7 +309,7 @@ textEnvTypes =
 
 mkUtxos :: BabbageEraOnwards era -> L.ScriptHash L.StandardCrypto -> UTxO era
 mkUtxos beo scriptHash = babbageEraOnwardsConstraints beo $ do
-  let sbe = inject beo
+  let sbe = convert beo
   UTxO
     [
       ( TxIn
@@ -356,7 +357,7 @@ mkTxOutput
   -- ^ there will be an asset in the txout if provided
   -> [TxOut CtxTx era]
 mkTxOutput beo address mScriptHash = babbageEraOnwardsConstraints beo $ do
-  let sbe = inject beo
+  let sbe = convert beo
   [ TxOut
       address
       ( TxOutValueShelleyBased


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    We introduce the `Convert` type class as an alternative to cardano-ledger's `Inject` typeclass.
    While `Inject` is more general, `Convert` is specifically designed for transformations between era-indexed types, 
    making the intent clearer at call sites where we're converting between eons. 

  type:
  - feature        # introduces a new feature
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
