### PR TITLE
Add pool operator extended key support

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.
@@ -37,6 +40,7 @@ module Cardano.Api.Internal.Keys.Shelley
   , VerificationKey (..)
   , SigningKey (..)
   , Hash (..)
+  , AnyStakePoolKey (..)
   )
 where
 
@@ -1657,6 +1661,242 @@ instance CastSigningKeyRole GenesisUTxOKey PaymentKey where
 --
 -- stake pool keys
 --
+
+--  | Wrapper that handles both normal and extended StakePoolKeys
+data AnyStakePoolKey stakePoolKeyType where
+  StakePoolKeyNormal :: StakePoolKey -> AnyStakePoolKey StakePoolKey
+  StakePoolKeyExtended :: StakePoolExtendedKey -> AnyStakePoolKey StakePoolExtendedKey
+
+instance HasTypeProxy (AnyStakePoolKey StakePoolKey) where
+  data AsType (AnyStakePoolKey StakePoolKey) where
+    AsAnyStakePoolKeyNormal :: AsType (AnyStakePoolKey StakePoolKey)
+  proxyToAsType (Proxy :: Proxy (AnyStakePoolKey StakePoolKey)) = AsAnyStakePoolKeyNormal
+
+instance HasTypeProxy (AnyStakePoolKey StakePoolExtendedKey) where
+  data AsType (AnyStakePoolKey StakePoolExtendedKey) where
+    AsAnyStakePoolKeyExtended :: AsType (AnyStakePoolKey StakePoolExtendedKey)
+  proxyToAsType (Proxy :: Proxy (AnyStakePoolKey StakePoolExtendedKey)) = AsAnyStakePoolKeyExtended
+
+instance Key (AnyStakePoolKey StakePoolKey) where
+  data VerificationKey (AnyStakePoolKey StakePoolKey)
+    = StakePoolVerificationKeyNormal (VerificationKey StakePoolKey)
+    deriving stock Eq
+    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey (AnyStakePoolKey StakePoolKey))
+    deriving anyclass SerialiseAsCBOR
+
+  data SigningKey (AnyStakePoolKey StakePoolKey) = StakePoolSigningKeyNormal (SigningKey StakePoolKey)
+    deriving (Show, IsString) via UsingRawBytesHex (SigningKey (AnyStakePoolKey StakePoolKey))
+    deriving anyclass SerialiseAsCBOR
+
+  deterministicSigningKey
+    :: AsType (AnyStakePoolKey StakePoolKey) -> Crypto.Seed -> SigningKey (AnyStakePoolKey StakePoolKey)
+  deterministicSigningKey AsAnyStakePoolKeyNormal seed =
+    StakePoolSigningKeyNormal (deterministicSigningKey AsStakePoolKey seed)
+
+  deterministicSigningKeySeedSize :: AsType (AnyStakePoolKey StakePoolKey) -> Word
+  deterministicSigningKeySeedSize AsAnyStakePoolKeyNormal =
+    deterministicSigningKeySeedSize AsStakePoolKey
+
+  getVerificationKey
+    :: SigningKey (AnyStakePoolKey StakePoolKey) -> VerificationKey (AnyStakePoolKey StakePoolKey)
+  getVerificationKey (StakePoolSigningKeyNormal sk) =
+    StakePoolVerificationKeyNormal (getVerificationKey sk)
+
+  verificationKeyHash
+    :: VerificationKey (AnyStakePoolKey StakePoolKey) -> Hash (AnyStakePoolKey StakePoolKey)
+  verificationKeyHash (StakePoolVerificationKeyNormal vkey) =
+    StakePoolKeyNormalHash (verificationKeyHash vkey)
+
+instance ToCBOR (VerificationKey (AnyStakePoolKey StakePoolKey)) where
+  toCBOR (StakePoolVerificationKeyNormal vk) = toCBOR vk
+
+instance FromCBOR (VerificationKey (AnyStakePoolKey StakePoolKey)) where
+  fromCBOR = StakePoolVerificationKeyNormal <$> fromCBOR
+
+instance ToCBOR (SigningKey (AnyStakePoolKey StakePoolKey)) where
+  toCBOR (StakePoolSigningKeyNormal sk) = toCBOR sk
+
+instance FromCBOR (SigningKey (AnyStakePoolKey StakePoolKey)) where
+  fromCBOR = StakePoolSigningKeyNormal <$> fromCBOR
+
+instance SerialiseAsRawBytes (VerificationKey (AnyStakePoolKey StakePoolKey)) where
+  serialiseToRawBytes (StakePoolVerificationKeyNormal vk) = serialiseToRawBytes vk
+
+  deserialiseFromRawBytes (AsVerificationKey AsAnyStakePoolKeyNormal) bs =
+    StakePoolVerificationKeyNormal <$> deserialiseFromRawBytes (AsVerificationKey AsStakePoolKey) bs
+
+instance SerialiseAsRawBytes (SigningKey (AnyStakePoolKey StakePoolKey)) where
+  serialiseToRawBytes (StakePoolSigningKeyNormal sk) = serialiseToRawBytes sk
+
+  deserialiseFromRawBytes (AsSigningKey AsAnyStakePoolKeyNormal) bs =
+    StakePoolSigningKeyNormal <$> deserialiseFromRawBytes (AsSigningKey AsStakePoolKey) bs
+
+instance SerialiseAsBech32 (VerificationKey (AnyStakePoolKey StakePoolKey)) where
+  bech32PrefixFor (StakePoolVerificationKeyNormal vk) = bech32PrefixFor vk
+
+  bech32PrefixesPermitted (AsVerificationKey AsAnyStakePoolKeyNormal) =
+    bech32PrefixesPermitted (AsVerificationKey AsStakePoolKey)
+
+instance SerialiseAsBech32 (SigningKey (AnyStakePoolKey StakePoolKey)) where
+  bech32PrefixFor (StakePoolSigningKeyNormal sk) = bech32PrefixFor sk
+
+  bech32PrefixesPermitted (AsSigningKey AsAnyStakePoolKeyNormal) =
+    bech32PrefixesPermitted (AsSigningKey AsStakePoolKey)
+
+instance Key (AnyStakePoolKey StakePoolExtendedKey) where
+  data VerificationKey (AnyStakePoolKey StakePoolExtendedKey)
+    = StakePoolVerificationKeyExtended (VerificationKey StakePoolExtendedKey)
+    deriving Eq
+    deriving
+      (Show, IsString)
+      via UsingRawBytesHex (VerificationKey (AnyStakePoolKey StakePoolExtendedKey))
+    deriving anyclass SerialiseAsCBOR
+
+  data SigningKey (AnyStakePoolKey StakePoolExtendedKey)
+    = StakePoolSigningKeyExtended (SigningKey StakePoolExtendedKey)
+    deriving (Show, IsString) via UsingRawBytesHex (SigningKey (AnyStakePoolKey StakePoolExtendedKey))
+    deriving anyclass SerialiseAsCBOR
+
+  deterministicSigningKey
+    :: AsType (AnyStakePoolKey StakePoolExtendedKey)
+    -> Crypto.Seed
+    -> SigningKey (AnyStakePoolKey StakePoolExtendedKey)
+  deterministicSigningKey AsAnyStakePoolKeyExtended seed =
+    StakePoolSigningKeyExtended (deterministicSigningKey AsStakePoolExtendedKey seed)
+
+  deterministicSigningKeySeedSize :: AsType (AnyStakePoolKey StakePoolExtendedKey) -> Word
+  deterministicSigningKeySeedSize AsAnyStakePoolKeyExtended =
+    deterministicSigningKeySeedSize AsStakePoolExtendedKey
+
+  getVerificationKey
+    :: SigningKey (AnyStakePoolKey StakePoolExtendedKey)
+    -> VerificationKey (AnyStakePoolKey StakePoolExtendedKey)
+  getVerificationKey (StakePoolSigningKeyExtended sk) =
+    StakePoolVerificationKeyExtended (getVerificationKey sk)
+
+  verificationKeyHash
+    :: VerificationKey (AnyStakePoolKey StakePoolExtendedKey)
+    -> Hash (AnyStakePoolKey StakePoolExtendedKey)
+  verificationKeyHash (StakePoolVerificationKeyExtended vkey) =
+    StakePoolKeyExtendedHash (verificationKeyHash vkey)
+
+instance ToCBOR (VerificationKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  toCBOR (StakePoolVerificationKeyExtended vk) = toCBOR vk
+
+instance FromCBOR (VerificationKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  fromCBOR = StakePoolVerificationKeyExtended <$> fromCBOR
+
+instance ToCBOR (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  toCBOR (StakePoolSigningKeyExtended sk) = toCBOR sk
+
+instance FromCBOR (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  fromCBOR = StakePoolSigningKeyExtended <$> fromCBOR
+
+instance SerialiseAsRawBytes (VerificationKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  serialiseToRawBytes (StakePoolVerificationKeyExtended vk) = serialiseToRawBytes vk
+
+  deserialiseFromRawBytes (AsVerificationKey AsAnyStakePoolKeyExtended) bs =
+    StakePoolVerificationKeyExtended
+      <$> deserialiseFromRawBytes (AsVerificationKey AsStakePoolExtendedKey) bs
+
+instance SerialiseAsRawBytes (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  serialiseToRawBytes (StakePoolSigningKeyExtended sk) = serialiseToRawBytes sk
+
+  deserialiseFromRawBytes (AsSigningKey AsAnyStakePoolKeyExtended) bs =
+    StakePoolSigningKeyExtended <$> deserialiseFromRawBytes (AsSigningKey AsStakePoolExtendedKey) bs
+
+instance SerialiseAsBech32 (VerificationKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  bech32PrefixFor (StakePoolVerificationKeyExtended vk) = bech32PrefixFor vk
+
+  bech32PrefixesPermitted (AsVerificationKey AsAnyStakePoolKeyExtended) =
+    bech32PrefixesPermitted (AsVerificationKey AsStakePoolExtendedKey)
+
+instance SerialiseAsBech32 (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  bech32PrefixFor (StakePoolSigningKeyExtended sk) = bech32PrefixFor sk
+
+  bech32PrefixesPermitted (AsSigningKey AsAnyStakePoolKeyExtended) =
+    bech32PrefixesPermitted (AsSigningKey AsStakePoolExtendedKey)
+
+data instance Hash (AnyStakePoolKey stakePoolKeyType) where
+  StakePoolKeyNormalHash :: Hash StakePoolKey -> Hash (AnyStakePoolKey StakePoolKey)
+  StakePoolKeyExtendedHash :: Hash StakePoolExtendedKey -> Hash (AnyStakePoolKey StakePoolExtendedKey)
+
+deriving via
+  (UsingRawBytesHex (Hash (AnyStakePoolKey StakePoolKey)))
+  instance
+    (Show (Hash (AnyStakePoolKey StakePoolKey)))
+
+deriving via
+  (UsingRawBytesHex (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+  instance
+    (Show (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+
+deriving via
+  (UsingRawBytesHex (Hash (AnyStakePoolKey StakePoolKey)))
+  instance
+    (IsString (Hash (AnyStakePoolKey StakePoolKey)))
+
+deriving via
+  (UsingRawBytesHex (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+  instance
+    (IsString (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+
+deriving via
+  (UsingRawBytes (Hash (AnyStakePoolKey StakePoolKey)))
+  instance
+    ToCBOR (Hash (AnyStakePoolKey StakePoolKey))
+
+deriving via
+  (UsingRawBytes (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+  instance
+    ToCBOR (Hash (AnyStakePoolKey StakePoolExtendedKey))
+
+deriving via
+  (UsingRawBytes (Hash (AnyStakePoolKey StakePoolKey)))
+  instance
+    FromCBOR (Hash (AnyStakePoolKey StakePoolKey))
+
+deriving via
+  (UsingRawBytes (Hash (AnyStakePoolKey StakePoolExtendedKey)))
+  instance
+    FromCBOR (Hash (AnyStakePoolKey StakePoolExtendedKey))
+
+deriving anyclass instance SerialiseAsCBOR (Hash (AnyStakePoolKey StakePoolKey))
+
+deriving anyclass instance SerialiseAsCBOR (Hash (AnyStakePoolKey StakePoolExtendedKey))
+
+deriving stock instance Eq (Hash StakePoolKey) => Eq (Hash (AnyStakePoolKey StakePoolKey))
+
+deriving stock instance
+  Eq (Hash StakePoolExtendedKey) => Eq (Hash (AnyStakePoolKey StakePoolExtendedKey))
+
+deriving stock instance Ord (Hash StakePoolKey) => Ord (Hash (AnyStakePoolKey StakePoolKey))
+
+deriving stock instance
+  Ord (Hash StakePoolExtendedKey) => Ord (Hash (AnyStakePoolKey StakePoolExtendedKey))
+
+instance SerialiseAsRawBytes (Hash (AnyStakePoolKey StakePoolKey)) where
+  serialiseToRawBytes (StakePoolKeyNormalHash vkh) = serialiseToRawBytes vkh
+  deserialiseFromRawBytes (AsHash AsAnyStakePoolKeyNormal) bs =
+    StakePoolKeyNormalHash <$> deserialiseFromRawBytes (AsHash AsStakePoolKey) bs
+
+instance SerialiseAsRawBytes (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
+  serialiseToRawBytes (StakePoolKeyExtendedHash vkh) = serialiseToRawBytes vkh
+
+  deserialiseFromRawBytes (AsHash AsAnyStakePoolKeyExtended) bs =
+    StakePoolKeyExtendedHash <$> deserialiseFromRawBytes (AsHash AsStakePoolExtendedKey) bs
+
+instance HasTextEnvelope (VerificationKey (AnyStakePoolKey StakePoolKey)) where
+  textEnvelopeType (AsVerificationKey AsAnyStakePoolKeyNormal) = textEnvelopeType (AsVerificationKey AsStakePoolKey)
+
+instance HasTextEnvelope (VerificationKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  textEnvelopeType (AsVerificationKey AsAnyStakePoolKeyExtended) = textEnvelopeType (AsVerificationKey AsStakePoolExtendedKey)
+
+instance HasTextEnvelope (SigningKey (AnyStakePoolKey StakePoolKey)) where
+  textEnvelopeType (AsSigningKey AsAnyStakePoolKeyNormal) = textEnvelopeType (AsSigningKey AsStakePoolKey)
+
+instance HasTextEnvelope (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
+  textEnvelopeType (AsSigningKey AsAnyStakePoolKeyExtended) = textEnvelopeType (AsSigningKey AsStakePoolExtendedKey)
 
 data StakePoolKey
 

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -1906,6 +1906,18 @@ instance SerialiseAsBech32 (SigningKey StakePoolExtendedKey) where
   bech32PrefixFor _ = "pool_xsk"
   bech32PrefixesPermitted _ = ["pool_xsk"]
 
+instance CastVerificationKeyRole StakePoolExtendedKey StakePoolKey where
+  castVerificationKey (StakePoolExtendedVerificationKey vk) =
+    StakePoolVerificationKey
+      . Shelley.VKey
+      . fromMaybe impossible
+      . Crypto.rawDeserialiseVerKeyDSIGN
+      . Crypto.HD.xpubPublicKey
+      $ vk
+   where
+    impossible =
+      error "castVerificationKey: byron and shelley key sizes do not match!"
+
 --
 -- DRep keys
 --

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -7,9 +7,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -42,6 +45,11 @@ module Cardano.Api.Internal.Keys.Shelley
   , Hash (..)
   , AnyStakePoolKey (..)
   , AnyStakePoolKeyWrapper (..)
+  , rewrapAnyStakePoolKey
+  , foldStakePoolKey
+  , liftStakePoolKey
+  , liftStakePoolKeyM
+  , unStakePoolAnyKeyHash
   )
 where
 
@@ -415,6 +423,10 @@ instance SerialiseAsRawBytes (Hash StakeKey) where
   deserialiseFromRawBytes (AsHash AsStakeKey) bs =
     maybeToRight (SerialiseAsRawBytesError "Unable to deserialise Hash StakeKey") $
       StakeKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs
+
+instance SerialiseAsBech32 (Hash StakeKey) where
+  bech32PrefixFor _ = "pool"
+  bech32PrefixesPermitted _ = ["pool"]
 
 instance HasTextEnvelope (VerificationKey StakeKey) where
   textEnvelopeType _ =
@@ -1665,7 +1677,83 @@ instance CastSigningKeyRole GenesisUTxOKey PaymentKey where
 
 -- | Wrapper that handles both normal and extended StakePoolKeys and hides the type with an existential
 data AnyStakePoolKeyWrapper t
-  = forall stakePoolKeyType. AnyStakePoolKeyWrapper (t (AnyStakePoolKey stakePoolKeyType))
+  = forall x. StakePoolKey ~ x => StakePoolNormalKeyWrapper (t (AnyStakePoolKey x))
+  | forall x. StakePoolExtendedKey ~ x => StakePoolExtendedKeyWrapper (t (AnyStakePoolKey x))
+
+instance
+  (Eq (t (AnyStakePoolKey StakePoolKey)), Eq (t (AnyStakePoolKey StakePoolExtendedKey)))
+  => Eq (AnyStakePoolKeyWrapper t)
+  where
+  (==) :: AnyStakePoolKeyWrapper t -> AnyStakePoolKeyWrapper t -> Bool
+  (==) (StakePoolNormalKeyWrapper x) (StakePoolNormalKeyWrapper y) = x == y
+  (==) (StakePoolExtendedKeyWrapper x) (StakePoolExtendedKeyWrapper y) = x == y
+  (==) _ _ = False
+
+instance
+  (Ord (t (AnyStakePoolKey StakePoolKey)), Ord (t (AnyStakePoolKey StakePoolExtendedKey)))
+  => Ord (AnyStakePoolKeyWrapper t)
+  where
+  compare :: AnyStakePoolKeyWrapper t -> AnyStakePoolKeyWrapper t -> Ordering
+  compare (StakePoolNormalKeyWrapper x) (StakePoolNormalKeyWrapper y) = compare x y
+  compare (StakePoolExtendedKeyWrapper x) (StakePoolExtendedKeyWrapper y) = compare x y
+  compare (StakePoolNormalKeyWrapper _) (StakePoolExtendedKeyWrapper _) = LT
+  compare (StakePoolExtendedKeyWrapper _) (StakePoolNormalKeyWrapper _) = GT
+
+instance
+  (Show (t (AnyStakePoolKey StakePoolKey)), (Show (t (AnyStakePoolKey StakePoolExtendedKey))))
+  => Show (AnyStakePoolKeyWrapper t)
+  where
+  show (StakePoolNormalKeyWrapper x) = show x
+  show (StakePoolExtendedKeyWrapper x) = show x
+
+rewrapAnyStakePoolKey
+  :: (forall x. t (AnyStakePoolKey x) -> f (AnyStakePoolKey x))
+  -> AnyStakePoolKeyWrapper t
+  -> AnyStakePoolKeyWrapper f
+rewrapAnyStakePoolKey f x = liftStakePoolKey x (const f)
+
+foldStakePoolKey
+  :: AnyStakePoolKeyWrapper t
+  -> ( forall a
+        . ( Key (AnyStakePoolKey a)
+          , SerialiseAsBech32
+              (VerificationKey (AnyStakePoolKey a))
+          , ToJSON (Hash (AnyStakePoolKey a))
+          )
+       => AsType (AnyStakePoolKey a) -> t (AnyStakePoolKey a) -> f
+     )
+  -> f
+foldStakePoolKey (StakePoolNormalKeyWrapper x) f = f AsAnyStakePoolKeyNormal x
+foldStakePoolKey (StakePoolExtendedKeyWrapper x) f = f AsAnyStakePoolKeyExtended x
+
+liftStakePoolKey
+  :: AnyStakePoolKeyWrapper t
+  -> ( forall a
+        . ( Key (AnyStakePoolKey a)
+          , SerialiseAsBech32
+              (VerificationKey (AnyStakePoolKey a))
+          )
+       => AsType (AnyStakePoolKey a) -> t (AnyStakePoolKey a) -> f (AnyStakePoolKey a)
+     )
+  -> AnyStakePoolKeyWrapper f
+liftStakePoolKey (StakePoolNormalKeyWrapper x) f = StakePoolNormalKeyWrapper $ f AsAnyStakePoolKeyNormal x
+liftStakePoolKey (StakePoolExtendedKeyWrapper x) f = StakePoolExtendedKeyWrapper $ f AsAnyStakePoolKeyExtended x
+
+liftStakePoolKeyM
+  :: Applicative g
+  => AnyStakePoolKeyWrapper t
+  -> ( forall a
+        . ( Key (AnyStakePoolKey a)
+          , SerialiseAsBech32
+              (VerificationKey (AnyStakePoolKey a))
+          )
+       => AsType (AnyStakePoolKey a) -> t (AnyStakePoolKey a) -> g (f (AnyStakePoolKey a))
+     )
+  -> g (AnyStakePoolKeyWrapper f)
+liftStakePoolKeyM (StakePoolNormalKeyWrapper x) f = do
+  StakePoolNormalKeyWrapper <$> f AsAnyStakePoolKeyNormal x
+liftStakePoolKeyM (StakePoolExtendedKeyWrapper x) f = do
+  StakePoolExtendedKeyWrapper <$> f AsAnyStakePoolKeyExtended x
 
 --  | Wrapper that handles both normal and extended StakePoolKeys
 data AnyStakePoolKey stakePoolKeyType where
@@ -1891,6 +1979,32 @@ instance SerialiseAsRawBytes (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
   deserialiseFromRawBytes (AsHash AsAnyStakePoolKeyExtended) bs =
     StakePoolKeyExtendedHash <$> deserialiseFromRawBytes (AsHash AsStakePoolExtendedKey) bs
 
+instance SerialiseAsBech32 (Hash (AnyStakePoolKey StakePoolKey)) where
+  bech32PrefixFor (StakePoolKeyNormalHash spkh) = bech32PrefixFor spkh
+  bech32PrefixesPermitted (AsHash AsAnyStakePoolKeyNormal) = bech32PrefixesPermitted (AsHash AsStakePoolKey)
+
+instance SerialiseAsBech32 (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
+  bech32PrefixFor (StakePoolKeyExtendedHash spkh) = bech32PrefixFor spkh
+  bech32PrefixesPermitted (AsHash AsAnyStakePoolKeyExtended) = bech32PrefixesPermitted (AsHash AsStakePoolExtendedKey)
+
+instance ToJSON (Hash (AnyStakePoolKey StakePoolKey)) where
+  toJSON (StakePoolKeyNormalHash spk) = toJSON $ serialiseToBech32 spk
+
+instance ToJSONKey (Hash (AnyStakePoolKey StakePoolKey)) where
+  toJSONKey = toJSONKeyText serialiseToBech32 -- FixMe: ensure this is correct
+
+instance FromJSON (Hash (AnyStakePoolKey StakePoolKey)) where
+  parseJSON x = StakePoolKeyNormalHash <$> parseJSON x
+
+instance ToJSON (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
+  toJSON (StakePoolKeyExtendedHash spk) = toJSON $ serialiseToBech32 spk
+
+instance ToJSONKey (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
+  toJSONKey = toJSONKeyText serialiseToBech32 -- FixMe: ensure this is correct
+
+instance FromJSON (Hash (AnyStakePoolKey StakePoolExtendedKey)) where
+  parseJSON x = StakePoolKeyExtendedHash <$> parseJSON x
+
 instance HasTextEnvelope (VerificationKey (AnyStakePoolKey StakePoolKey)) where
   textEnvelopeType (AsVerificationKey AsAnyStakePoolKeyNormal) = textEnvelopeType (AsVerificationKey AsStakePoolKey)
 
@@ -1902,6 +2016,11 @@ instance HasTextEnvelope (SigningKey (AnyStakePoolKey StakePoolKey)) where
 
 instance HasTextEnvelope (SigningKey (AnyStakePoolKey StakePoolExtendedKey)) where
   textEnvelopeType (AsSigningKey AsAnyStakePoolKeyExtended) = textEnvelopeType (AsSigningKey AsStakePoolExtendedKey)
+
+unStakePoolAnyKeyHash
+  :: AnyStakePoolKeyWrapper Hash -> Shelley.KeyHash Shelley.StakePool StandardCrypto
+unStakePoolAnyKeyHash (StakePoolNormalKeyWrapper (StakePoolKeyNormalHash (StakePoolKeyHash spkh))) = spkh
+unStakePoolAnyKeyHash (StakePoolExtendedKeyWrapper (StakePoolKeyExtendedHash (StakePoolExtendedKeyHash spkh))) = spkh
 
 data StakePoolKey
 
@@ -1986,8 +2105,8 @@ instance SerialiseAsRawBytes (Hash StakePoolKey) where
       (StakePoolKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs)
 
 instance SerialiseAsBech32 (Hash StakePoolKey) where
-  bech32PrefixFor _ = "pool"
-  bech32PrefixesPermitted _ = ["pool"]
+  bech32PrefixFor _ = "pool_xvkh"
+  bech32PrefixesPermitted _ = ["pool_xvkh"]
 
 instance ToJSON (Hash StakePoolKey) where
   toJSON = toJSON . serialiseToBech32
@@ -2137,6 +2256,10 @@ instance SerialiseAsRawBytes (Hash StakePoolExtendedKey) where
       (SerialiseAsRawBytesError "Unable to deserialise Hash StakePoolExtendedKey")
       (StakePoolExtendedKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs)
 
+instance SerialiseAsBech32 (Hash StakePoolExtendedKey) where
+  bech32PrefixFor _ = "pool_x" -- FixMe: make sure this is right
+  bech32PrefixesPermitted _ = ["pool_x"]
+
 instance HasTextEnvelope (VerificationKey StakePoolExtendedKey) where
   textEnvelopeType _ = "StakePoolExtendedVerificationKey_ed25519_bip32"
 
@@ -2150,6 +2273,24 @@ instance SerialiseAsBech32 (VerificationKey StakePoolExtendedKey) where
 instance SerialiseAsBech32 (SigningKey StakePoolExtendedKey) where
   bech32PrefixFor _ = "pool_xsk"
   bech32PrefixesPermitted _ = ["pool_xsk"]
+
+instance ToJSON (Hash StakePoolExtendedKey) where
+  toJSON = toJSON . serialiseToBech32
+
+instance ToJSONKey (Hash StakePoolExtendedKey) where
+  toJSONKey = toJSONKeyText serialiseToBech32
+
+instance FromJSON (Hash StakePoolExtendedKey) where
+  parseJSON = withText "PoolId" $ \str ->
+    case deserialiseFromBech32 (AsHash AsStakePoolExtendedKey) str of
+      Left err ->
+        fail $
+          docToString $
+            mconcat
+              [ "Error deserialising Hash StakePoolKey: " <> pretty str
+              , " Error: " <> prettyError err
+              ]
+      Right h -> pure h
 
 instance CastVerificationKeyRole StakePoolExtendedKey StakePoolKey where
   castVerificationKey (StakePoolExtendedVerificationKey vk) =

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -41,6 +41,7 @@ module Cardano.Api.Internal.Keys.Shelley
   , SigningKey (..)
   , Hash (..)
   , AnyStakePoolKey (..)
+  , AnyStakePoolKeyWrapper (..)
   )
 where
 
@@ -1661,6 +1662,10 @@ instance CastSigningKeyRole GenesisUTxOKey PaymentKey where
 --
 -- stake pool keys
 --
+
+-- | Wrapper that handles both normal and extended StakePoolKeys and hides the type with an existential
+data AnyStakePoolKeyWrapper t
+  = forall stakePoolKeyType. AnyStakePoolKeyWrapper (t (AnyStakePoolKey stakePoolKeyType))
 
 --  | Wrapper that handles both normal and extended StakePoolKeys
 data AnyStakePoolKey stakePoolKeyType where

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Sign.hs
@@ -791,6 +791,7 @@ data ShelleyWitnessSigningKey
   | WitnessStakeKey (SigningKey StakeKey)
   | WitnessStakeExtendedKey (SigningKey StakeExtendedKey)
   | WitnessStakePoolKey (SigningKey StakePoolKey)
+  | WitnessStakePoolExtendedKey (SigningKey StakePoolExtendedKey)
   | WitnessGenesisKey (SigningKey GenesisKey)
   | WitnessGenesisExtendedKey (SigningKey GenesisExtendedKey)
   | WitnessGenesisDelegateKey (SigningKey GenesisDelegateKey)
@@ -1170,6 +1171,7 @@ toShelleySigningKey key = case key of
   -- The cases for extended keys
   WitnessPaymentExtendedKey (PaymentExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
   WitnessStakeExtendedKey (StakeExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
+  WitnessStakePoolExtendedKey (StakePoolExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
   WitnessGenesisExtendedKey (GenesisExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
   WitnessGenesisDelegateExtendedKey (GenesisDelegateExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk
   WitnessCommitteeColdExtendedKey (CommitteeColdExtendedSigningKey sk) -> ShelleyExtendedSigningKey sk

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -204,6 +204,7 @@ module Cardano.Api.Shelley
 
     -- ** Stake pool operator's keys
   , AnyStakePoolKey (..)
+  , AnyStakePoolKeyWrapper (..)
   , Hash (StakePoolKeyNormalHash, StakePoolKeyExtendedHash)
   , StakePoolExtendedKey
   , StakePoolKey

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -203,6 +203,8 @@ module Cardano.Api.Shelley
   , DRepMetadataReference (DRepMetadataReference)
 
     -- ** Stake pool operator's keys
+  , AnyStakePoolKey (..)
+  , Hash (StakePoolKeyNormalHash, StakePoolKeyExtendedHash)
   , StakePoolExtendedKey
   , StakePoolKey
   , PoolId

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -205,6 +205,10 @@ module Cardano.Api.Shelley
     -- ** Stake pool operator's keys
   , AnyStakePoolKey (..)
   , AnyStakePoolKeyWrapper (..)
+  , rewrapAnyStakePoolKey
+  , foldStakePoolKey
+  , liftStakePoolKey
+  , liftStakePoolKeyM
   , Hash (StakePoolKeyNormalHash, StakePoolKeyExtendedHash)
   , StakePoolExtendedKey
   , StakePoolKey


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for stake pool extended key
  type:
  - feature
```

# Context

Tries to address https://github.com/IntersectMBO/cardano-api/issues/668. Work in progress

# How to trust this PR

Don't trust it.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
