### PR TITLE
Fix transaction autobalancing when deregistering credential

### DIFF
--- a/cardano-api/internal/Cardano/Api/IPC.hs
+++ b/cardano-api/internal/Cardano/Api/IPC.hs
@@ -174,6 +174,7 @@ data LocalNodeConnectInfo
   , localNodeNetworkId :: NetworkId
   , localNodeSocketPath :: SocketPath
   }
+  deriving Show
 
 -- ----------------------------------------------------------------------------
 -- Actually connect to the node

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -1916,6 +1916,7 @@ instance Error TxBodyError where
 
 createTransactionBody
   :: ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)
@@ -2661,7 +2662,8 @@ convTotalCollateral txTotalCollateral =
 
 convTxOuts
   :: forall ctx era ledgerera
-   . ShelleyLedgerEra era ~ ledgerera
+   . HasCallStack
+  => ShelleyLedgerEra era ~ ledgerera
   => ShelleyBasedEra era
   -> [TxOut ctx era]
   -> Seq.StrictSeq (Ledger.TxOut ledgerera)
@@ -2844,6 +2846,7 @@ guardShelleyTxInsOverflow txIns = do
 -- all eras
 mkCommonTxBody
   :: ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxIns BuildTx era
   -> [TxOut ctx era]

--- a/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
@@ -37,6 +37,7 @@ import           Data.Maybe.Strict
 import           Data.Monoid
 import qualified Data.Sequence.Strict as Seq
 import           GHC.Exts (IsList (..))
+import           GHC.Stack
 import           Lens.Micro hiding (ix)
 
 data AnyProtocolUpdate era where
@@ -206,7 +207,8 @@ createCompatibleSignedTx sbe ins outs witnesses txFee' anyProtocolUpdate anyVote
         .~ shelleyBootstrapWitnesses
 
 createCommonTxBody
-  :: ShelleyBasedEra era
+  :: HasCallStack
+  => ShelleyBasedEra era
   -> [TxIn]
   -> [TxOut ctx era]
   -> Lovelace


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix transaction autobalancing when deregistering a credential
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The first step of autobalancing was not considering ADA inflow from deregistering a credential, so the resulting change could get negative and it was blowing up in ledger code.

## Detailed cause explanation
The negative intermediate change value could be a result of the first call to:
```haskell
calculateChangeValue sbe totalValueAtSpendableUTxO txbodycontent
```
`calculateChangeValue` considers only:
- tx inputs
- tx outputs
- minted assets

so if there's not enough input value, meaning `tx outs > tx ins`, the calculated intermediate change gets negative. Note, that's a valid scenario if enough funds are coming in from certificate deposit return.

If that change is then used as a new transaction output (the change output), it will throw an exception in the ledger code.

## The fix

We're using the exact change value in the first step of autobalancing, for the execution units calculation.

Regression tests executed in:
- https://github.com/IntersectMBO/cardano-node-tests/actions/runs/13072587532

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
