### PR TITLE
Add `HasTextEnvelope` instance for `EraHistory`

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -165,6 +165,7 @@ library
     prettyprinter-ansi-terminal,
     prettyprinter-configurable ^>=1.36,
     random,
+    reflection,
     safe-exceptions,
     scientific,
     serialise,

--- a/cardano-api/src/Cardano/Api/Internal/Query.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Query.hs
@@ -194,6 +194,9 @@ instance SerialiseAsCBOR EraHistory where
     EraHistory
       <$> CBOR.decodeFullDecoder' "EraHistory" (give History.EraParamsWithGenesisWindow CBOR.decode) bs
 
+-- | The @HasTextEnvelope@ instance for @EraHistory@ is required by the
+-- @transaction calculate-plutus-script-cost@ command in @cartdano-cli and it
+-- can be obtained through the @query era-history@ command.
 instance HasTextEnvelope EraHistory where
   textEnvelopeType :: AsType EraHistory -> TextEnvelopeType
   textEnvelopeType _ = "EraHistory"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added `HasTextEnvelope` instance for `EraHistory`
  type:
  - feature        # introduces a new feature
  - compatible     # the API has changed but is non-breaking
```

# Context

This change in the API is required to support the related PR in `cardano-cli`: https://github.com/IntersectMBO/cardano-cli/pull/1079

# How to trust this PR

I would look at all the changes, which are few. The fact that it type-checks already gives a lot of guarantee. The approach is pretty similar to that of other `HasTextEnvelope` instances. The tests in the related `cardano-cli` PR can offer further assurance.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

