### PR TITLE
Change a representation of witnesses in transaction's certificates to an ordered map where a certificate is the key

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -207,6 +207,7 @@ library internal
     mtl,
     network,
     network-mux,
+    ordered-containers,
     ouroboros-consensus ^>=0.22,
     ouroboros-consensus-cardano ^>=0.21,
     ouroboros-consensus-diffusion ^>=0.19,

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -621,7 +621,7 @@ genTxCertificates =
         certs <- Gen.list (Range.constant 0 3) $ genCertificate w
         Gen.choice
           [ pure TxCertificatesNone
-          , pure (TxCertificates w certs $ BuildTxWith mempty)
+          , pure (TxCertificates w $ fromList ((,BuildTxWith Nothing) <$> certs))
           -- TODO: Generate certificates
           ]
     )

--- a/cardano-api/internal/Cardano/Api/Certificate.hs
+++ b/cardano-api/internal/Cardano/Api/Certificate.hs
@@ -142,6 +142,8 @@ data Certificate era where
 
 deriving instance Eq (Certificate era)
 
+deriving instance Ord (Certificate era)
+
 deriving instance Show (Certificate era)
 
 instance Typeable era => HasTypeProxy (Certificate era) where

--- a/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ConwayEraOnwards.hs
@@ -55,6 +55,8 @@ deriving instance Show (ConwayEraOnwards era)
 
 deriving instance Eq (ConwayEraOnwards era)
 
+deriving instance Ord (ConwayEraOnwards era)
+
 instance Eon ConwayEraOnwards where
   inEonForEra no yes = \case
     ByronEra -> no

--- a/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/internal/Cardano/Api/Eon/ShelleyToBabbageEra.hs
@@ -50,6 +50,8 @@ deriving instance Show (ShelleyToBabbageEra era)
 
 deriving instance Eq (ShelleyToBabbageEra era)
 
+deriving instance Ord (ShelleyToBabbageEra era)
+
 instance Eon ShelleyToBabbageEra where
   inEonForEra no yes = \case
     ByronEra -> no

--- a/cardano-api/internal/Cardano/Api/Script.hs
+++ b/cardano-api/internal/Cardano/Api/Script.hs
@@ -565,6 +565,8 @@ data ScriptLanguageInEra lang era where
 
 deriving instance Eq (ScriptLanguageInEra lang era)
 
+deriving instance Ord (ScriptLanguageInEra lang era)
+
 deriving instance Show (ScriptLanguageInEra lang era)
 
 instance ToJSON (ScriptLanguageInEra lang era) where
@@ -742,7 +744,7 @@ data ScriptWitness witctx era where
 
 deriving instance Show (ScriptWitness witctx era)
 
--- The GADT in the SimpleScriptWitness constructor requires a custom instance
+-- The existential in the SimpleScriptWitness constructor requires a custom instance
 instance Eq (ScriptWitness witctx era) where
   (==)
     (SimpleScriptWitness langInEra script)

--- a/cardano-api/internal/Cardano/Api/Tx/Body.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Body.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -135,6 +136,7 @@ module Cardano.Api.Tx.Body
   , TxWithdrawals (..)
   , indexTxWithdrawals
   , TxCertificates (..)
+  , mkTxCertificates
   , indexTxCertificates
   , TxUpdateProposal (..)
   , TxMintValue (..)
@@ -302,6 +304,7 @@ import           Data.Functor (($>))
 import           Data.List (sortBy)
 import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
+import           Data.Map.Ordered.Strict (OMap)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe
@@ -1280,38 +1283,61 @@ indexTxWithdrawals (TxWithdrawals _ withdrawals) =
 --
 
 data TxCertificates build era where
+  -- | No certificates
   TxCertificatesNone
     :: TxCertificates build era
+  -- | Represents certificates present in transaction. Prefer using 'mkTxCertificates' to constructing
+  -- this type with a constructor
   TxCertificates
     :: ShelleyBasedEra era
-    -> [Certificate era]
-    -> BuildTxWith build [(StakeCredential, Witness WitCtxStake era)]
-    -- ^ There can be more than one script witness per stake credential
+    -> OMap
+        (Certificate era)
+        ( BuildTxWith
+            build
+            (Maybe (StakeCredential, Witness WitCtxStake era))
+        )
     -> TxCertificates build era
 
 deriving instance Eq (TxCertificates build era)
 
 deriving instance Show (TxCertificates build era)
 
--- | Index certificates with witnesses by the order they appear in the list (in the transaction). If there are multiple witnesses for the same stake credential, they will be present multiple times with the same index.
--- are multiple witnesses for the credential, there will be multiple entries for
+-- | Create 'TxCertificates'. Note that 'Certificate era' will be deduplicated. Only Certificates with a
+-- stake credential will be in the result.
+--
+-- Note that, when building a transaction in Conway era, a witness is not required for staking credential
+-- registration, but this is only the case during the transitional period of Conway era and only for staking
+-- credential registration certificates without a deposit. Future eras will require a witness for
+-- registration certificates, because the one without a deposit will be removed.
+mkTxCertificates
+  :: Applicative (BuildTxWith build)
+  => ShelleyBasedEra era
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -> TxCertificates build era
+mkTxCertificates _ [] = TxCertificatesNone
+mkTxCertificates sbe certs = TxCertificates sbe . fromList $ map getStakeCred certs
+ where
+  getStakeCred (cert, mWit) = do
+    let wit =
+          maybe
+            (KeyWitness KeyWitnessForStakeAddr)
+            (ScriptWitness ScriptWitnessForStakeAddr)
+            mWit
+    ( cert
+      , pure $
+          (,wit) <$> selectStakeCredentialWitness cert
+      )
+
+-- | Index certificates with witnesses by the order they appear in the list (in the transaction).
 -- See section 4.1 of https://github.com/intersectmbo/cardano-ledger/releases/latest/download/alonzo-ledger.pdf
 indexTxCertificates
   :: TxCertificates BuildTx era
   -> [(ScriptWitnessIndex, Certificate era, StakeCredential, Witness WitCtxStake era)]
 indexTxCertificates TxCertificatesNone = []
-indexTxCertificates (TxCertificates _ certs (BuildTxWith witnesses)) =
-  [ (ScriptWitnessIndexCertificate ix, cert, stakeCred, wit)
-  | (ix, cert) <- zip [0 ..] certs
-  , stakeCred <- maybeToList (selectStakeCredentialWitness cert)
-  , wit <- findAll stakeCred witnesses
+indexTxCertificates (TxCertificates _ certsWits) =
+  [ (ScriptWitnessIndexCertificate ix, cert, stakeCred, witness)
+  | (ix, (cert, BuildTxWith (Just (stakeCred, witness)))) <- zip [0 ..] $ toList certsWits
   ]
- where
-  findAll needle = map snd . filter ((==) needle . fst)
-
--- ----------------------------------------------------------------------------
--- Transaction update proposal (era-dependent)
---
 
 data TxUpdateProposal era where
   TxUpdateProposalNone :: TxUpdateProposal era
@@ -2537,7 +2563,8 @@ fromLedgerTxCertificates sbe body =
     let certificates = body ^. L.certsTxBodyL
      in if null certificates
           then TxCertificatesNone
-          else TxCertificates sbe (map (fromShelleyCertificate sbe) $ toList certificates) ViewTx
+          else
+            TxCertificates sbe . fromList $ map ((,ViewTx) . fromShelleyCertificate sbe) $ toList certificates
 
 maybeFromLedgerTxUpdateProposal
   :: ()
@@ -2645,7 +2672,7 @@ convCertificates
   -> Seq.StrictSeq (Shelley.TxCert (ShelleyLedgerEra era))
 convCertificates _ = \case
   TxCertificatesNone -> Seq.empty
-  TxCertificates _ cs _ -> fromList (map toShelleyCertificate cs)
+  TxCertificates _ cs -> fromList . map (toShelleyCertificate . fst) $ toList cs
 
 convWithdrawals :: TxWithdrawals build era -> L.Withdrawals StandardCrypto
 convWithdrawals txWithdrawals =

--- a/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
+++ b/cardano-api/internal/Cardano/Api/Tx/Compatible.hs
@@ -159,7 +159,8 @@ createCompatibleSignedTx sbe ins outs witnesses txFee' anyProtocolUpdate anyVote
     conwayEraOnwardsConstraints conwayOnwards $
       (L.bodyTxL . L.votingProceduresTxBodyL) .~ votingProcedures
 
-  indexedTxCerts :: [(ScriptWitnessIndex, Certificate era, StakeCredential, Witness WitCtxStake era)]
+  indexedTxCerts
+    :: [(ScriptWitnessIndex, Certificate era, StakeCredential, Witness WitCtxStake era)]
   indexedTxCerts = indexTxCertificates txCertificates'
 
   allWitnesses

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -391,6 +391,7 @@ module Cardano.Api
   , TxExtraKeyWitnesses (..)
   , TxWithdrawals (..)
   , TxCertificates (..)
+  , mkTxCertificates
   , TxUpdateProposal (..)
   , TxMintValue (..)
   , txMintValueToValue


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Change a representation of witnesses in transaction's certificates to an ordered map where a certificate is the key.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR changes representation of transaction certificates' witnesses from a list of with stake credentials to a map.

The issue is that there's a relationship `Certificate *--1 StakeCredential` which makes the assigning of witnesses impossible in the cases where we have more than one certificate with the same stake credential. This then breaks witnesses indexing.

See related PRs:
- https://github.com/IntersectMBO/cardano-cli/pull/1028
- https://github.com/IntersectMBO/cardano-node/pull/6082/

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
