### PR TITLE
Bug fix - redeemer pointer map construction

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -332,6 +332,7 @@ test-suite cardano-api-test
     cardano-ledger-alonzo,
     cardano-ledger-api >=1.9,
     cardano-ledger-binary,
+    cardano-ledger-conway,
     cardano-ledger-core:{cardano-ledger-core, testlib} >=1.14,
     cardano-ledger-mary,
     cardano-protocol-tpraos,
@@ -377,6 +378,7 @@ test-suite cardano-api-test
     Test.Cardano.Api.Orphans
     Test.Cardano.Api.RawBytes
     Test.Cardano.Api.Transaction.Autobalance
+    Test.Cardano.Api.Transaction.Body.Plutus.Scripts
     Test.Cardano.Api.TxBody
     Test.Cardano.Api.Value
 

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -34,9 +34,35 @@ module Cardano.Api.Experimental
   , babbageEraOnwardsToEra
   , eraToBabbageEraOnwards
   , sbeToEra
+
+    -- ** Witness related
+  , AnyWitness (..)
+  , PlutusScriptWitness (..)
+  , Witnessable (..)
+  , WitnessableItem (..)
+
+    -- ** Plutus related
+  , PlutusScriptInEra (..)
+  , PlutusScriptOrReferenceInput (..)
+  , IndexedPlutusScriptWitness (..)
+  , PlutusScriptPurpose (..)
+  , PlutusScriptDatum (..)
+  , NoScriptDatum (..)
+
+    -- ** Internal
+  , getAnyWitnessRedeemerPointerMap
+  , toPlutusScriptPurpose
+
+    -- ** Legacy
+  , toPlutusSLanguage
   )
 where
 
 import Cardano.Api.Internal.Experimental.Eras
+import Cardano.Api.Internal.Experimental.Plutus.IndexedPlutusScriptWitness
+import Cardano.Api.Internal.Experimental.Plutus.Script
+import Cardano.Api.Internal.Experimental.Plutus.ScriptWitness
+import Cardano.Api.Internal.Experimental.Plutus.Shim.LegacyScripts
 import Cardano.Api.Internal.Experimental.Tx
+import Cardano.Api.Internal.Experimental.Witness.AnyWitness
 import Cardano.Api.Internal.Fees (evaluateTransactionExecutionUnitsShelley)

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/ScriptWitness.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/ScriptWitness.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -64,6 +65,8 @@ data PlutusScriptWitness (lang :: L.Language) (purpose :: PlutusScriptPurpose) e
     -> ScriptRedeemer
     -> ExecutionUnits
     -> PlutusScriptWitness lang purpose era
+
+deriving instance Show (PlutusScriptWitness lang purpose era)
 
 getPlutusScriptWitnessLanguage :: PlutusScriptWitness lang purpose era -> L.Language
 getPlutusScriptWitnessLanguage (PlutusScriptWitness l _ _ _ _) =

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
@@ -12,6 +12,7 @@
 
 module Cardano.Api.Internal.Experimental.Plutus.Shim.LegacyScripts
   ( legacyWitnessToScriptRequirements
+  , toPlutusSLanguage
   )
 where
 

--- a/cardano-api/src/Cardano/Api/Internal/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ScriptData.hs
@@ -98,7 +98,7 @@ data HashableScriptData
       !BS.ByteString
       -- ^ Original 'ScriptData' bytes
       !ScriptData
-  deriving (Eq, Show)
+  deriving (Eq, Show, Ord)
 
 instance HasTypeProxy HashableScriptData where
   data AsType HashableScriptData = AsHashableScriptData

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Body/Plutus/Scripts.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Body/Plutus/Scripts.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Api.Transaction.Body.Plutus.Scripts
+  ( tests
+  )
+where
+
+import Cardano.Api (AlonzoEraOnwards (..))
+import Cardano.Api.Experimental
+import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Shelley (fromAlonzoData)
+
+import Cardano.Ledger.Alonzo.TxWits qualified as L
+import Cardano.Ledger.Conway qualified as L
+
+import Prelude
+
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+
+import Test.Gen.Cardano.Api.Typed (genIndexedPlutusScriptWitness, genWitnessable)
+
+import Test.Cardano.Api.Orphans ()
+
+import Hedgehog
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+-- | This property checks that the redeemer pointer map is constructed correctly.
+-- Previously identical script purposes were being created and overwriting each other
+-- in the redeemer pointer map.
+prop_getAnyWitnessRedeemerPointerMap :: Property
+prop_getAnyWitnessRedeemerPointerMap = property $ do
+  let eon = AlonzoEraOnwardsConway
+  l <- forAll $ Gen.int (Range.linear 2 5)
+  witnessables <- forAll $ Gen.list (Range.singleton l) $ genWitnessable @L.ConwayEra
+  wits <-
+    forAll $
+      Gen.list (Range.singleton l) $
+        genIndexedPlutusScriptWitness @ConwayEra
+  let anyWits =
+        [ AnyPlutusScriptWitness swit
+        | IndexedPlutusScriptWitness _ _ swit <- wits
+        ]
+
+      zipped = zip witnessables anyWits
+      expectedRedeemerPointerMapLength = length zipped
+      finalWits = take expectedRedeemerPointerMapLength wits
+
+      L.Redeemers constructedRedeemerPointerMap = getAnyWitnessRedeemerPointerMap eon zipped
+
+  annotate "Constructed redeemer pointer map"
+  annotateShow constructedRedeemerPointerMap
+  let redeemerPointerMapSize = Map.size constructedRedeemerPointerMap
+
+  cover 30 "Redeemer pointer map size more than 1" $ redeemerPointerMapSize > 1
+
+  -- Confirm we have the expected number of redeemers
+  Map.size constructedRedeemerPointerMap === expectedRedeemerPointerMapLength
+
+  let initialRedeemers =
+        [ redeemer
+        | IndexedPlutusScriptWitness _ _ swit <- finalWits
+        , let PlutusScriptWitness _ _ _ redeemer _ = swit
+        ]
+
+      ledgerRedeemers :: [L.Data L.ConwayEra]
+      ledgerRedeemers = map fst $ Map.elems constructedRedeemerPointerMap
+
+      convertedRedeemers = map fromAlonzoData ledgerRedeemers
+
+  annotate "Initial Indexed Script Witnesses"
+  annotateShow wits
+
+  -- Confirm we have idential redeemers
+  List.sort initialRedeemers === List.sort convertedRedeemers
+
+tests :: TestTree
+tests =
+  testGroup
+    "Test.Cardano.Api.Transaction.Body.Plutus.Scripts"
+    [ testProperty "prop_getAnyWitnessRedeemerPointerMap" prop_getAnyWitnessRedeemerPointerMap
+    ]

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -24,6 +24,7 @@ import Test.Cardano.Api.Metadata qualified
 import Test.Cardano.Api.Ord qualified
 import Test.Cardano.Api.RawBytes qualified
 import Test.Cardano.Api.Transaction.Autobalance qualified
+import Test.Cardano.Api.Transaction.Body.Plutus.Scripts qualified
 import Test.Cardano.Api.TxBody qualified
 import Test.Cardano.Api.Value qualified
 
@@ -59,6 +60,7 @@ tests =
     , Test.Cardano.Api.Metadata.tests
     , Test.Cardano.Api.Ord.tests
     , Test.Cardano.Api.RawBytes.tests
+    , Test.Cardano.Api.Transaction.Body.Plutus.Scripts.tests
     , Test.Cardano.Api.Transaction.Autobalance.tests
     , Test.Cardano.Api.TxBody.tests
     , Test.Cardano.Api.Value.tests


### PR DESCRIPTION
Fixes #798

# Changelog

```yaml
- description: |
    Fix bug in the construction of the redeemer pointer map. We were not correctly assigning the indexes and this resulted in keys being overwritten in the redeemer pointer map
# uncomment types applicable to the change:
  type:
  - breaking       # the API has changed in a breaking way
  - bugfix         # fixes a defect
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
