### PR TITLE
Add modifier functions for TxInsCollateral, TxInsReference, TxExtraKe…

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -300,11 +300,19 @@ module Cardano.Api
   , defaultTxValidityUpperBound
   , setTxIns
   , modTxIns
+  , addTxIns
   , addTxIn
   , setTxInsCollateral
+  , modTxInsCollateral
+  , addTxInsCollateral
+  , addTxInCollateral
   , setTxInsReference
+  , modTxInsReference
+  , addTxInsReference
+  , addTxInReference
   , setTxOuts
   , modTxOuts
+  , addTxOuts
   , addTxOut
   , setTxTotalCollateral
   , setTxReturnCollateral
@@ -314,6 +322,8 @@ module Cardano.Api
   , setTxMetadata
   , setTxAuxScripts
   , setTxExtraKeyWits
+  , modTxExtraKeyWits
+  , addTxExtraKeyWits
   , setTxProtocolParams
   , setTxWithdrawals
   , setTxCertificates


### PR DESCRIPTION
…yWits to Cardano.Api.Tx.Body

# Changelog

```yaml
- description: |
    Add TxBodyModifier functions: `addTxIns`, `modTxInsCollateral`, `addTxInsCollateral`, `addTxInCollateral`, `modTxInsReference`, `addTxInsReference`, `addTxInReference`, `addTxOuts`, `modTxExtraKeyWits`, `addTxExtraKeyWits`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
