### PR TITLE
Fix typo in cardano-api's change log

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for cardano-api
 
-## 10.9.0.0
+## 10.9.0.0
 
 - Re-export `DebugPlutusFailure` and `renderDebugPlutusFailure`.
   (compatible)


### PR DESCRIPTION
I accidentally wrote the wrong kind of space

# Changelog

```yaml
- description: |
    Fixed wrong type of space in cardano-api's change log
  type:
  - bugfix
```

# Context

Unfortunately, in MacOS, when you type <option+space> you get a non-breaking space (ASCII code 160), instead of a normal space (ASCII code 32). This is an easy error to make because in order to write a "#" you need to press <option+3>, and if you don't release the <option> key on time to press the space, then you get the non-breaking space. And the difference is invisible, but it does break scripts. So this PR fixes that.

# How to trust this PR

You can see the rendering of the title of the version works now, but it didn't before. If you really wanna be sure you can print the ascii code for the character I changed.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
