### PR TITLE
Remove `createPreviousGovernanceActionId`. Use `GovPurposeId` directly instead.

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Governance/Actions/ProposalProcedure.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Governance/Actions/ProposalProcedure.hs
@@ -220,14 +220,6 @@ fromProposalProcedure sbe (Proposal pp) =
     , fromGovernanceAction (Gov.pProcGovAction pp)
     )
 
-createPreviousGovernanceActionId
-  :: TxId
-  -> Word16
-  -- ^ Governance action transation index
-  -> Ledger.GovPurposeId (r :: Ledger.GovActionPurpose) (ShelleyLedgerEra era)
-createPreviousGovernanceActionId txid index =
-  Ledger.GovPurposeId $ createGovernanceActionId txid index
-
 createGovernanceActionId :: TxId -> Word16 -> Gov.GovActionId
 createGovernanceActionId txid index =
   Ledger.GovActionId

--- a/cardano-api/src/Cardano/Api/Internal/ReexposeLedger.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ReexposeLedger.hs
@@ -83,6 +83,7 @@ module Cardano.Api.Internal.ReexposeLedger
   , GovActionId (..)
   , GovActionIx (..)
   , GovActionState (..)
+  , GovPurposeId (..)
   , Vote (..)
   , Voter (..)
   , VotingProcedure (..)
@@ -210,7 +211,7 @@ import Cardano.Ledger.Alonzo.Scripts
   , plutusScriptLanguage
   )
 import Cardano.Ledger.Alonzo.TxWits (TxDats (..))
-import Cardano.Ledger.Api (Constitution (..), GovAction (..), unRedeemers)
+import Cardano.Ledger.Api (Constitution (..), GovAction (..), GovPurposeId (..), unRedeemers)
 import Cardano.Ledger.Api.Tx.Cert
   ( pattern AuthCommitteeHotKeyTxCert
   , pattern DelegStakeTxCert

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -192,7 +192,6 @@ module Cardano.Api.Shelley
 
     -- * Governance Actions
   , createAnchor
-  , createPreviousGovernanceActionId
   , createGovernanceActionId
 
     -- * DRep


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removed `createPreviousGovernanceActionId`. Use `GovPurposeId . createGovernanceActionId` instead.
    Export `GovPurposeId` through `Cardano.Api.Ledger`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Because the `L.GovPurposeId` no longer requires constraint `EraCrypto (ShelleyLedgerEra era) ~ StandardCrypto` it's easier to use the constructor directly, without extra type hints for compiler.

Changes in cardano-cli implemented in:
- https://github.com/IntersectMBO/cardano-cli/pull/1119

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
