### PR TITLE
Make 1-1 relationship of witness and policy ID in TxMintValue instead of 1-*

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -146,6 +146,7 @@ library
     memory,
     microlens,
     microlens-aeson,
+    mono-traversable,
     mtl,
     network,
     network-mux,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -234,8 +234,6 @@ module Cardano.Api
   , AssetName (..)
   , AssetId (..)
   , Value
-  , ParserValueRole (..)
-  , parseValue
   , parsePolicyId
   , parseAssetName
   , parseTxOutMultiAssetValue
@@ -251,9 +249,15 @@ module Cardano.Api
   , valueToNestedRep
   , valueFromNestedRep
   , renderValue
+  , renderMultiAsset
   , renderValuePretty
+  , renderMultiAssetPretty
   , toLedgerValue
   , fromLedgerValue
+  , PolicyAssets (..)
+  , policyAssetsToValue
+  , valueToPolicyAssets
+  , multiAssetToPolicyAssets
 
     -- ** Ada \/ Lovelace within multi-asset values
   , Lovelace
@@ -395,6 +399,7 @@ module Cardano.Api
   , mkTxCertificates
   , TxUpdateProposal (..)
   , TxMintValue (..)
+  , mkTxMintValue
   , txMintValueToValue
   , indexTxMintValue
   , TxVotingProcedures (..)

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
@@ -148,6 +148,19 @@ instance FromJSON (Some Era) where
       )
         . eraFromStringLike
 
+-- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
+instance Eon Era where
+  inEonForEra v f = \case
+    Api.ConwayEra -> f ConwayEra
+    Api.BabbageEra -> f BabbageEra
+    _ -> v
+
+-- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
+instance Api.ToCardanoEra Era where
+  toCardanoEra = \case
+    BabbageEra -> Api.BabbageEra
+    ConwayEra -> Api.ConwayEra
+
 eraToStringLike :: IsString a => Era era -> a
 {-# INLINE eraToStringLike #-}
 eraToStringLike = \case
@@ -252,13 +265,6 @@ instance IsEra BabbageEra where
 
 instance IsEra ConwayEra where
   useEra = ConwayEra
-
--- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
-instance Eon Era where
-  inEonForEra v f = \case
-    Api.ConwayEra -> f ConwayEra
-    Api.BabbageEra -> f BabbageEra
-    _ -> v
 
 obtainCommonConstraints
   :: Era era

--- a/cardano-api/src/Cardano/Api/Internal/ReexposeLedger.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ReexposeLedger.hs
@@ -56,6 +56,7 @@ module Cardano.Api.Internal.ReexposeLedger
   , TxId (..)
   , TxIn (..)
   , Value
+  , MultiAsset (..)
   , addDeltaCoin
   , castSafeHash
   , toDeltaCoin
@@ -321,6 +322,7 @@ import Cardano.Ledger.Keys
   , hashWithSerialiser
   , toVRFVerKeyHash
   )
+import Cardano.Ledger.Mary.Value (MultiAsset (..))
 import Cardano.Ledger.Plutus.Data (Data (..), unData)
 import Cardano.Ledger.Plutus.Language (Language, Plutus, languageToText, plutusBinary)
 import Cardano.Ledger.PoolParams (PoolMetadata (..), PoolParams (..), StakePoolRelay (..))

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -81,7 +81,7 @@ prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.pr
   let txMint =
         TxMintValue
           meo
-          [(policyId', [("eeee", 1, BuildTxWith plutusWitness)])]
+          [(policyId', ([("eeee", 1)], BuildTxWith plutusWitness))]
 
   -- tx body content without an asset in TxOut
   let content =
@@ -244,7 +244,7 @@ prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $
   let txMint =
         TxMintValue
           meo
-          [(policyId', [("eeee", 1, BuildTxWith plutusWitness)])]
+          [(policyId', ([("eeee", 1)], BuildTxWith plutusWitness))]
 
   let content =
         defaultTxBodyContent sbe
@@ -297,7 +297,7 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
       sbe = convert beo
       era = convert beo
   feeCoin@(L.Coin fee) <- forAll genLovelace
-  totalCollateral <- forAll $ genValueForTxOut sbe
+  totalCollateral <- forAll $ genLedgerValueForTxOut sbe
   let totalCollateralAda = totalCollateral ^. L.adaAssetL sbe
   pparams <-
     H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make 1-1 relationship of witness and policy ID in TxMintValue instead of 1-*
    Remove exports: `parseValue`, `ParserValueRole`
    Add new type `PolicyAssets` representing minted assets within a single PolicyId
    Add `mkTxMintValue` helper function
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes: 
 - https://github.com/IntersectMBO/cardano-api/issues/769

Previous related changes to `TxMintValue`:
 - https://github.com/IntersectMBO/cardano-api/pull/663/

Used in: 
- https://github.com/IntersectMBO/cardano-cli/pull/1085

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
