### PR TITLE
Relax ouroboros-consensus-diffusion bounds to ^>=0.19 || ^>=0.20

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-12-24T12:56:48Z
-  , cardano-haskell-packages 2025-01-08T16:35:32Z
+  , cardano-haskell-packages 2025-02-11T19:10:21Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -146,7 +146,7 @@ library
     ordered-containers,
     ouroboros-consensus ^>=0.22,
     ouroboros-consensus-cardano ^>=0.21,
-    ouroboros-consensus-diffusion ^>=0.19,
+    ouroboros-consensus-diffusion ^>=0.19 || ^>=0.20,
     ouroboros-consensus-protocol ^>=0.10,
     ouroboros-network,
     ouroboros-network-api ^>=0.12,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1736355014,
-        "narHash": "sha256-2eKlS3k8Up/2oxDSBrw5aoXHFhBq+WV1HwjWwjetom4=",
+        "lastModified": 1739302347,
+        "narHash": "sha256-Hm3Kp8i3rbA72dinxSx6jNjeFCgdYBwz5XDyCiPC0Fo=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "b7f0f0885cd6f507cc767263488f4a07ebdd79d1",
+        "rev": "33f3dc5f14a2f6f8a0ca35cda2956774eeddaf1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade ouroboros-consensus-diffusion to >=0.19 && <0.21
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Integrating CHaP revision into master: https://github.com/IntersectMBO/cardano-haskell-packages/commit/7c77b76a2dab9547abdd0edf35c10784f127aa7a

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
