### PR TITLE
Update CHaP index state and flake input

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-12-24T12:56:48Z
-  , cardano-haskell-packages 2025-02-11T19:10:21Z
+  , cardano-haskell-packages 2025-02-11T21:18:23Z
 
 packages:
     cardano-api

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1739302347,
-        "narHash": "sha256-Hm3Kp8i3rbA72dinxSx6jNjeFCgdYBwz5XDyCiPC0Fo=",
+        "lastModified": 1739310549,
+        "narHash": "sha256-TfqfDfAn+0VoljIQENLezfhQTvBnZJdu2kcfVRA0ZQQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "33f3dc5f14a2f6f8a0ca35cda2956774eeddaf1d",
+        "rev": "f837d4d481a0f2e4cd0cf7e458e4bd12a8400f9c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update CHaP index state and flake input
  type:
  - maintenance    # not directly related to the code
```

# Context

This keeps `cardano-api` in step with `cardano-node` and `cardano-cli`

# How to trust this PR

See IntersectMBO/cardano-node#6111 and IntersectMBO/cardano-cli#1064

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff