### PR TITLE
Add missing certificates in compatible transaction building in eras after Shelley and prior to Alonzo

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Compatible/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Compatible/Tx.hs
@@ -134,10 +134,9 @@ createCompatibleTx sbe ins outs txFee' anyProtocolUpdate anyVote txCertificates'
 
   setCerts :: Endo (L.TxBody (ShelleyLedgerEra era))
   setCerts =
-    monoidForEraInEon era $ \aeo ->
-      alonzoEraOnwardsConstraints aeo $
-        Endo $
-          L.certsTxBodyL .~ convCertificates sbe txCertificates'
+    shelleyBasedEraConstraints sbe $
+      Endo $
+        L.certsTxBodyL .~ convCertificates sbe txCertificates'
 
   setRefInputs :: Endo (L.TxBody (ShelleyLedgerEra era))
   setRefInputs = do


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add missing certificates in compatible transaction building in eras after Shelley and prior to Alonzo
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Certificates support was needlessly restricted to eras >= Alonzo.

Fixes:
- https://github.com/IntersectMBO/cardano-cli/issues/1080

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
