### PR TITLE
Add function `collectPlutusScriptHashes` to collect script hashes needed to validate a given transaction

### DIFF
--- a/cardano-api/internal/Cardano/Api/Plutus.hs
+++ b/cardano-api/internal/Cardano/Api/Plutus.hs
@@ -18,8 +18,8 @@ import           Cardano.Api.Query (UTxO, toLedgerUTxO)
 import qualified Cardano.Api.ReexposeLedger as L
 import           Cardano.Api.Script (ScriptHash, fromShelleyScriptHash)
 import qualified Cardano.Api.Script as Api
-import           Cardano.Api.Tx.Body (ScriptWitnessIndex (..), TxBody, toScriptIndex)
-import           Cardano.Api.Tx.Sign (Tx (..), makeSignedTransaction)
+import           Cardano.Api.Tx.Body (ScriptWitnessIndex (..), toScriptIndex)
+import           Cardano.Api.Tx.Sign (Tx (..))
 
 import qualified Cardano.Ledger.Alonzo.Scripts as L
 import qualified Cardano.Ledger.Alonzo.UTxO as Alonzo
@@ -105,12 +105,12 @@ lookupPlutusErrorCode code =
 -- and return them in a map with their corresponding 'ScriptWitnessIndex' as key.
 collectPlutusScriptHashes
   :: AlonzoEraOnwards era
-  -> TxBody era
+  -> Tx era
   -> UTxO era
   -> Map ScriptWitnessIndex ScriptHash
-collectPlutusScriptHashes aeo tb utxo =
+collectPlutusScriptHashes aeo tx utxo =
   alonzoEraOnwardsConstraints aeo $
-    let ShelleyTx _ ledgerTx' = makeSignedTransaction [] tb
+    let ShelleyTx _ ledgerTx' = tx
         ledgerUTxO = toLedgerUTxO (convert aeo) utxo
      in getPurposes aeo $ L.getScriptsNeeded ledgerUTxO (ledgerTx' ^. L.bodyTxL)
  where

--- a/cardano-api/internal/Cardano/Api/Plutus.hs
+++ b/cardano-api/internal/Cardano/Api/Plutus.hs
@@ -112,24 +112,24 @@ collectScriptHashes aeo tb utxo =
   alonzoEraOnwardsConstraints aeo $
     let ShelleyTx _ ledgerTx' = makeSignedTransaction [] tb
         ledgerUTxO = toLedgerUTxO (convert aeo) utxo
-     in getPurpouses aeo $ L.getScriptsNeeded ledgerUTxO (ledgerTx' ^. L.bodyTxL)
+     in getPurposes aeo $ L.getScriptsNeeded ledgerUTxO (ledgerTx' ^. L.bodyTxL)
  where
-  getPurpouses
+  getPurposes
     :: L.EraCrypto (ShelleyLedgerEra era) ~ L.StandardCrypto
     => AlonzoEraOnwards era
     -> Alonzo.AlonzoScriptsNeeded (ShelleyLedgerEra era)
     -> Map ScriptWitnessIndex Api.ScriptHash
-  getPurpouses aeo' (Alonzo.AlonzoScriptsNeeded purpouses) =
+  getPurposes aeo' (Alonzo.AlonzoScriptsNeeded purposes) =
     alonzoEraOnwardsConstraints aeo $
       Map.fromList $
         Prelude.map
-          (bimap (toScriptIndex aeo' . purpouseAsIxItemToAsIx aeo') fromShelleyScriptHash)
-          purpouses
+          (bimap (toScriptIndex aeo' . purposeAsIxItemToAsIx aeo') fromShelleyScriptHash)
+          purposes
 
-  purpouseAsIxItemToAsIx
+  purposeAsIxItemToAsIx
     :: AlonzoEraOnwards era
     -> L.PlutusPurpose L.AsIxItem (ShelleyLedgerEra era)
     -> L.PlutusPurpose L.AsIx (ShelleyLedgerEra era)
-  purpouseAsIxItemToAsIx onwards purpose =
+  purposeAsIxItemToAsIx onwards purpose =
     alonzoEraOnwardsConstraints onwards $
       L.hoistPlutusPurpose L.toAsIx purpose

--- a/cardano-api/internal/Cardano/Api/Plutus.hs
+++ b/cardano-api/internal/Cardano/Api/Plutus.hs
@@ -5,7 +5,7 @@
 module Cardano.Api.Plutus
   ( DebugPlutusFailure (..)
   , renderDebugPlutusFailure
-  , collectScriptHashes
+  , collectPlutusScriptHashes
   )
 where
 
@@ -101,14 +101,14 @@ lookupPlutusErrorCode code =
         Nothing -> "Unknown error code: " <> code
 -}
 
--- | Collect all script hashes that are needed to validate the given transaction
+-- | Collect all plutus script hashes that are needed to validate the given transaction
 -- and return them in a map with their corresponding 'ScriptWitnessIndex' as key.
-collectScriptHashes
+collectPlutusScriptHashes
   :: AlonzoEraOnwards era
   -> TxBody era
   -> UTxO era
   -> Map ScriptWitnessIndex ScriptHash
-collectScriptHashes aeo tb utxo =
+collectPlutusScriptHashes aeo tb utxo =
   alonzoEraOnwardsConstraints aeo $
     let ShelleyTx _ ledgerTx' = makeSignedTransaction [] tb
         ledgerUTxO = toLedgerUTxO (convert aeo) utxo

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -611,7 +611,7 @@ module Cardano.Api
   , examplePlutusScriptAlwaysFails
 
     -- ** Script data
-  , collectScriptHashes
+  , collectPlutusScriptHashes
   , HashableScriptData
   , hashScriptDataBytes
   , getOriginalScriptDataBytes
@@ -1123,7 +1123,7 @@ import           Cardano.Api.Monad.Error
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
 import           Cardano.Api.Orphans ()
-import           Cardano.Api.Plutus (collectScriptHashes)
+import           Cardano.Api.Plutus (collectPlutusScriptHashes)
 import           Cardano.Api.Pretty
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -611,6 +611,7 @@ module Cardano.Api
   , examplePlutusScriptAlwaysFails
 
     -- ** Script data
+  , collectScriptHashes
   , HashableScriptData
   , hashScriptDataBytes
   , getOriginalScriptDataBytes
@@ -1122,6 +1123,7 @@ import           Cardano.Api.Monad.Error
 import           Cardano.Api.NetworkId
 import           Cardano.Api.OperationalCertificate
 import           Cardano.Api.Orphans ()
+import           Cardano.Api.Plutus (collectScriptHashes)
 import           Cardano.Api.Pretty
 import           Cardano.Api.Protocol
 import           Cardano.Api.ProtocolParameters


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add function `collectPlutusScriptHashes` to collect script hashes needed to validate a given transaction
  type:
  - feature
```

# Context

This is required functionality by this `cardano-cli` PR: https://github.com/IntersectMBO/cardano-cli/pull/1031

# How to trust this PR

Ensure the API is in the correct place and has the right structure, that it does the right thing, that the documentation is adequate. Also check in conjunction with the related PRs:
- `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/6097
- `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/1031

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
