### PR TITLE
Fix `toAnyWitness` to not ignore simple scripts

### DIFF
--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -47,6 +47,7 @@ module Test.Gen.Cardano.Api.Typed
   , genScript
   , genValidScript
   , genSimpleScript
+  , genSimpleScriptMintWitness
   , genPlutusScript
   , genPlutusV1Script
   , genPlutusV2Script
@@ -135,6 +136,7 @@ module Test.Gen.Cardano.Api.Typed
   , genVotingProcedures
   , genSimpleScriptWithoutEmptyAnys
   , genWitnessable
+  , genMintWitnessable
   , genPlutusScriptWitness
   , genIndexedPlutusScriptWitness
   )
@@ -248,6 +250,9 @@ genSimpleScriptWithoutEmptyAnys = genRandomSimpleScript False
 
 genSimpleScript :: Gen SimpleScript
 genSimpleScript = genRandomSimpleScript True
+
+genSimpleScriptMintWitness :: ShelleyBasedEra era -> Gen (Witness WitCtxMint era)
+genSimpleScriptMintWitness sbe = ScriptWitness ScriptWitnessForMinting <$> genScriptWitnessForMint sbe
 
 -- | We include a @hasEmptyAnys@ parameter to control whether we allow empty
 -- 'RequireAnyOf' constructors. This is because an empty 'RequireAnyOf',
@@ -1371,6 +1376,9 @@ genTreasuryDonation _era = Q.arbitrary
 
 genWitnessable :: L.AlonzoEraScript era => Gen (Exp.Witnessable Exp.TxInItem era)
 genWitnessable = Exp.WitTxIn <$> genTxIn  
+
+genMintWitnessable :: L.AlonzoEraScript era => Gen (Exp.Witnessable Exp.MintItem era)
+genMintWitnessable = Exp.WitMint <$> genPolicyId <*> genPolicyAssets 
 
 genIndexedPlutusScriptWitness 
   :: L.AlonzoEraScript (ShelleyLedgerEra era) 

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -38,8 +38,13 @@ module Cardano.Api.Experimental
     -- ** Witness related
   , AnyWitness (..)
   , PlutusScriptWitness (..)
+  , TxScriptWitnessRequirements (..)
   , Witnessable (..)
   , WitnessableItem (..)
+
+    -- ** Simple script related
+  , SimpleScript (..)
+  , SimpleScriptOrReferenceInput (..)
 
     -- ** Plutus related
   , PlutusScriptInEra (..)
@@ -54,6 +59,7 @@ module Cardano.Api.Experimental
   , toPlutusScriptPurpose
 
     -- ** Legacy
+  , legacyWitnessConversion
   , toPlutusSLanguage
   )
 where
@@ -63,6 +69,8 @@ import Cardano.Api.Internal.Experimental.Plutus.IndexedPlutusScriptWitness
 import Cardano.Api.Internal.Experimental.Plutus.Script
 import Cardano.Api.Internal.Experimental.Plutus.ScriptWitness
 import Cardano.Api.Internal.Experimental.Plutus.Shim.LegacyScripts
+import Cardano.Api.Internal.Experimental.Simple.Script
 import Cardano.Api.Internal.Experimental.Tx
 import Cardano.Api.Internal.Experimental.Witness.AnyWitness
+import Cardano.Api.Internal.Experimental.Witness.TxScriptWitnessRequirements
 import Cardano.Api.Internal.Fees (evaluateTransactionExecutionUnitsShelley)

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
@@ -12,6 +12,7 @@
 
 module Cardano.Api.Internal.Experimental.Plutus.Shim.LegacyScripts
   ( legacyWitnessToScriptRequirements
+  , legacyWitnessConversion
   , toPlutusSLanguage
   )
 where

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
@@ -195,7 +195,7 @@ legacyWitnessToScriptRequirements eon wits = do
 -- Misc helpers
 
 getVersion :: forall era. AlonzoEraOnwards era -> Version
-getVersion eon = alonzoEraOnwardsConstraints eon $ L.eraProtVerLow @(ShelleyLedgerEra era)
+getVersion eon = alonzoEraOnwardsConstraints eon $ L.eraProtVerHigh @(ShelleyLedgerEra era)
 
 obtainConstraints
   :: Old.PlutusScriptVersion lang

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Plutus/Shim/LegacyScripts.hs
@@ -54,10 +54,10 @@ toAnyWitness
        (Witnessable thing (ShelleyLedgerEra era), AnyWitness (ShelleyLedgerEra era))
 toAnyWitness _ (witnessable, BuildTxWith (Old.KeyWitness _)) =
   return (witnessable, AnyKeyWitnessPlaceholder)
-toAnyWitness _ (witnessable, BuildTxWith (Old.ScriptWitness _ Old.SimpleScriptWitness{})) =
-  return (witnessable, AnyKeyWitnessPlaceholder)
+toAnyWitness eon (witnessable, BuildTxWith (Old.ScriptWitness _ oldSw@Old.SimpleScriptWitness{})) =
+  convertToNewScriptWitness eon oldSw witnessable
 toAnyWitness eon (witnessable, BuildTxWith (Old.ScriptWitness _ oldApiPlutusScriptWitness)) =
-  convertToNewPlutusScriptWitness eon oldApiPlutusScriptWitness witnessable
+  convertToNewScriptWitness eon oldApiPlutusScriptWitness witnessable
 
 type family ToPlutusScriptPurpose witnessable = (purpose :: PlutusScriptPurpose) | purpose -> witnessable where
   ToPlutusScriptPurpose TxInItem = SpendingScript
@@ -67,14 +67,14 @@ type family ToPlutusScriptPurpose witnessable = (purpose :: PlutusScriptPurpose)
   ToPlutusScriptPurpose VoterItem = ProposingScript
   ToPlutusScriptPurpose ProposalItem = VotingScript
 
-convertToNewPlutusScriptWitness
+convertToNewScriptWitness
   :: AlonzoEraOnwards era
   -> Old.ScriptWitness witctx era
   -> Witnessable thing (ShelleyLedgerEra era)
   -> Either
        CBOR.DecoderError
        (Witnessable thing (ShelleyLedgerEra era), AnyWitness (ShelleyLedgerEra era))
-convertToNewPlutusScriptWitness eon (Old.PlutusScriptWitness _ v scriptOrRefInput datum scriptRedeemer execUnits) witnessable = do
+convertToNewScriptWitness eon (Old.PlutusScriptWitness _ v scriptOrRefInput datum scriptRedeemer execUnits) witnessable = do
   let d = createPlutusScriptDatum witnessable v datum
   newScriptWitness <-
     obtainConstraints v $
@@ -86,9 +86,9 @@ convertToNewPlutusScriptWitness eon (Old.PlutusScriptWitness _ v scriptOrRefInpu
         execUnits
         d
   return (witnessable, newScriptWitness)
-convertToNewPlutusScriptWitness eon (Old.SimpleScriptWitness _ scriptOrRefInput) witnessable =
+convertToNewScriptWitness eon (Old.SimpleScriptWitness _ scriptOrRefInput) witnessable =
   case scriptOrRefInput of
-    Old.SScript simpleScript -> do
+    Old.SScript simpleScript -> alonzoEraOnwardsConstraints eon $ do
       let timelock = convertTotimelock eon simpleScript
       return (witnessable, AnySimpleScriptWitness $ SScript $ SimpleScript timelock)
     Old.SReferenceScript txIn ->

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Simple/Script.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Simple/Script.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.Api.Internal.Experimental.Simple.Script
   ( SimpleScript (..)
@@ -13,8 +14,11 @@ import Cardano.Ledger.Core qualified as Ledger
 -- | A simple script in a particular era. We leverage ledger's Cardano.Api.Experimental.ErasraScript
 -- type class methods to work with the script.
 data SimpleScript era where
-  SimpleScript :: Ledger.NativeScript era -> SimpleScript era
+  SimpleScript :: Ledger.EraScript era => Ledger.NativeScript era -> SimpleScript era
+
+deriving instance Show (SimpleScript era)
 
 data SimpleScriptOrReferenceInput era
   = SScript (SimpleScript era)
   | SReferenceScript TxIn
+  deriving Show

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Witness/TxScriptWitnessRequirements.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Witness/TxScriptWitnessRequirements.hs
@@ -13,6 +13,7 @@ module Cardano.Api.Internal.Experimental.Witness.TxScriptWitnessRequirements
 
     -- * For testing only
   , extractExecutionUnits
+  , getTxScriptWitnessRequirements
   )
 where
 

--- a/cardano-api/src/Cardano/Api/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Shelley.hs
@@ -284,6 +284,7 @@ module Cardano.Api.Shelley
   , mergeVotingProcedures
   , singletonVotingProcedures
   , extractExecutionUnits
+  , getTxScriptWitnessRequirements
   , VotesMergingConflict (..)
   )
 where


### PR DESCRIPTION
# Changelog
Resolves: [#1126](https://github.com/IntersectMBO/cardano-cli/issues/1126)
```yaml
- description: |
    Fix `toAnyWitness` to not ignore simple scripts
  type:
  - compatible    
  - bugfix         
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
