### PR TITLE
Allow providing of actual datum for reference inputs

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Tx/BuildTxWith.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/BuildTxWith.hs
@@ -40,6 +40,13 @@ instance Applicative (BuildTxWith BuildTx) where
   pure = BuildTxWith
   (BuildTxWith f) <*> (BuildTxWith a) = BuildTxWith (f a)
 
+instance Semigroup a => Semigroup (BuildTxWith build a) where
+  ViewTx <> ViewTx = ViewTx
+  (BuildTxWith a) <> (BuildTxWith b) = BuildTxWith (a <> b)
+
+instance (Applicative (BuildTxWith build), Monoid a) => Monoid (BuildTxWith build a) where
+  mempty = pure mempty
+
 buildTxWithToMaybe :: BuildTxWith build a -> Maybe a
 buildTxWithToMaybe ViewTx = Nothing
 buildTxWithToMaybe (BuildTxWith a) = Just a

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Output.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Output.hs
@@ -14,30 +14,43 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.Api.Internal.Tx.Output
-  ( -- ** Transaction outputs
-    CtxTx
+  ( -- * Transaction outputs
+    TxOut (..)
+
+    -- ** Transaction output contexts
+  , CtxTx
   , CtxUTxO
-  , TxOut (..)
-  , TxOutValue (..)
-  , TxOutDatum (TxOutDatumNone, TxOutDatumHash, TxOutSupplementalDatum, TxOutDatumInline)
   , toCtxUTxOTxOut
   , fromCtxUTxOTxOut
-  , lovelaceToTxOutValue
-  , prettyRenderTxOut
-  , txOutValueToLovelace
-  , txOutValueToValue
-  , parseHash
-  , TxOutInAnyEra (..)
-  , txOutInAnyEra
+
+    -- ** Ledger conversion functions for outputs
   , fromShelleyTxOut
   , toShelleyTxOut
   , toShelleyTxOutAny
   , convTxOuts
   , fromLedgerTxOuts
   , toByronTxOut
+  --  ** An Output Value
+  , TxOutValue (..)
+  , lovelaceToTxOutValue
+  , txOutValueToLovelace
+  , txOutValueToValue
+
+    -- ** Datum
+  , TxOutDatum (..)
   , binaryDataToScriptData
   , scriptDataToInlineDatum
+
+    -- ** Existential type over an era
+  , TxOutInAnyEra (..)
+  , txOutInAnyEra
+
+    -- ** Utilities
   , validateTxOuts
+  , parseHash
+  , prettyRenderTxOut
+
+    -- ** Error types
   , TxOutputError (..)
   )
 where
@@ -959,8 +972,6 @@ data TxOutDatum ctx era where
 deriving instance Eq (TxOutDatum ctx era)
 
 deriving instance Show (TxOutDatum ctx era)
-
-{-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutSupplementalDatum, TxOutDatumInline #-}
 
 toAlonzoTxOutDatumHash
   :: TxOutDatum ctx era -> StrictMaybe Plutus.DataHash

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -61,16 +61,18 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
   let era = Exp.ConwayEra
   let sbe = Api.convert era
 
-  signedTxTraditional <- exampleTransacitonTraditionalWay sbe
+  signedTxTraditional <- exampleTransactionTraditionalWay sbe
   signedTxExperimental <- exampleTransactionExperimentalWay era sbe
 
   let oldStyleTx :: Api.Tx Api.ConwayEra = ShelleyTx sbe signedTxExperimental
 
   oldStyleTx H.=== signedTxTraditional
  where
-  exampleTransacitonTraditionalWay
-    :: H.MonadTest m => Api.ShelleyBasedEra Exp.ConwayEra -> m (Tx Exp.ConwayEra)
-  exampleTransacitonTraditionalWay sbe = do
+  exampleTransactionTraditionalWay
+    :: H.MonadTest m
+    => Api.ShelleyBasedEra Exp.ConwayEra
+    -> m (Tx Exp.ConwayEra)
+  exampleTransactionTraditionalWay sbe = do
     txBodyContent <- exampleTxBodyContent Api.AsConwayEra sbe
     signingKey <- exampleSigningKey
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Allow providing of actual datum for reference inputs in `TxInsReference`.
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR adds a method of adding actual datum for the datum hashes present in reference inputs.

Tested in: 
- https://github.com/IntersectMBO/cardano-node/pull/6174

Integrated in CLI:
- https://github.com/IntersectMBO/cardano-cli/pull/1169

Closes https://github.com/IntersectMBO/cardano-api/issues/803

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
