### PR TITLE
Split compatible transaction building and signing

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -179,6 +179,7 @@ library
   other-modules:
     Cardano.Api.Internal.Anchor
     Cardano.Api.Internal.Certificate
+    Cardano.Api.Internal.Compatible.Tx
     Cardano.Api.Internal.Convenience.Construction
     Cardano.Api.Internal.Convenience.Query
     Cardano.Api.Internal.DeserialiseAnyOf
@@ -247,7 +248,6 @@ library
     Cardano.Api.Internal.SpecialByron
     Cardano.Api.Internal.StakePoolMetadata
     Cardano.Api.Internal.Tx.Body
-    Cardano.Api.Internal.Tx.Compatible
     Cardano.Api.Internal.Tx.UTxO
     Cardano.Api.Internal.TxIn
     Cardano.Api.Internal.TxMetadata

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -461,7 +461,9 @@ module Cardano.Api
   , makeByronKeyWitness
   , ShelleyWitnessSigningKey (..)
   , makeShelleyKeyWitness
+  , makeShelleyKeyWitness'
   , makeShelleyBootstrapWitness
+  , makeShelleyBasedBootstrapWitness
 
     -- * Transaction metadata
 

--- a/cardano-api/src/Cardano/Api/Compatible.hs
+++ b/cardano-api/src/Cardano/Api/Compatible.hs
@@ -1,6 +1,6 @@
 module Cardano.Api.Compatible
-  ( module Cardano.Api.Internal.Tx.Compatible
+  ( module Cardano.Api.Internal.Compatible.Tx
   )
 where
 
-import Cardano.Api.Internal.Tx.Compatible
+import Cardano.Api.Internal.Compatible.Tx


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Split compatible transaction building into separate building and signing functions.
    Rename `Cardano.Api.Internal.Tx.Compatible` to `Cardano.Api.Internal.Compatible.Tx`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`createCompatibleSignedTx` wasn't really signing the transaction but just blindly adding signatures. It's split into two separate functions for building and signing.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
