### PR TITLE
Revert "Switch to system dependencies action fork to fix macos build issues"

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -76,8 +76,7 @@ jobs:
         cabal-version: ${{ matrix.cabal }}
 
     - name: Install system dependencies
-      # TODO: switch to input-output-hk/actions/base@latest after https://github.com/input-output-hk/actions/pull/29 gets merged
-      uses: carbolymer/actions/base@latest
+      uses: input-output-hk/actions/base@latest
       with:
         use-sodium-vrf: true # default is true
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use iohk `actions` again, after it has been fixed
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Since https://github.com/input-output-hk/actions/pull/29 was merged, we don't need @carbolymer's fork (that served us well though, we merged many PRs last night :stuck_out_tongue:).

# How to trust this PR

* It's a revert of https://github.com/IntersectMBO/cardano-api/pull/694
* The CI passes

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff