### PR TITLE
New eon constraints

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/AllegraEraOnwards.hs
@@ -98,6 +98,7 @@ type AllegraEraOnwardsConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/AlonzoEraOnwards.hs
@@ -112,6 +112,7 @@ type AlonzoEraOnwardsConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/BabbageEraOnwards.hs
@@ -116,6 +116,7 @@ type BabbageEraOnwardsConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ConwayEraOnwards.hs
@@ -119,6 +119,7 @@ type ConwayEraOnwardsConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/MaryEraOnwards.hs
@@ -100,6 +100,7 @@ type MaryEraOnwardsConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
@@ -224,6 +224,7 @@ type ShelleyBasedEraConstraints era =
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (L.PredicateFailure (L.EraRule "LEDGER" (ShelleyLedgerEra era)))
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
@@ -211,6 +211,9 @@ type ShelleyBasedEraConstraints era =
   , Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
   , Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era) ~ ConsensusBlockForEra era
   , Consensus.ShelleyCompatible (ConsensusProtocol era) (ShelleyLedgerEra era)
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , IsCardanoEra era
+  , IsShelleyBasedEra era
   , L.ADDRHASH ~ Blake2b.Blake2b_224
   , L.Era (ShelleyLedgerEra era)
   , L.EraPParams (ShelleyLedgerEra era)

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyEraOnly.hs
@@ -94,6 +94,7 @@ type ShelleyEraOnlyConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAllegraEra.hs
@@ -97,6 +97,7 @@ type ShelleyToAllegraEraConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAlonzoEra.hs
@@ -98,6 +98,7 @@ type ShelleyToAlonzoEraConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToBabbageEra.hs
@@ -102,6 +102,7 @@ type ShelleyToBabbageEraConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToMaryEra.hs
@@ -97,6 +97,7 @@ type ShelleyToMaryEraConstraints era =
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
   , IsShelleyBasedEra era
+  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
   )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `ToJSON (Consensus.ChainDepState (ConsensusProtocol era))` constraints for shelley based eons.
    New constraints for `ShelleyBasedEra`:
    * FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
    * IsCardanoEra era
    * IsShelleyBasedEra era
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# How to trust this PR

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
