### PR TITLE
GH CI: do not run on MacOS since it's broken

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -25,14 +25,14 @@ jobs:
         sys:
           - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
           - { os: ubuntu-latest, shell: bash }
-        include:
+        # include:
           # Using include, to make sure there will only be one macOS job, even if the matrix gets expanded later on.
           # We want a single job, because macOS runners are scarce.
-          - cabal: "3.12"
-            ghc: "9.6"
-            sys:
-              os: macos-latest
-              shell: bash
+          # - cabal: "3.12"
+          #   ghc: "9.6"
+          #   sys:
+          #     os: macos-latest
+          #     shell: bash
 
     defaults:
         run:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    GH CI: do not run on MacOS since it's broken
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

As [recently updated PRs](https://github.com/IntersectMBO/cardano-api/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen) on API show, the MacOS CI is broken right now, see for example 

![image](https://github.com/user-attachments/assets/fd38de22-aaf6-4dc1-af55-38173de87d39)

on https://github.com/IntersectMBO/cardano-api/pull/691 and https://github.com/IntersectMBO/cardano-api/pull/692

This failure was raised on Slack but didn't gain traction: https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1732543089865619

So this PR turns off the GitHub action build on MacOS for now.

# How to trust this PR

It's less checks. Don't trust it.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff