### PR TITLE
Switch cryptonite to crypton

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,7 +28,7 @@ if impl(ghc < 9.8)
 program-options
   ghc-options: -Werror
 
-package cryptonite
+package crypton
   -- Using RDRAND instead of /dev/urandom as an entropy source for key
   -- generation is dubious. Set the flag so we use /dev/urandom by default.
   flags: -support_rdrand

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -133,7 +133,7 @@ library
     cborg,
     containers,
     contra-tracer,
-    cryptonite,
+    crypton,
     data-default-class,
     deepseq,
     directory,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Switch `cryptonite` to `crypton`
  type:
  - compatible
  - maintenance
  - release
```

# Context

`crypton` is the new drop-in replacement to `cryptonite`. We have switched already in [`ledger`](https://github.com/IntersectMBO/cardano-ledger/pull/4859). `cryptonite` is no longer maintained.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] ~~New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details~~
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
