### PR TITLE
fromProposalProcedure: return StakeCredential

### DIFF
--- a/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/internal/Cardano/Api/Governance/Actions/ProposalProcedure.hs
@@ -15,7 +15,6 @@ module Cardano.Api.Governance.Actions.ProposalProcedure where
 import           Cardano.Api.Address
 import           Cardano.Api.Eon.ShelleyBasedEra
 import           Cardano.Api.HasTypeProxy
-import           Cardano.Api.Keys.Shelley
 import           Cardano.Api.ProtocolParameters
 import qualified Cardano.Api.ReexposeLedger as Ledger
 import           Cardano.Api.SerialiseCBOR
@@ -196,15 +195,12 @@ createProposalProcedure sbe nw dep cred govAct anchor =
 fromProposalProcedure
   :: ShelleyBasedEra era
   -> Proposal era
-  -> (L.Coin, Hash StakeKey, GovernanceAction era)
+  -> (L.Coin, StakeCredential, GovernanceAction era)
 fromProposalProcedure sbe (Proposal pp) =
   shelleyBasedEraConstraints
     sbe
     ( Gov.pProcDeposit pp
-    , case fromShelleyStakeCredential (L.raCredential (Gov.pProcReturnAddr pp)) of
-        StakeCredentialByKey keyhash -> keyhash
-        StakeCredentialByScript _scripthash ->
-          error "fromProposalProcedure TODO: Conway era script reward addresses not yet supported"
+    , fromShelleyStakeCredential (L.raCredential (Gov.pProcReturnAddr pp))
     , fromGovernanceAction (Gov.pProcGovAction pp)
     )
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    fromProposalProcedure: return StakeCredential
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Required for fixing https://github.com/IntersectMBO/cardano-api/issues/682

# How to trust this PR

The only caller in CLI is perfectly having `fromProposalProcedure` returning a `StakeCredential`, as visible in https://github.com/IntersectMBO/cardano-cli/pull/978.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff