### PR TITLE
Added examples of transaction creation to Haddock

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -77,6 +77,8 @@ library
     Cardano.Api.Internal.Eon.ShelleyBasedEra
     Cardano.Api.Internal.Eras
     Cardano.Api.Internal.Error
+    Cardano.Api.Internal.Experimental.Eras
+    Cardano.Api.Internal.Experimental.Tx
     Cardano.Api.Internal.Fees
     Cardano.Api.Internal.Genesis
     Cardano.Api.Internal.GenesisParameters
@@ -92,6 +94,7 @@ library
     Cardano.Api.Internal.Script
     Cardano.Api.Internal.SerialiseLedgerCddl
     Cardano.Api.Internal.SerialiseTextEnvelope
+    Cardano.Api.Internal.Tx.Body
     Cardano.Api.Internal.Tx.Sign
     Cardano.Api.Ledger
     Cardano.Api.Ledger.Lens
@@ -197,8 +200,6 @@ library
     Cardano.Api.Internal.Eon.ShelleyToMaryEra
     Cardano.Api.Internal.Eras.Case
     Cardano.Api.Internal.Eras.Core
-    Cardano.Api.Internal.Experimental.Eras
-    Cardano.Api.Internal.Experimental.Tx
     Cardano.Api.Internal.Feature
     Cardano.Api.Internal.Governance.Actions.ProposalProcedure
     Cardano.Api.Internal.Governance.Actions.VotingProcedure
@@ -247,7 +248,6 @@ library
     Cardano.Api.Internal.SerialiseUsing
     Cardano.Api.Internal.SpecialByron
     Cardano.Api.Internal.StakePoolMetadata
-    Cardano.Api.Internal.Tx.Body
     Cardano.Api.Internal.Tx.UTxO
     Cardano.Api.Internal.TxIn
     Cardano.Api.Internal.TxMetadata

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -1,7 +1,16 @@
--- | This module provides an experimental library interface that is intended
--- to replace the existing api. It is subject to dramatic changes so use with caution.
+-- |
+-- This module provides an experimental library interface intended to replace the existing API.
+-- It is subject to significant changes. Please, use it with caution.
 module Cardano.Api.Experimental
-  ( -- * Tx related
+  ( -- * Creating transactions
+
+    -- |
+    -- For details and an example of creating a transaction using the experimental API,
+    -- see the "Cardano.Api.Internal.Experimental.Tx" documentation.
+
+    -- * Contents
+
+    -- ** Transaction-related
     UnsignedTx (..)
   , UnsignedTxError (..)
   , makeUnsignedTx
@@ -12,7 +21,8 @@ module Cardano.Api.Experimental
   , obtainCommonConstraints
   , hashTxBody
   , evaluateTransactionExecutionUnitsShelley
-  -- Era related
+
+    -- ** Era-related
   , BabbageEra
   , ConwayEra
   , Era (..)

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
@@ -61,14 +61,16 @@ import GHC.Exts (IsString)
 import Prettyprinter
 
 -- | Users typically interact with the latest features on the mainnet or experiment with features
--- from the upcoming era. Hence, the protocol versions are limited to the current mainnet era
--- and the next era (upcoming era).
+-- from the upcoming era. Therefore, protocol versions are limited to the current mainnet era
+-- and the next (upcoming) era.
 type family LedgerEra era = (r :: Type) | r -> era where
   LedgerEra BabbageEra = Ledger.Babbage
   LedgerEra ConwayEra = Ledger.Conway
 
--- | An existential wrapper for types of kind @k -> Types@. Use it to hold any era e.g. @Some Era@. One can
--- then bring the era witness back into scope for example using this pattern:
+-- | An existential wrapper for types of kind @k -> Type@. It can hold any
+-- era, for example, @Some Era@. The era witness can be brought back into scope,
+-- for example, using this pattern:
+--
 -- @
 -- anyEra = Some ConwayEra
 -- -- then later in the code
@@ -82,15 +84,15 @@ data Some (f :: k -> Type) where
     => f a
     -> Some f
 
--- | Represents the eras in Cardano's blockchain.
--- This type represents eras currently on mainnet and new eras which are
--- in development.
+-- | Represents the latest Cardano blockchain eras, including
+-- the one currently on mainnet and the upcoming one.
 --
--- After a hardfork, the era from which we hardfork from gets deprecated and
--- after deprecation period, gets removed. During deprecation period,
--- consumers of cardano-api should update their codebase to the mainnet era.
+-- After a hard fork takes place, the era on mainnet before the hard fork
+-- is deprecated and, after a deprecation period, removed from @cardano-api@.
+-- During the deprecation period, @cardano-api@ users should update their
+-- codebase to the new mainnet era.
 data Era era where
-  -- | The era currently active on Cardano's mainnet.
+  -- | The currently active era on the Cardano mainnet.
   BabbageEra :: Era BabbageEra
   -- | The upcoming era in development.
   ConwayEra :: Era ConwayEra
@@ -159,15 +161,16 @@ eraFromStringLike = \case
   "Conway" -> pure $ Some ConwayEra
   wrong -> Left wrong
 
--- | How to deprecate an era
+-- | How to deprecate an era:
 --
---   1. Add DEPRECATED pragma to the era type tag and the era constructor at the same time:
+--   1. Add the DEPRECATED pragma to the era type tag and constructor at the same time:
+--
 -- @
 -- {-# DEPRECATED BabbageEra "BabbageEra no longer supported, use ConwayEra" #-}
 -- data BabbageEra
 -- @
 --
---   2. Update haddock for the constructor of the deprecated era, mentioning deprecation.
+--   2. Update the Haddock documentation for the constructor of the deprecated era, mentioning the deprecation.
 --
 -- @
 -- data Era era where
@@ -177,7 +180,9 @@ eraFromStringLike = \case
 --   ConwayEra :: Era ConwayEra
 -- @
 --
---   3. Add new 'IsEra' instance and update the deprecated era instance to produce a compile-time error:
+--   3. Add a new 'IsEra' instance and update the deprecated era instance to
+--   produce a compile-time error:
+--
 -- @
 -- instance TypeError ('Text "IsEra BabbageEra: Deprecated. Update to ConwayEra") => IsEra BabbageEra where
 --   useEra = error "unreachable"
@@ -248,7 +253,7 @@ instance IsEra BabbageEra where
 instance IsEra ConwayEra where
   useEra = ConwayEra
 
--- | A temporary compatibility instance, for easier conversion between experimental and old API.
+-- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
 instance Eon Era where
   inEonForEra v f = \case
     Api.ConwayEra -> f ConwayEra

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -17,20 +17,194 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
 
--- | Transaction bodies
 module Cardano.Api.Internal.Tx.Body
-  ( parseTxId
+  ( -- * Creating transactions using the old API
 
-    -- * Transaction bodies
+    -- |
+    -- Both the old and new APIs support transaction creation. Transactions can be
+    -- converted between formats, as they share the same underlying representation.
+    -- @cardano-api@ will be moving towards using the new API and deprecating
+    -- the old way to ensure simplicity, closer alignment with the ledger, and
+    -- easier maintenance.
+    --
+    -- In both the new and old APIs, to construct a transaction, you need
+    -- to construct a 'TxBodyContent', and you will need at least a
+    -- witness (for example, a 'ShelleyWitnessSigningKey'), to sign the transaction.
+    -- This process remains unchanged.
+    --
+    -- To learn how to create a transaction using the new API, refer to
+    -- "Cardano.Api.Internal.Experimental.Tx" documentation.
+    --
+    -- The next examples use the following qualified modules:
+    --
+    -- @
+    -- import qualified Cardano.Api as Api                -- the general `cardano-api` exports (including the old API)
+    -- import qualified Cardano.Api.Script as Script      -- types related to scripts (Plutus and native)
+    -- import qualified Cardano.Api.Ledger as Ledger      -- cardano-ledger re-exports
+    -- @
+
+    -- ** Creating a 'TxBodyContent'
+
+    -- |
+    --
+    -- To create a transaction, you first need to define the contents of its body. This section
+    -- will show how to use the API to create a 'TxBodyContent' for a simple transaction.
+    --
+    -- 'TxBodyContent' datatype provides several fields because transactions can serve multiple
+    -- purposes, but the function 'defaultTxBodyContent' (exported from "Cardano.Api") already provides
+    -- a base 'TxBodyContent' with all fields set to their default values that you can use as a starting point
+    -- so as not to have to set all fields manually.
+    --
+    -- The 'defaultTxBodyContent' takes, as the only parameter, the 'ShelleyBasedEra' witness for the era
+    -- you are working with. For example, if you are working with the 'ConwayEra', use 'shelleyBasedEra'
+    -- available in "Cardano.Api", as follows:
+    --
+    -- @
+    -- let sbe :: Api.ShelleyBasedEra Api.ConwayEra = Api.shelleyBasedEra
+    -- @
+    --
+    -- This is what creating a simple 'TxBodyContent' would look like.
+    --
+    -- First, choose a transaction output to spend (a UTXO). Specify which UTXO to spend by
+    -- providing the transaction ID and the index of the output in that transaction that you want
+    -- to spend.
+    --
+    -- To specify the transaction ID, you can use the 'deserialiseFromRawBytesHex' function on the
+    -- hexadecimal representation of the transaction hash. For example:
+    --
+    -- @
+    -- let (Right srcTxId) = Api.deserialiseFromRawBytesHex Api.AsTxId "be6efd42a3d7b9a00d09d77a5d41e55ceaf0bd093a8aa8a893ce70d9caafd978"
+    -- @
+    --
+    -- In real implementations, failure cases should be handled appropriately.
+    --
+    -- To specify the transaction index, use the 'TxIx' constructor. For example:
+    --
+    -- @
+    -- let srcTxIx = Api.TxIx 0
+    -- @
+    --
+    -- Now, combine both to create a 'TxIn' value and pair it with a witness requirement using 'BuildTxWith' :
+    --
+    -- @
+    -- let txIn = ( Api.TxIn srcTxId srcTxIx
+    --            , Api.BuildTxWith (Api.KeyWitness Api.KeyWitnessForSpending)
+    --            )
+    -- @
+    --
+    -- Next, specify the address of the recipient of the transaction. If you have the bech32 representation,
+    -- you can use the 'deserialiseAddress' function to get the 'AddressInEra' type. For example:
+    --
+    -- @
+    -- let (Just destAddress) = Api.deserialiseAddress (Api.AsAddressInEra eraAsType) "addr_test1vzpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpcue4v2v"
+    -- @
+    --
+    -- Now, you can create a 'TxOut' value. For simplicity, assume the output is a simple payment output
+    -- of 10 ada, with no datum or reference script attached to it:
+    --
+    -- @
+    -- let txOut = Api.TxOut
+    --               destAddress
+    --               (Api.lovelaceToTxOutValue sbe 10_000_000)
+    --               Api.TxOutDatumNone
+    --               Script.ReferenceScriptNone
+    -- @
+    --
+    -- Note to set the transaction fee. For example, set it to 2 ada:
+    --
+    -- @
+    -- let txFee = Api.TxFeeExplicit sbe 2_000_000
+    -- @
+    --
+    -- Finally, you can create the 'TxBodyContent' by using the 'defaultTxBodyContent' function and
+    -- putting everything together:
+    --
+    -- @
+    -- let txBodyContent = Api.defaultTxBodyContent sbe
+    --                      & Api.setTxIns [txIn]
+    --                      & Api.setTxOuts [txOut]
+    --                      & Api.setTxFee txFee
+    -- @
+    --
+    -- The 'txBodyContent' can now be used to create a transaction using the old or the new API.
+
+    -- ** Balancing a transaction
+
+    -- |
+    -- If you have a UTXO with exactly 12 ada, you could just construct the transaction as in the
+    -- previous section directly, and it would be a valid transaction, but:
+    --
+    --   * It is probably wasting ADA
+    --   * There may not be exactly one UTXO of 12 ada
+    --   * The transaciton may not be this simple.
+    --
+    -- For these reasons, it is recommended that you balance the transaction before proceeding with
+    -- signing and submitting.
+    --
+    -- See how to balance a transaction in the "Cardano.Api.Internal.Fees" documentation.
+
+    -- ** Creating a 'ShelleyWitnessSigningKey'
+
+    -- |
+    -- Signing a transaction requires a witness, for example, a 'ShelleyWitnessSigningKey'.
+    --
+    -- Learn how to create a 'ShelleyWitnessSigningKey' in the "Cardano.Api.Internal.Tx.Sign" documentation.
+
+    -- ** Creating a transaction using the old API
+
+    -- |
+    -- Now that you have a 'TxBodyContent' and a 'ShelleyWitnessSigningKey', you can easily create a transaction using the old API.
+    -- First, create a transaction body using the 'createTransactionBody' function and the 'ShelleyBasedEra' witness
+    -- defined earlier.
+    --
+    -- Create the transaction body using the 'TransactionBodyContent' created earlier:
+    --
+    -- @
+    -- let (Right txBody) = Api.createTransactionBody sbe txBodyContent
+    -- @
+    --
+    -- Then, sign the transaction using the 'signShelleyTransaction' function and the witness:
+    --
+    -- @
+    -- let oldApiSignedTx :: Api.Tx Api.ConwayEra = Api.signShelleyTransaction sbe txBody [witness]
+    -- @
+    --
+    -- We now have a signed transaction.
+
+    -- ** Inspecting transactions
+
+    -- |
+    -- To deconstruct an old-style 'TxBody' into a 'TxBodyContent', you can also use the
+    -- 'TxBody' pattern. Note that this cannot be used for constructing. For that, use 'ShelleyTxBody'
+    -- or 'createTransactionBody', as in the example.
+    --
+    -- To extract the 'TxBody' and the 'KeyWitness'es from an old-style 'Tx', use
+    -- the functions 'getTxBody' and 'getTxWitnesses' respectively, from "Cardano.Api".
+
+    -- ** Appendix: Getting Shelley-based era witness from the new API
+
+    -- |
+    -- If you are using the new API, you can also derive the 'ShelleyBasedEra' of it from 'ConwayEra'
+    -- from "Cardano.Api.Internal.Experimental" using the 'convert' function:
+    --
+    -- @
+    -- let era = Exp.ConwayEra
+    -- let sbe = Api.convert era
+    -- @
+
+    -- * Contents
+    parseTxId
+
+    -- ** Transaction bodies
   , TxBody (.., TxBody)
   , createTransactionBody
   , createAndValidateTransactionBody
   , TxBodyContent (..)
 
-    -- * Byron only
+    -- ** Byron only
   , makeByronTransactionBody
 
-    -- ** Transaction body builders
+    -- *** Transaction body builders
   , defaultTxBodyContent
   , defaultTxFee
   , defaultTxValidityUpperBound
@@ -93,13 +267,13 @@ module Cardano.Api.Internal.Tx.Body
   , txScriptValidityToIsValid
   , txScriptValidityToScriptValidity
 
-    -- * Transaction Ids
+    -- ** Transaction Ids
   , TxId (..)
   , getTxId
   , getTxIdByron
   , getTxIdShelley
 
-    -- * Transaction inputs
+    -- ** Transaction inputs
   , TxIn (..)
   , TxIns
   , indexTxIns
@@ -107,7 +281,7 @@ module Cardano.Api.Internal.Tx.Body
   , genesisUTxOPseudoTxIn
   , getReferenceInputsSizeForTxIds
 
-    -- * Transaction outputs
+    -- ** Transaction outputs
   , CtxTx
   , CtxUTxO
   , TxOut (..)
@@ -122,7 +296,7 @@ module Cardano.Api.Internal.Tx.Body
   , TxOutInAnyEra (..)
   , txOutInAnyEra
 
-    -- * Other transaction body types
+    -- ** Other transaction body types
   , TxInsCollateral (..)
   , TxInsReference (..)
   , TxReturnCollateral (..)
@@ -150,23 +324,23 @@ module Cardano.Api.Internal.Tx.Body
   , indexTxProposalProcedures
   , convProposalProcedures
 
-    -- ** Building vs viewing transactions
+    -- *** Building vs viewing transactions
   , BuildTxWith (..)
   , BuildTx
   , ViewTx
   , buildTxWithToMaybe
 
-    -- * Inspecting 'ScriptWitness'es
+    -- ** Inspecting 'ScriptWitness'es
   , AnyScriptWitness (..)
   , ScriptWitnessIndex (..)
   , renderScriptWitnessIndex
   , collectTxBodyScriptWitnesses
   , toScriptIndex
 
-    -- * Conversion to inline data
+    -- ** Conversion to inline data
   , scriptDataToInlineDatum
 
-    -- * Internal conversion functions & types
+    -- ** Internal conversion functions & types
   , convCertificates
   , convCollateralTxIns
   , convExtraKeyWitnesses
@@ -200,10 +374,10 @@ module Cardano.Api.Internal.Tx.Body
   , fromLedgerTxOuts
   , renderTxIn
 
-    -- * Misc helpers
+    -- ** Misc helpers
   , calculateExecutionUnitsLovelace
 
-    -- * Data family instances
+    -- ** Data family instances
   , AsType (AsTxId, AsTxBody, AsByronTxBody, AsShelleyTxBody, AsMaryTxBody)
   , getTxBodyContent
   -- Temp

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Sign.hs
@@ -13,9 +13,38 @@
 -- not export any from this API. We also use them unticked as nature intended.
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
--- | Complete, signed transactions
+-- | Creating complete, signed transactions.
 module Cardano.Api.Internal.Tx.Sign
-  ( -- * Signing transactions
+  ( -- * Example: Creating a 'ShelleyWitnessSigningKey'
+
+    -- |
+    -- Signing a transaction requires a witness, for example, a 'ShelleyWitnessSigningKey'.
+    --
+    -- This example uses the following qualified module:
+    --
+    -- @
+    -- import qualified Cardano.Api as Api                -- the general `cardano-api` exports (including the old API)
+    -- @
+    --
+    -- There are several ways of signing a transaction and representing a signing key. If the
+    -- bech32 representation of the signing key is available, it is possible to use the
+    -- 'deserialiseFromBech32' function as follows:
+    --
+    -- @
+    -- let (Right signingKey) = Api.deserialiseFromBech32 (Api.AsSigningKey Api.AsPaymentKey) "addr_sk1648253w4tf6fv5fk28dc7crsjsaw7d9ymhztd4favg3cwkhz7x8sl5u3ms"
+    -- @
+    --
+    -- Then, simply wrap the signing key in a 'ShelleyWitnessSigningKey' value:
+    --
+    -- @
+    -- let witness = Api.WitnessPaymentKey signingKey
+    -- @
+    --
+    -- This could also be done using an extended key, such as 'AsPaymentExtendedKey' and 'WitnessPaymentExtendedKey'.
+
+    -- * Contents
+
+    -- ** Signing transactions
 
     -- | Creating transaction witnesses one by one, or all in one go.
     Tx (.., Tx)
@@ -26,13 +55,13 @@ module Cardano.Api.Internal.Tx.Sign
   , getTxWitnessesByron
   , ScriptValidity (..)
 
-    -- ** Signing in one go
+    -- *** Signing in one go
   , ShelleySigningKey (..)
   , toShelleySigningKey
   , signByronTransaction
   , signShelleyTransaction
 
-    -- ** Incremental signing and separate witnesses
+    -- *** Incremental signing and separate witnesses
   , makeSignedByronTransaction
   , makeSignedTransaction
   , makeSignedTransaction'
@@ -48,7 +77,7 @@ module Cardano.Api.Internal.Tx.Sign
   , getShelleyKeyWitnessVerificationKey
   , getTxBodyAndWitnesses
 
-    -- * Data family instances
+    -- ** Data family instances
   , AsType
     ( AsTx
     , AsMaryTx

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -11,10 +12,23 @@ where
 import Cardano.Api qualified as Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Internal.Eon.ShelleyBasedEra (ShelleyBasedEraConstraints)
+import Cardano.Api.Internal.Genesis qualified as Genesis
+import Cardano.Api.Internal.ProtocolParameters qualified as Api
 import Cardano.Api.Internal.Script qualified as Script
 import Cardano.Api.Internal.Tx.Sign (Tx (ShelleyTx))
 import Cardano.Api.Ledger qualified as Ledger
 
+import Cardano.Ledger.Alonzo.Scripts qualified as UnexportedLedger
+import Cardano.Ledger.Api qualified as UnexportedLedger
+import Cardano.Slotting.EpochInfo qualified as Slotting
+import Cardano.Slotting.Slot qualified as Slotting
+import Cardano.Slotting.Time qualified as Slotting
+
+import Control.Monad.Identity (Identity)
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
+import Data.Time qualified as Time
+import Data.Time.Clock.POSIX qualified as Time
 import Lens.Micro ((&))
 
 import Hedgehog (Property)
@@ -37,6 +51,9 @@ tests =
     [ testProperty
         "Created transaction with traditional and experimental APIs are equivalent"
         prop_created_transaction_with_both_apis_are_the_same
+    , testProperty
+        "Check two methods of balancing transaction are equivalent"
+        prop_balance_transaction_two_ways
     ]
 
 prop_created_transaction_with_both_apis_are_the_same :: Property
@@ -51,50 +68,6 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
 
   oldStyleTx H.=== signedTxTraditional
  where
-  exampleTxBodyContent
-    :: (ShelleyBasedEraConstraints era, H.MonadTest m)
-    => Api.AsType era
-    -> Api.ShelleyBasedEra era
-    -> m (Api.TxBodyContent Api.BuildTx era)
-  exampleTxBodyContent eraAsType sbe = do
-    srcTxId <-
-      H.evalEither $
-        Api.deserialiseFromRawBytesHex
-          Api.AsTxId
-          "be6efd42a3d7b9a00d09d77a5d41e55ceaf0bd093a8aa8a893ce70d9caafd978"
-    let srcTxIx = Api.TxIx 0
-    destAddress <-
-      H.evalMaybe $
-        Api.deserialiseAddress
-          (Api.AsAddressInEra eraAsType)
-          "addr_test1vzpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpcue4v2v"
-
-    let txBodyContent =
-          Api.defaultTxBodyContent sbe
-            & Api.setTxIns
-              [
-                ( Api.TxIn srcTxId srcTxIx
-                , Api.BuildTxWith (Api.KeyWitness Api.KeyWitnessForSpending)
-                )
-              ]
-            & Api.setTxOuts
-              [ Api.TxOut
-                  destAddress
-                  (Api.TxOutValueShelleyBased sbe (Api.inject (Ledger.Coin 10_000_000)))
-                  Api.TxOutDatumNone
-                  Script.ReferenceScriptNone
-              ]
-            & Api.setTxFee (Api.TxFeeExplicit sbe (Ledger.Coin 2_000_000))
-
-    return txBodyContent
-
-  exampleSigningKey :: H.MonadTest m => m (Api.SigningKey Api.PaymentKey)
-  exampleSigningKey =
-    H.evalEither $
-      Api.deserialiseFromBech32
-        (Api.AsSigningKey Api.AsPaymentKey)
-        "addr_sk1648253w4tf6fv5fk28dc7crsjsaw7d9ymhztd4favg3cwkhz7x8sl5u3ms"
-
   exampleTransacitonTraditionalWay
     :: H.MonadTest m => Api.ShelleyBasedEra Exp.ConwayEra -> m (Tx Exp.ConwayEra)
   exampleTransacitonTraditionalWay sbe = do
@@ -124,3 +97,188 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
 
     let signedTx :: Ledger.Tx (Exp.LedgerEra Exp.ConwayEra) = Exp.signTx era bootstrapWitnesses keyWitnesses unsignedTx
     return signedTx
+
+prop_balance_transaction_two_ways :: Property
+prop_balance_transaction_two_ways = H.propertyOnce $ do
+  let era = Exp.ConwayEra
+  let sbe = Api.convert era
+  let meo = Api.MaryEraOnwardsConway
+
+  changeAddress <- getExampleChangeAddress sbe
+
+  txBodyContent <- exampleTxBodyContent Api.AsConwayEra sbe
+  txBody <- H.evalEither $ Api.createTransactionBody sbe txBodyContent
+
+  -- Simple way (fee calculation)
+  let fees = Api.evaluateTransactionFee sbe exampleProtocolParams txBody 0 1 0
+  H.note_ $ "Fees 1: " <> show fees
+
+  -- Balance without ledger context (other that protocol parameters)
+  Api.BalancedTxBody
+    _txBodyContent2
+    _txBody2
+    _changeOutput2
+    fees2 <-
+    H.evalEither
+      $ Api.estimateBalancedTxBody
+        meo
+        txBodyContent
+        exampleProtocolParams
+        mempty
+        mempty
+        mempty
+        mempty
+        0
+        1
+        0
+        0
+        changeAddress
+      $ Api.lovelaceToValue 12_000_000
+
+  H.note_ $ "Fees 2: " <> show fees2
+  -- H.note_ $ "New TxBody 2: " <> show txBody2
+  -- H.note_ $ "New TxBodyContent 2: " <> show txBodyContent2
+  -- H.note_ $ "Change output 2: " <> show changeOutput2
+
+  -- Automatically balance the transaction (with ledger context)
+  currTime <- Api.liftIO Time.getCurrentTime
+  srcTxId <- getExampleSrcTxId
+  let startTime = Time.posixSecondsToUTCTime (Time.utcTimeToPOSIXSeconds currTime - Time.nominalDay)
+  let epochInfo =
+        Api.LedgerEpochInfo $ Slotting.fixedEpochInfo (Slotting.EpochSize 100) (Slotting.mkSlotLength 1000)
+  let utxoToUse =
+        Api.UTxO
+          [
+            ( srcTxId
+            , Api.TxOut
+                changeAddress
+                (Api.lovelaceToTxOutValue sbe 12_000_000)
+                Api.TxOutDatumNone
+                Script.ReferenceScriptNone
+            )
+          ]
+
+  Api.BalancedTxBody
+    _txBodyContent3
+    _txBody3
+    _changeOutput3
+    fees3 <-
+    H.evalEither $
+      Api.makeTransactionBodyAutoBalance
+        sbe
+        (Api.SystemStart startTime)
+        epochInfo
+        (Api.LedgerProtocolParameters exampleProtocolParams)
+        mempty
+        mempty
+        mempty
+        utxoToUse
+        txBodyContent
+        changeAddress
+        Nothing
+
+  H.note_ $ "Fees 3: " <> show fees3
+  -- H.note_ $ "TxBody 3: " <> show txBody3
+  -- H.note_ $ "TxBodyContent 3: " <> show txBodyContent3
+  -- H.note_ $ "Change output 3: " <> show changeOutput3
+
+  H.success
+
+exampleProtocolParams :: Ledger.PParams (UnexportedLedger.ConwayEra Ledger.StandardCrypto)
+exampleProtocolParams =
+  UnexportedLedger.upgradePParams conwayUpgrade $
+    UnexportedLedger.upgradePParams () $
+      UnexportedLedger.upgradePParams alonzoUpgrade $
+        UnexportedLedger.upgradePParams () $
+          UnexportedLedger.upgradePParams () $
+            Genesis.sgProtocolParams Genesis.shelleyGenesisDefaults
+ where
+  conwayUpgrade :: Ledger.UpgradeConwayPParams Identity
+  conwayUpgrade = Ledger.cgUpgradePParams Genesis.conwayGenesisDefaults
+
+  alonzoUpgrade :: UnexportedLedger.UpgradeAlonzoPParams Identity
+  alonzoUpgrade =
+    UnexportedLedger.UpgradeAlonzoPParams
+      { UnexportedLedger.uappCoinsPerUTxOWord = Ledger.CoinPerWord $ Ledger.Coin 34_482
+      , UnexportedLedger.uappCostModels = UnexportedLedger.emptyCostModels -- We are not using scripts for this tests, so this is fine for now
+      , UnexportedLedger.uappPrices =
+          Ledger.Prices
+            { Ledger.prSteps = fromMaybe maxBound $ Ledger.boundRational $ 721 % 10_000_000
+            , Ledger.prMem = fromMaybe maxBound $ Ledger.boundRational $ 577 % 10_000
+            }
+      , UnexportedLedger.uappMaxTxExUnits =
+          Ledger.ExUnits
+            { Ledger.exUnitsMem = 140_000_000
+            , Ledger.exUnitsSteps = 10_000_000_000
+            }
+      , UnexportedLedger.uappMaxBlockExUnits =
+          Ledger.ExUnits
+            { Ledger.exUnitsMem = 62_000_000
+            , Ledger.exUnitsSteps = 20_000_000_000
+            }
+      , UnexportedLedger.uappMaxValSize = 5000
+      , UnexportedLedger.uappCollateralPercentage = 150
+      , UnexportedLedger.uappMaxCollateralInputs = 3
+      }
+
+getExampleSrcTxId :: H.MonadTest m => m Api.TxIn
+getExampleSrcTxId = do
+  srcTxId <-
+    H.evalEither $
+      Api.deserialiseFromRawBytesHex
+        Api.AsTxId
+        "be6efd42a3d7b9a00d09d77a5d41e55ceaf0bd093a8aa8a893ce70d9caafd978"
+  let srcTxIx = Api.TxIx 0
+  return $ Api.TxIn srcTxId srcTxIx
+
+getExampleDestAddress
+  :: (H.MonadTest m, Api.IsCardanoEra era) => Script.AsType era -> m (Api.AddressInEra era)
+getExampleDestAddress eraAsType = do
+  H.evalMaybe $
+    Api.deserialiseAddress
+      (Api.AsAddressInEra eraAsType)
+      "addr_test1vzpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpcue4v2v"
+
+getExampleChangeAddress :: H.MonadTest m => Api.ShelleyBasedEra era -> m (Api.AddressInEra era)
+getExampleChangeAddress sbe = do
+  signingKey <- exampleSigningKey
+  return $
+    Api.shelleyAddressInEra sbe $
+      Api.makeShelleyAddress
+        (Api.Testnet $ Api.NetworkMagic 2)
+        (Api.PaymentCredentialByKey $ Api.verificationKeyHash $ Api.getVerificationKey signingKey)
+        Api.NoStakeAddress
+
+exampleTxBodyContent
+  :: (ShelleyBasedEraConstraints era, H.MonadTest m)
+  => Api.AsType era
+  -> Api.ShelleyBasedEra era
+  -> m (Api.TxBodyContent Api.BuildTx era)
+exampleTxBodyContent eraAsType sbe = do
+  srcTxIn <- getExampleSrcTxId
+  destAddress <- getExampleDestAddress eraAsType
+  let txBodyContent =
+        Api.defaultTxBodyContent sbe
+          & Api.setTxIns
+            [
+              ( srcTxIn
+              , Api.BuildTxWith (Api.KeyWitness Api.KeyWitnessForSpending)
+              )
+            ]
+          & Api.setTxOuts
+            [ Api.TxOut
+                destAddress
+                (Api.lovelaceToTxOutValue sbe 10_000_000)
+                Api.TxOutDatumNone
+                Script.ReferenceScriptNone
+            ]
+          & Api.setTxFee (Api.TxFeeExplicit sbe 2_000_000)
+
+  return txBodyContent
+
+exampleSigningKey :: H.MonadTest m => m (Api.SigningKey Api.PaymentKey)
+exampleSigningKey =
+  H.evalEither $
+    Api.deserialiseFromBech32
+      (Api.AsSigningKey Api.AsPaymentKey)
+      "addr_sk1648253w4tf6fv5fk28dc7crsjsaw7d9ymhztd4favg3cwkhz7x8sl5u3ms"

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -13,6 +13,7 @@ import Test.Cardano.Api.Crypto qualified
 import Test.Cardano.Api.Envelope qualified
 import Test.Cardano.Api.EpochLeadership qualified
 import Test.Cardano.Api.Eras qualified
+import Test.Cardano.Api.Experimental qualified
 import Test.Cardano.Api.Genesis qualified
 import Test.Cardano.Api.GovAnchorValidation qualified
 import Test.Cardano.Api.IO qualified
@@ -50,6 +51,7 @@ tests =
     , Test.Cardano.Api.Envelope.tests
     , Test.Cardano.Api.EpochLeadership.tests
     , Test.Cardano.Api.Eras.tests
+    , Test.Cardano.Api.Experimental.tests
     , Test.Cardano.Api.Genesis.tests
     , Test.Cardano.Api.IO.tests
     , Test.Cardano.Api.Json.tests


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added example of transaction creation with traditional and experimental APIs to Haddock.
  type:
  - test
  - documentation
```

# Context

Prompted by [this slack discussion](https://input-output-rnd.slack.com/archives/G011N23CEAE/p1732647670120119)

# How to trust this PR

Have a read of the haddock.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
