### PR TITLE
Add `modX` functions for all fields of `TxBodyContent` up to Babbage.

### DIFF
--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -50,19 +50,29 @@ module Cardano.Api.Tx.Body
   , addTxOut
   , addTxOuts
   , setTxTotalCollateral
+  , modTxTotalCollateral
   , setTxReturnCollateral
+  , modTxReturnCollateral
   , setTxFee
+  , modTxFee
   , setTxValidityLowerBound
+  , modTxValidityLowerBound
   , setTxValidityUpperBound
+  , modTxValidityUpperBound
   , setTxMetadata
+  , modTxMetadata
   , setTxAuxScripts
+  , modTxAuxScripts
   , setTxExtraKeyWits
   , modTxExtraKeyWits
   , addTxExtraKeyWits
   , setTxProtocolParams
   , setTxWithdrawals
+  , modTxWithdrawals
   , setTxCertificates
+  , modTxCertificates
   , setTxUpdateProposal
+  , modTxUpdateProposal
   , setTxProposalProcedures
   , setTxVotingProcedures
   , setTxMintValue
@@ -70,6 +80,7 @@ module Cardano.Api.Tx.Body
   , addTxMintValue
   , subtractTxMintValue
   , setTxScriptValidity
+  , modTxScriptValidity
   , setTxCurrentTreasuryValue
   , setTxTreasuryDonation
   , TxBodyError (..)
@@ -1536,26 +1547,68 @@ addTxOuts txOuts = modTxOuts (<> txOuts)
 setTxTotalCollateral :: TxTotalCollateral era -> TxBodyContent build era -> TxBodyContent build era
 setTxTotalCollateral v txBodyContent = txBodyContent{txTotalCollateral = v}
 
+modTxTotalCollateral
+  :: (TxTotalCollateral era -> TxTotalCollateral era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxTotalCollateral f txBodyContent = txBodyContent{txTotalCollateral = f (txTotalCollateral txBodyContent)}
+
 setTxReturnCollateral
   :: TxReturnCollateral CtxTx era -> TxBodyContent build era -> TxBodyContent build era
 setTxReturnCollateral v txBodyContent = txBodyContent{txReturnCollateral = v}
 
+modTxReturnCollateral
+  :: (TxReturnCollateral CtxTx era -> TxReturnCollateral CtxTx era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxReturnCollateral f txBodyContent = txBodyContent{txReturnCollateral = f (txReturnCollateral txBodyContent)}
+
 setTxFee :: TxFee era -> TxBodyContent build era -> TxBodyContent build era
 setTxFee v txBodyContent = txBodyContent{txFee = v}
+
+modTxFee
+  :: (TxFee era -> TxFee era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxFee f txBodyContent = txBodyContent{txFee = f (txFee txBodyContent)}
 
 setTxValidityLowerBound
   :: TxValidityLowerBound era -> TxBodyContent build era -> TxBodyContent build era
 setTxValidityLowerBound v txBodyContent = txBodyContent{txValidityLowerBound = v}
 
+modTxValidityLowerBound
+  :: (TxValidityLowerBound era -> TxValidityLowerBound era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxValidityLowerBound f txBodyContent = txBodyContent{txValidityLowerBound = f (txValidityLowerBound txBodyContent)}
+
 setTxValidityUpperBound
   :: TxValidityUpperBound era -> TxBodyContent build era -> TxBodyContent build era
 setTxValidityUpperBound v txBodyContent = txBodyContent{txValidityUpperBound = v}
 
+modTxValidityUpperBound
+  :: (TxValidityUpperBound era -> TxValidityUpperBound era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxValidityUpperBound f txBodyContent = txBodyContent{txValidityUpperBound = f (txValidityUpperBound txBodyContent)}
+
 setTxMetadata :: TxMetadataInEra era -> TxBodyContent build era -> TxBodyContent build era
 setTxMetadata v txBodyContent = txBodyContent{txMetadata = v}
 
+modTxMetadata
+  :: (TxMetadataInEra era -> TxMetadataInEra era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxMetadata f txBodyContent = txBodyContent{txMetadata = f (txMetadata txBodyContent)}
+
 setTxAuxScripts :: TxAuxScripts era -> TxBodyContent build era -> TxBodyContent build era
 setTxAuxScripts v txBodyContent = txBodyContent{txAuxScripts = v}
+
+modTxAuxScripts
+  :: (TxAuxScripts era -> TxAuxScripts era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxAuxScripts f txBodyContent = txBodyContent{txAuxScripts = f (txAuxScripts txBodyContent)}
 
 setTxExtraKeyWits :: TxExtraKeyWitnesses era -> TxBodyContent build era -> TxBodyContent build era
 setTxExtraKeyWits v txBodyContent = txBodyContent{txExtraKeyWits = v}
@@ -1586,11 +1639,29 @@ setTxProtocolParams v txBodyContent = txBodyContent{txProtocolParams = v}
 setTxWithdrawals :: TxWithdrawals build era -> TxBodyContent build era -> TxBodyContent build era
 setTxWithdrawals v txBodyContent = txBodyContent{txWithdrawals = v}
 
+modTxWithdrawals
+  :: (TxWithdrawals build era -> TxWithdrawals build era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxWithdrawals f txBodyContent = txBodyContent{txWithdrawals = f (txWithdrawals txBodyContent)}
+
 setTxCertificates :: TxCertificates build era -> TxBodyContent build era -> TxBodyContent build era
 setTxCertificates v txBodyContent = txBodyContent{txCertificates = v}
 
+modTxCertificates
+  :: (TxCertificates build era -> TxCertificates build era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxCertificates f txBodyContent = txBodyContent{txCertificates = f (txCertificates txBodyContent)}
+
 setTxUpdateProposal :: TxUpdateProposal era -> TxBodyContent build era -> TxBodyContent build era
 setTxUpdateProposal v txBodyContent = txBodyContent{txUpdateProposal = v}
+
+modTxUpdateProposal
+  :: (TxUpdateProposal era -> TxUpdateProposal era)
+  -> TxBodyContent build era
+  -> TxBodyContent build era
+modTxUpdateProposal f txBodyContent = txBodyContent{txUpdateProposal = f (txUpdateProposal txBodyContent)}
 
 setTxMintValue :: TxMintValue build era -> TxBodyContent build era -> TxBodyContent build era
 setTxMintValue v txBodyContent = txBodyContent{txMintValue = v}
@@ -1623,6 +1694,10 @@ subtractTxMintValue assets = addTxMintValue (fmap (fmap (\(x, y, z) -> (x, negat
 
 setTxScriptValidity :: TxScriptValidity era -> TxBodyContent build era -> TxBodyContent build era
 setTxScriptValidity v txBodyContent = txBodyContent{txScriptValidity = v}
+
+modTxScriptValidity
+  :: (TxScriptValidity era -> TxScriptValidity era) -> TxBodyContent build era -> TxBodyContent build era
+modTxScriptValidity f txBodyContent = txBodyContent{txScriptValidity = f (txScriptValidity txBodyContent)}
 
 setTxProposalProcedures
   :: Maybe (Featured ConwayEraOnwards era (TxProposalProcedures build era))

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -329,6 +329,9 @@ module Cardano.Api
   , setTxCertificates
   , setTxUpdateProposal
   , setTxMintValue
+  , modTxMintValue
+  , addTxMintValue
+  , subtractTxMintValue
   , setTxScriptValidity
   , setTxProposalProcedures
   , setTxVotingProcedures

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -315,24 +315,35 @@ module Cardano.Api
   , addTxOuts
   , addTxOut
   , setTxTotalCollateral
+  , modTxTotalCollateral
   , setTxReturnCollateral
+  , modTxReturnCollateral
   , setTxFee
+  , modTxFee
   , setTxValidityLowerBound
+  , modTxValidityLowerBound
   , setTxValidityUpperBound
+  , modTxValidityUpperBound
   , setTxMetadata
+  , modTxMetadata
   , setTxAuxScripts
+  , modTxAuxScripts
   , setTxExtraKeyWits
   , modTxExtraKeyWits
   , addTxExtraKeyWits
   , setTxProtocolParams
   , setTxWithdrawals
+  , modTxWithdrawals
   , setTxCertificates
+  , modTxCertificates
   , setTxUpdateProposal
+  , modTxUpdateProposal
   , setTxMintValue
   , modTxMintValue
   , addTxMintValue
   , subtractTxMintValue
   , setTxScriptValidity
+  , modTxScriptValidity
   , setTxProposalProcedures
   , setTxVotingProcedures
   , setTxCurrentTreasuryValue


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Adds `modTxTotalCollateral`, `modTxReturnCollateral`, `modTxFee`, `modTxValidityLowerBound`, `modTxValidityUpperBound`, `modTxMetadata`, `modTxAuxScripts`, `modTxWithdrawals`, `modTxCertificates`, `modTxUpdateProposal`, `modTxScriptValidity`, `modTxMintValue` functions for modifying `TxBodyContent`. Adds `addTxMintValue` and `subtractTxMintValue`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
