### PR TITLE
Improve autobalancing errors when change has no lovelace

### DIFF
--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Orphans.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Orphans.hs
@@ -1,12 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Api.Orphans () where
 
 import Cardano.Api.Shelley
+
+import Cardano.Ledger.Mary.Value qualified as L
+
+import Data.String (IsString (..))
 
 import Test.Cardano.Crypto.Orphans ()
 
@@ -29,3 +34,5 @@ deriving instance Eq (SigningKey GenesisUTxOKey)
 deriving instance Eq (SigningKey KesKey)
 
 deriving instance Eq (SigningKey VrfKey)
+
+deriving instance IsString L.AssetName


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Improve autobalancing errors when change has no lovelace
    `checkMinUTxOValue` has its arguments flipped.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Previously for txout with 0 lovelace and some non-ada assets the returned error was about negative balance, which doesn't make sense.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
