### PR TITLE
Add support for the ratify-state query

### DIFF
--- a/cardano-api/internal/Cardano/Api/Query/Expr.hs
+++ b/cardano-api/internal/Cardano/Api/Query/Expr.hs
@@ -35,6 +35,7 @@ module Cardano.Api.Query.Expr
   , querySPOStakeDistribution
   , queryDRepState
   , queryGovState
+  , queryRatifyState
   , queryStakeVoteDelegatees
   , queryProposals
   )
@@ -400,6 +401,20 @@ queryGovState
 queryGovState era = do
   let sbe = convert era
   queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryGovState
+
+queryRatifyState
+  :: ()
+  => ConwayEraOnwards era
+  -> LocalStateQueryExpr
+      block
+      point
+      QueryInMode
+      r
+      IO
+      (Either UnsupportedNtcVersionError (Either EraMismatch (L.RatifyState (ShelleyLedgerEra era))))
+queryRatifyState era = do
+  let sbe = convert era
+  queryExpr $ QueryInEra $ QueryInShelleyBasedEra sbe QueryRatifyState
 
 queryDRepState
   :: ConwayEraOnwards era

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -1029,6 +1029,7 @@ module Cardano.Api
   , queryUtxo
   , queryConstitution
   , queryGovState
+  , queryRatifyState
   , queryDRepState
   , queryDRepStakeDistribution
   , querySPOStakeDistribution


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for the ratify-state query
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Support the `ratify-state` query added in consensus: https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-cardano/CHANGELOG.md#01800--2024-08-26
* Required for the corresponding CLI PR: https://github.com/IntersectMBO/cardano-cli/pull/1036

# How to trust this PR

* It's the same boilerplate as e.g. `QueryGovState`
* Tested with the CLI

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff