### PR TITLE
Export the Convert class

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -145,7 +145,6 @@ import qualified Cardano.Binary as CBOR
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hash.Class as CRYPTO
 import qualified Cardano.Crypto.Seed as Crypto
-import           Cardano.Api.Eon.Convert
 import qualified Cardano.Ledger.Alonzo.Scripts as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
 import qualified Cardano.Ledger.Core as Ledger

--- a/cardano-api/internal/Cardano/Api/Eras.hs
+++ b/cardano-api/internal/Cardano/Api/Eras.hs
@@ -30,6 +30,7 @@ module Cardano.Api.Eras
   , maybeEon
   , monoidForEraInEon
   , monoidForEraInEonA
+  , Convert (..)
   , Inject (..)
 
     -- * Data family instances
@@ -49,5 +50,6 @@ module Cardano.Api.Eras
   )
 where
 
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eras.Case
 import           Cardano.Api.Eras.Core

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -48,6 +48,7 @@ module Cardano.Api
   , unFeatured
   , asFeaturedInEra
   , asFeaturedInShelleyBasedEra
+  , Convert (..)
   , Inject (..)
 
     -- * Eons
@@ -1045,6 +1046,7 @@ import           Cardano.Api.Eon.AllegraEraOnwards
 import           Cardano.Api.Eon.AlonzoEraOnwards
 import           Cardano.Api.Eon.BabbageEraOnwards
 import           Cardano.Api.Eon.ByronToAlonzoEra
+import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Eon.ConwayEraOnwards
 import           Cardano.Api.Eon.MaryEraOnwards
 import           Cardano.Api.Eon.ShelleyBasedEra

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Api.Transaction.Autobalance
 where
 
 import           Cardano.Api
-import           Cardano.Api.Eon.Convert
 import           Cardano.Api.Fees
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Ledger.Lens as L


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Export the Convert class
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

https://github.com/IntersectMBO/cardano-api/pull/690 overlooked exporting the new `Convert` class. This PR fixes this.

# How to trust this PR

It's just an additional export

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff