### PR TITLE
Remove unused newtypes: `GovernanceActionId` and `Voter`

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Governance/Actions/VotingProcedure.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Governance/Actions/VotingProcedure.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -12,8 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Api.Internal.Governance.Actions.VotingProcedure where
 
@@ -35,40 +32,7 @@ import Data.Map qualified as Map
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
-import Data.Typeable
 import GHC.Generics
-
-newtype GovernanceActionId era = GovernanceActionId
-  { unGovernanceActionId :: Ledger.GovActionId
-  }
-  deriving (Show, Eq, Ord)
-
-instance IsShelleyBasedEra era => ToCBOR (GovernanceActionId era) where
-  toCBOR = \case
-    GovernanceActionId v ->
-      shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(ShelleyLedgerEra era) v
-
-instance IsShelleyBasedEra era => FromCBOR (GovernanceActionId era) where
-  fromCBOR = do
-    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(ShelleyLedgerEra era)
-    return $ GovernanceActionId v
-
-data Voter era where
-  Voter :: Typeable era => Ledger.Voter -> Voter era
-
-deriving instance Show (Voter era)
-
-deriving instance Eq (Voter era)
-
-deriving instance Ord (Voter era)
-
-instance IsShelleyBasedEra era => ToCBOR (Voter era) where
-  toCBOR (Voter v) = shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.toEraCBOR @(ShelleyLedgerEra era) v
-
-instance IsShelleyBasedEra era => FromCBOR (Voter era) where
-  fromCBOR = do
-    !v <- shelleyBasedEraConstraints (shelleyBasedEra @era) $ Ledger.fromEraCBOR @(ShelleyLedgerEra era)
-    pure $ Voter v
 
 data Vote
   = No

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -4017,18 +4017,18 @@ extractWitnessableVotes
 extractWitnessableVotes e@ConwayEraOnwardsConway TxBodyContent{txVotingProcedures} =
   List.nub
     [ (WitVote vote, BuildTxWith wit)
-    | (Voter vote, wit) <- getVotes e $ maybe TxVotingProceduresNone unFeatured txVotingProcedures
+    | (vote, wit) <- getVotes e $ maybe TxVotingProceduresNone unFeatured txVotingProcedures
     ]
  where
   getVotes
     :: ConwayEraOnwards era
     -> TxVotingProcedures BuildTx era
-    -> [(Voter era, Witness WitCtxStake era)]
+    -> [(L.Voter, Witness WitCtxStake era)]
   getVotes ConwayEraOnwardsConway TxVotingProceduresNone = []
   getVotes ConwayEraOnwardsConway (TxVotingProcedures allVotingProcedures (BuildTxWith scriptWitnessedVotes)) =
-    [ (Voter singleVoter, wit)
-    | (singleVoter, _) <- toList $ L.unVotingProcedures allVotingProcedures
-    , let wit = case Map.lookup singleVoter scriptWitnessedVotes of
+    [ (voter, wit)
+    | (voter, _) <- toList $ L.unVotingProcedures allVotingProcedures
+    , let wit = case Map.lookup voter scriptWitnessedVotes of
             Just sWit -> ScriptWitness ScriptWitnessForStakeAddr sWit
             Nothing -> KeyWitness KeyWitnessForStakeAddr
     ]

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -251,7 +251,6 @@ module Cardano.Api.Shelley
 
     -- ** Governance
   , GovernanceAction (..)
-  , GovernanceActionId (..)
   , Proposal (..)
   , VotingProcedure (..)
   , VotingProcedures (..)
@@ -259,7 +258,6 @@ module Cardano.Api.Shelley
   , GovernancePollAnswer (..)
   , GovernancePollError (..)
   , Vote (..)
-  , Voter (..)
   , createProposalProcedure
   , createVotingProcedure
   , renderGovernancePollError


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove unused ledger types' wrappers: `GovernanceActionId` and `Voter`. Use `GovActionId` and `Voter` from ledger instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Those types were not really used, `L.GovActionId` and `L.Voter` are more frequently used, so there's no point in keeping them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
