### PR TITLE
Don't export coerceKeyRole, export RewardAccount

### DIFF
--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -100,6 +100,7 @@ import           Cardano.Api.Value
 
 import           Cardano.Ledger.BaseTypes (strictMaybe)
 import qualified Cardano.Ledger.Coin as L
+import qualified Cardano.Ledger.Keys as Ledger
 
 import           Control.Monad.Except (MonadError (..))
 import           Data.ByteString (ByteString)

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -18,7 +18,7 @@ module Cardano.Api.ReexposeLedger
   , hashVerKeyVRF
   , hashWithSerialiser
   , PoolParams (..)
-  , HasKeyRole (..)
+  , HasKeyRole
   , MIRPot (..)
   , MIRTarget (..)
   , MIRCert (..)
@@ -221,7 +221,7 @@ import           Cardano.Ledger.Core (Era (..), EraPParams (..), EraTxOut, PPara
 import           Cardano.Ledger.Credential (Credential (..), credToText)
 import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import           Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
-import           Cardano.Ledger.Keys (HasKeyRole (..), KeyHash (..), KeyRole (..), VKey (..),
+import           Cardano.Ledger.Keys (HasKeyRole, KeyHash (..), KeyRole (..), VKey (..),
                    hashWithSerialiser)
 import           Cardano.Ledger.Plutus.Data (Data (..), unData)
 import           Cardano.Ledger.Plutus.Language (Language, Plutus, languageToText, plutusBinary)

--- a/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
+++ b/cardano-api/internal/Cardano/Api/ReexposeLedger.hs
@@ -175,10 +175,13 @@ module Cardano.Api.ReexposeLedger
   , SafeHash
   , unsafeMakeSafeHash
   , extractHash
+  -- Reward
+  , RewardAccount (..)
   )
 where
 
 import           Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
+import           Cardano.Ledger.Address (RewardAccount (..))
 import           Cardano.Ledger.Allegra.Scripts (showTimelock)
 import           Cardano.Ledger.Alonzo.Core (AlonzoEraScript (..), AlonzoEraTxBody (..),
                    AlonzoEraTxWits (..), AsIx (..), AsIxItem (AsIxItem), CoinPerWord (..), EraGov,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Don't export the ledger's `coerceKeyRole` function anymore, export RewardAccount
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Required for https://github.com/IntersectMBO/cardano-cli/pull/990
* This is the [datatype RewardAccount](https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs#L182) that is being exported
* The export of `coerceKeyRole` is no longer necessary for solving https://github.com/IntersectMBO/cardano-cli/issues/911, which is good; because @Jimbo4350 had concerned about it (on Slack). I must say I readied https://github.com/IntersectMBO/cardano-api/pull/699 too fast.

Not marking this one as _breaking_, because it actually reverts https://github.com/IntersectMBO/cardano-api/pull/699. Since there was no release since 699, overall it's not going to be a breaking change (I'll update 699's changelog to not breaking either when we merge this one).

# How to trust this PR

The new export only concerns a data structure, nothing controversial

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff