### PR TITLE
Draft: Use era type class constraints in generators

### DIFF
--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -218,7 +218,7 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
   txInsColl <- forAll $ genTxInsCollateral era
   txRetColl <-
     forAll $ Gen.frequency [(4, pure TxReturnCollateralNone), (1, genTxReturnCollateral sbe)]
-  txTotColl <- forAll $ Gen.frequency [(4, pure TxTotalCollateralNone), (1, genTxTotalCollateral era)]
+  txTotColl <- forAll $ Gen.frequency [(4, pure TxTotalCollateralNone), (1, genTxTotalCollateral)]
   let address = AddressInEra (ShelleyAddressInEra sbe) (ShelleyAddress L.Testnet def L.StakeRefNull)
 
   let (resRetColl, resTotColl) =

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/TxBody.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -33,7 +34,7 @@ import           Test.Tasty.Hedgehog (testProperty)
 prop_roundtrip_txbodycontent_txouts :: forall era. ShelleyBasedEra era -> Property
 prop_roundtrip_txbodycontent_txouts era = H.property $ do
   (body, content :: TxBodyContent BuildTx era) <-
-    shelleyBasedEraConstraints era $ H.forAll $ genValidTxBody era
+    shelleyBasedEraConstraints era $ H.forAll $ genValidTxBody
   -- Convert ledger body back via 'getTxBodyContent' and 'fromLedgerTxBody'
   let (TxBody content') = body
   matchTxOuts (txOuts content) (txOuts content')
@@ -81,8 +82,7 @@ prop_roundtrip_txbodycontent_txouts era = H.property $ do
 
 prop_roundtrip_txbodycontent_conway_fields :: Property
 prop_roundtrip_txbodycontent_conway_fields = H.property $ do
-  let sbe = ShelleyBasedEraConway
-  (body, content) <- H.forAll $ genValidTxBody sbe
+  (body, content) <- H.forAll $ genValidTxBody @ConwayEra
   -- Convert ledger body back via 'getTxBodyContent' and 'fromLedgerTxBody'
   let (TxBody content') = body
 


### PR DESCRIPTION
Draft. I tried to change some generator to use type classes rather than witnesses, which works - but I struggled to update the tests that use generators in any era. I managed to make it compile, but what I had to do is very unsatisfying, so I'm wondering if anyone can see how to do that part better - or explain why it isn't possible.

Thanks. 

# Changelog

```yaml
- description: |
    Change hedgehog generators to use type classes.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
