### PR TITLE
Remove redundant constraints from cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -51,6 +51,3 @@ semaphore: True
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-
-constraints:
-    Cabal < 3.14,


### PR DESCRIPTION
`cabal-doctest` has now been fixed

# Changelog

```yaml
- description: |
    Remove redundant constraints from cabal.project
# uncomment types applicable to the change:
  type:
  - maintenance    # not directly related to the code
```

# Context

This constraint was added in e8da9762f9 to work around a temporary problem.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff