### PR TITLE
Export HasKeyRole's coerceKeyRole function

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -100,7 +100,6 @@ import           Cardano.Api.Value
 
 import           Cardano.Ledger.BaseTypes (strictMaybe)
 import qualified Cardano.Ledger.Coin as L
-import qualified Cardano.Ledger.Keys as Ledger
 
 import           Control.Monad.Except (MonadError (..))
 import           Data.ByteString (ByteString)

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -18,7 +18,7 @@ module Cardano.Api.ReexposeLedger
   , hashVerKeyVRF
   , hashWithSerialiser
   , PoolParams (..)
-  , HasKeyRole
+  , HasKeyRole (..)
   , MIRPot (..)
   , MIRTarget (..)
   , MIRCert (..)
@@ -220,7 +220,7 @@ import           Cardano.Ledger.Core (Era (..), EraPParams (..), EraTxOut, PPara
 import           Cardano.Ledger.Credential (Credential (..), credToText)
 import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import           Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
-import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VKey (..),
+import           Cardano.Ledger.Keys (HasKeyRole (..), KeyHash (..), KeyRole (..), VKey (..),
                    hashWithSerialiser)
 import           Cardano.Ledger.Plutus.Data (Data (..), unData)
 import           Cardano.Ledger.Plutus.Language (Language, Plutus, languageToText, plutusBinary)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Export HasKeyRole's coerceKeyRole function
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Required for https://github.com/IntersectMBO/cardano-cli/commits/smelc/augment-spo-stake-distribution/
  * This branch is for solving https://github.com/IntersectMBO/cardano-cli/issues/911

# How to trust this PR

It's only an additional export, and exporting a class name but not its functions was weird anyway.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff