### PR TITLE
Re-export DebugPlutusFailure and renderDebugPlutusFailure

### DIFF
--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -1067,6 +1067,10 @@ module Cardano.Api
   , ResolvablePointers (..)
   , unsafeBoundedRational
 
+    -- ** Debug
+  , DebugPlutusFailure (..)
+  , renderDebugPlutusFailure
+
     -- ** Supporting modules
   , module Cardano.Api.Internal.Monad.Error
   , module Cardano.Api.Internal.Pretty
@@ -1121,7 +1125,7 @@ import           Cardano.Api.Internal.Monad.Error
 import           Cardano.Api.Internal.NetworkId
 import           Cardano.Api.Internal.OperationalCertificate
 import           Cardano.Api.Internal.Orphans ()
-import           Cardano.Api.Internal.Plutus (collectPlutusScriptHashes)
+import           Cardano.Api.Internal.Plutus
 import           Cardano.Api.Internal.Pretty
 import           Cardano.Api.Internal.Protocol
 import           Cardano.Api.Internal.ProtocolParameters

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -31,7 +31,6 @@ module Test.Golden.ErrorsSpec
 where
 
 import           Cardano.Api
-import           Cardano.Api.Internal.Plutus
 import           Cardano.Api.Shelley
 
 import           Cardano.Binary as CBOR


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Re-export `DebugPlutusFailure` and `renderDebugPlutusFailure`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
