### PR TITLE
Add top level fromList and toList functions in `Cardano.Api.UTxO`

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Convenience/Query.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Convenience/Query.hs
@@ -35,7 +35,7 @@ import Cardano.Api.Internal.ProtocolParameters
 import Cardano.Api.Internal.Query
 import Cardano.Api.Internal.Query.Expr
 import Cardano.Api.Internal.Tx.Body
-import Cardano.Api.Internal.Tx.UTxO
+import Cardano.Api.Internal.Tx.UTxO (UTxO (..))
 import Cardano.Api.Internal.Utils
 
 import Cardano.Ledger.Api qualified as L

--- a/cardano-api/src/Cardano/Api/Internal/Fees.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Fees.hs
@@ -360,7 +360,7 @@ import Cardano.Api.Internal.Query
 import Cardano.Api.Internal.Script
 import Cardano.Api.Internal.Tx.Body
 import Cardano.Api.Internal.Tx.Sign
-import Cardano.Api.Internal.Tx.UTxO
+import Cardano.Api.Internal.Tx.UTxO (UTxO (..))
 import Cardano.Api.Internal.Value
 import Cardano.Api.Ledger.Lens qualified as A
 

--- a/cardano-api/src/Cardano/Api/Internal/Query.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Query.hs
@@ -79,7 +79,7 @@ import Cardano.Api.Internal.ProtocolParameters
 import Cardano.Api.Internal.Query.Types
 import Cardano.Api.Internal.ReexposeLedger qualified as Ledger
 import Cardano.Api.Internal.Tx.Body
-import Cardano.Api.Internal.Tx.UTxO
+import Cardano.Api.Internal.Tx.UTxO (UTxO (..))
 
 import Cardano.Chain.Update.Validation.Interface qualified as Byron.Update
 import Cardano.Ledger.Api qualified as L

--- a/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
@@ -77,3 +77,11 @@ inputSet = Map.keysSet . unUTxO
 -- | Remove the right hand side from the left hand side.
 difference :: UTxO era -> UTxO era -> UTxO era
 difference a b = UTxO $ Map.difference (unUTxO a) (unUTxO b)
+
+-- | Convert from a list of key/value pairs.
+fromList :: UTxO era -> [(TxIn, (TxOut CtxUTxO era))]
+fromList (UTxO xs) = Map.fromList xs
+
+-- | Convert to a list of key/value pairs.
+toList :: [(TxIn, (TxOut CtxUTxO era))] -> UTxO era
+toList = UTxO . Map.toList

--- a/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
@@ -21,11 +21,11 @@ import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Text (Text)
-import GHC.Exts (IsList (..))
+import GHC.Exts qualified as GHC
 
 newtype UTxO era = UTxO {unUTxO :: Map TxIn (TxOut CtxUTxO era)}
   deriving stock (Eq, Show)
-  deriving newtype (Semigroup, Monoid, IsList)
+  deriving newtype (Semigroup, Monoid, GHC.IsList)
 
 instance IsCardanoEra era => ToJSON (UTxO era) where
   toJSON (UTxO m) = toJSON m
@@ -36,7 +36,7 @@ instance
   => FromJSON (UTxO era)
   where
   parseJSON = Aeson.withObject "UTxO" $ \hm -> do
-    let l = toList $ KeyMap.toHashMapText hm
+    let l = GHC.toList $ KeyMap.toHashMapText hm
     res <- mapM toTxIn l
     pure . UTxO $ Map.fromList res
    where
@@ -79,9 +79,9 @@ difference :: UTxO era -> UTxO era -> UTxO era
 difference a b = UTxO $ Map.difference (unUTxO a) (unUTxO b)
 
 -- | Convert from a list of key/value pairs.
-fromList :: UTxO era -> [(TxIn, (TxOut CtxUTxO era))]
-fromList (UTxO xs) = Map.fromList xs
+fromList :: [(TxIn, TxOut CtxUTxO era)] -> UTxO era
+fromList = UTxO . Map.fromList
 
 -- | Convert to a list of key/value pairs.
-toList :: [(TxIn, (TxOut CtxUTxO era))] -> UTxO era
-toList = UTxO . Map.toList
+toList :: UTxO era -> [(TxIn, TxOut CtxUTxO era)]
+toList (UTxO xs) = Map.toList xs

--- a/cardano-api/src/Cardano/Api/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Tx/UTxO.hs
@@ -7,6 +7,8 @@ module Cardano.Api.Tx.UTxO
   , UTxO.filterWithKey
   , UTxO.inputSet
   , UTxO.difference
+  , UTxO.fromList
+  , UTxO.toList
   )
 where
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Define `fromList` and `toList` in `Cardano.Api.UTxO` module.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

I'd like to add these because the user experience is annoying to have to import `GHC.Exts` when what I want to say is `UTxO.fromList` and `UTxO.toList` (a la  `Data.Map`).

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
