### PR TITLE
Release cardano-api-10.12.0.0

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog for cardano-api
 
+## 10.12.0.0
+
+- Bumped ledger and dependencies for node 10.3 release.
+  (breaking)
+  [PR 758](https://github.com/IntersectMBO/cardano-api/pull/758)
+    * Removed `queryProtocolParametersUpdate` and the use of parameterised crypto (`EraCrypto c`, this enables many other data types to become mono-morphic over `StandardCrypto`)
+    * Added `queryStakePoolDefaultVote` and `queryLedgerConfig`
+
+- New witness api
+  (feature, compatible, refactoring)
+  [PR 763](https://github.com/IntersectMBO/cardano-api/pull/763)
+
+- Fix inputSet to be parameterized on the era
+  (breaking, bugfix)
+  [PR 788](https://github.com/IntersectMBO/cardano-api/pull/788)
+
+- Remove the ProtocolParameters type, that has been deprecated for a while
+  (breaking)
+  [PR 729](https://github.com/IntersectMBO/cardano-api/pull/729)
+
 ## 10.11.1.0
 
 - Add missing `CastVerificationKeyRole StakePoolExtendedKey StakePoolKey` instance

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cardano-api
-version: 10.11.1.0
+version: 10.12.0.0
 synopsis: The cardano API
 description: The cardano API.
 category:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-api-10.12.0.0
  type:
  - release
```

# Context

This is a redundant PR of release 10.12.0.0. The original is this but is broken: https://github.com/IntersectMBO/cardano-api/pull/791

# How to trust this PR

Same content as: https://github.com/IntersectMBO/cardano-api/pull/791

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
