### PR TITLE
Medium QoL changes

### DIFF
--- a/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
+++ b/cardano-api/gen/Test/Hedgehog/Roundtrip/Bech32.hs
@@ -10,8 +10,8 @@ import Hedgehog qualified as H
 
 roundtrip_Bech32
   :: (SerialiseAsBech32 a, Eq a, Show a)
-  => AsType a -> Gen a -> Property
-roundtrip_Bech32 typeProxy gen =
+  => Gen a -> Property
+roundtrip_Bech32 gen =
   H.property $ do
     val <- H.forAll gen
-    H.tripping val serialiseToBech32 (deserialiseFromBech32 typeProxy)
+    H.tripping val serialiseToBech32 deserialiseFromBech32

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -160,6 +160,7 @@ module Cardano.Api
     -- * Type tags
   , HasTypeProxy (..)
   , AsType (..)
+  , asType
 
     -- * Cryptographic key interface
     -- $keys

--- a/cardano-api/src/Cardano/Api/Internal/Address.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Address.hs
@@ -270,7 +270,7 @@ instance SerialiseAddress (Address ShelleyAddr) where
 
   deserialiseAddress (AsAddress AsShelleyAddr) t =
     either (const Nothing) Just $
-      deserialiseFromBech32 (AsAddress AsShelleyAddr) t
+      deserialiseFromBech32 t
 
 instance ToJSON (Address ShelleyAddr) where
   toJSON = Aeson.String . serialiseAddress
@@ -590,7 +590,7 @@ instance SerialiseAddress StakeAddress where
 
   deserialiseAddress AsStakeAddress t =
     either (const Nothing) Just $
-      deserialiseFromBech32 AsStakeAddress t
+      deserialiseFromBech32 t
 
 instance ToJSON StakeAddress where
   toJSON s = Aeson.String $ serialiseAddress s

--- a/cardano-api/src/Cardano/Api/Internal/Address.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Address.hs
@@ -384,10 +384,10 @@ instance IsShelleyBasedEra era => FromJSON (AddressInEra era) where
           addressAny <- runParsecParser parseAddressAny txt
           pure $ anyAddressInShelleyBasedEra sbe addressAny
 
-parseAddressAny :: Parsec.Parser AddressAny
+parseAddressAny :: SerialiseAddress addr => Parsec.Parser addr
 parseAddressAny = do
   str <- lexPlausibleAddressString
-  case deserialiseAddress AsAddressAny str of
+  case deserialiseAddress asType str of
     Nothing -> fail $ "invalid address: " <> Text.unpack str
     Just addr -> pure addr
 

--- a/cardano-api/src/Cardano/Api/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/AllegraEraOnwards.hs
@@ -37,6 +37,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data AllegraEraOnwards era where
@@ -101,6 +102,7 @@ type AllegraEraOnwardsConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 allegraEraOnwardsConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/AlonzoEraOnwards.hs
@@ -46,6 +46,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data AlonzoEraOnwards era where
@@ -115,6 +116,7 @@ type AlonzoEraOnwardsConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 alonzoEraOnwardsConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/BabbageEraOnwards.hs
@@ -45,6 +45,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data BabbageEraOnwards era where
@@ -119,6 +120,7 @@ type BabbageEraOnwardsConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 babbageEraOnwardsConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/Convert.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/Convert.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
@@ -14,3 +15,6 @@ import Data.Kind (Type)
 -- relationship between types.
 class Convert (f :: a -> Type) (g :: a -> Type) where
   convert :: forall era. f era -> g era
+
+instance Convert a a where
+  convert = id

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ConwayEraOnwards.hs
@@ -46,6 +46,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ConwayEraOnwards era where
@@ -122,6 +123,7 @@ type ConwayEraOnwardsConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 conwayEraOnwardsConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/MaryEraOnwards.hs
@@ -40,6 +40,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data MaryEraOnwards era where
@@ -103,6 +104,7 @@ type MaryEraOnwardsConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 maryEraOnwardsConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyBasedEra.hs
@@ -59,7 +59,7 @@ import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 import Control.DeepSeq
 import Data.Aeson (FromJSON (..), ToJSON, toJSON, withText)
 import Data.Text qualified as Text
-import Data.Type.Equality (TestEquality (..), (:~:) (Refl))
+import Data.Type.Equality (TestEquality (..), (:~:) (Refl), type (==))
 import Data.Typeable (Typeable)
 import Text.Pretty (Pretty (..))
 
@@ -230,6 +230,7 @@ type ShelleyBasedEraConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (L.PredicateFailure (L.EraRule "LEDGER" (ShelleyLedgerEra era)))
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyBasedEraConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyEraOnly.hs
@@ -38,6 +38,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ShelleyEraOnly era where
@@ -97,6 +98,7 @@ type ShelleyEraOnlyConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyEraOnlyConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAllegraEra.hs
@@ -39,6 +39,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ShelleyToAllegraEra era where
@@ -100,6 +101,7 @@ type ShelleyToAllegraEraConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyToAllegraEraConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAlonzoEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToAlonzoEra.hs
@@ -37,6 +37,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ShelleyToAlonzoEra era where
@@ -101,6 +102,7 @@ type ShelleyToAlonzoEraConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyToAlonzoEraConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToBabbageEra.hs
@@ -37,6 +37,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ShelleyToBabbageEra era where
@@ -105,6 +106,7 @@ type ShelleyToBabbageEraConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyToBabbageEraConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eon/ShelleyToMaryEra.hs
@@ -38,6 +38,7 @@ import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger qualified as Consensus
 
 import Data.Aeson
+import Data.Type.Equality
 import Data.Typeable (Typeable)
 
 data ShelleyToMaryEra era where
@@ -100,6 +101,7 @@ type ShelleyToMaryEraConstraints era =
   , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
   , ToJSON (DebugLedgerState era)
   , Typeable era
+  , (era == ByronEra) ~ False
   )
 
 shelleyToMaryEraConstraints

--- a/cardano-api/src/Cardano/Api/Internal/Eras/Case.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Eras/Case.hs
@@ -150,6 +150,7 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway -> r ConwayEraOnwardsConway
 
+{-# DEPRECATED shelleyToAlonzoEraToShelleyToBabbageEra "Use convert instead" #-}
 shelleyToAlonzoEraToShelleyToBabbageEra
   :: ()
   => ShelleyToAlonzoEra era
@@ -160,6 +161,7 @@ shelleyToAlonzoEraToShelleyToBabbageEra = \case
   ShelleyToAlonzoEraMary -> ShelleyToBabbageEraMary
   ShelleyToAlonzoEraAlonzo -> ShelleyToBabbageEraAlonzo
 
+{-# DEPRECATED alonzoEraOnwardsToMaryEraOnwards "Use convert instead" #-}
 alonzoEraOnwardsToMaryEraOnwards
   :: ()
   => AlonzoEraOnwards era
@@ -169,6 +171,7 @@ alonzoEraOnwardsToMaryEraOnwards = \case
   AlonzoEraOnwardsBabbage -> MaryEraOnwardsBabbage
   AlonzoEraOnwardsConway -> MaryEraOnwardsConway
 
+{-# DEPRECATED babbageEraOnwardsToMaryEraOnwards "Use convert instead" #-}
 babbageEraOnwardsToMaryEraOnwards
   :: ()
   => BabbageEraOnwards era
@@ -177,6 +180,7 @@ babbageEraOnwardsToMaryEraOnwards = \case
   BabbageEraOnwardsBabbage -> MaryEraOnwardsBabbage
   BabbageEraOnwardsConway -> MaryEraOnwardsConway
 
+{-# DEPRECATED babbageEraOnwardsToAlonzoEraOnwards "Use convert instead" #-}
 babbageEraOnwardsToAlonzoEraOnwards
   :: ()
   => BabbageEraOnwards era

--- a/cardano-api/src/Cardano/Api/Internal/HasTypeProxy.hs
+++ b/cardano-api/src/Cardano/Api/Internal/HasTypeProxy.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Api.Internal.HasTypeProxy
   ( HasTypeProxy (AsType, proxyToAsType)
+  , asType
   , Proxy (..)
   , FromSomeType (..)
   )
@@ -24,3 +25,7 @@ class Typeable t => HasTypeProxy t where
 
 data FromSomeType (c :: Type -> Constraint) b where
   FromSomeType :: c a => AsType a -> (a -> b) -> FromSomeType c b
+
+-- | Provide type proxy from the already existing 'HasTypeProxy' instance
+asType :: HasTypeProxy t => AsType t
+asType = proxyToAsType Proxy

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Read.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Read.hs
@@ -28,27 +28,25 @@ import Data.List.NonEmpty (NonEmpty)
 -- The contents of the file can either be Bech32-encoded, hex-encoded, or in
 -- the text envelope format.
 readKeyFile
-  :: AsType a
-  -> NonEmpty (InputFormat a)
+  :: NonEmpty (InputFormat a)
   -> FilePath
   -> IO (Either (FileError InputDecodeError) a)
-readKeyFile asType acceptedFormats path = do
+readKeyFile acceptedFormats path = do
   eContent <- runExceptT $ fileIOExceptT path readFileBlocking
   case eContent of
     Left e -> return $ Left e
     Right content ->
-      return . first (FileError path) $ deserialiseInput asType acceptedFormats content
+      return . first (FileError path) $ deserialiseInput acceptedFormats content
 
 -- | Read a cryptographic key from a file.
 --
 -- The contents of the file must be in the text envelope format.
 readKeyFileTextEnvelope
   :: HasTextEnvelope a
-  => AsType a
-  -> File content In
+  => File content In
   -> IO (Either (FileError InputDecodeError) a)
-readKeyFileTextEnvelope asType fp =
-  first (fmap InputTextEnvelopeError) <$> readFileTextEnvelope asType fp
+readKeyFileTextEnvelope fp =
+  first (fmap InputTextEnvelopeError) <$> readFileTextEnvelope fp
 
 -- | Read a cryptographic key from a file given that it is one of the provided
 -- types.

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -1787,7 +1787,7 @@ instance ToJSONKey (Hash StakePoolKey) where
 
 instance FromJSON (Hash StakePoolKey) where
   parseJSON = withText "PoolId" $ \str ->
-    case deserialiseFromBech32 (AsHash AsStakePoolKey) str of
+    case deserialiseFromBech32 str of
       Left err ->
         fail $
           docToString $
@@ -1953,7 +1953,7 @@ instance ToJSONKey (Hash StakePoolExtendedKey) where
 
 instance FromJSON (Hash StakePoolExtendedKey) where
   parseJSON = withText "PoolId" $ \str ->
-    case deserialiseFromBech32 (AsHash AsStakePoolExtendedKey) str of
+    case deserialiseFromBech32 str of
       Left err ->
         fail $
           docToString $
@@ -2073,7 +2073,7 @@ instance ToJSONKey (Hash DRepKey) where
 
 instance FromJSON (Hash DRepKey) where
   parseJSON = withText "DRepId" $ \str ->
-    case deserialiseFromBech32 (AsHash AsDRepKey) str of
+    case deserialiseFromBech32 str of
       Left err ->
         fail $
           docToString $

--- a/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
@@ -85,6 +85,7 @@ import Ouroboros.Consensus.Shelley.Eras qualified as Consensus
 import Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
 import Ouroboros.Consensus.Shelley.Ledger.Query qualified as Consensus
 import Ouroboros.Network.Block (HeaderHash, Tip (..))
+import Ouroboros.Network.Protocol.LocalTxSubmission.Type qualified as Net.Tx
 import PlutusLedgerApi.Common qualified as P
 import PlutusLedgerApi.V2 qualified as V2
 
@@ -367,6 +368,8 @@ instance ToJSON PraosState where
       , "labNonce" .= Consensus.praosStateLabNonce s
       , "lastEpochBlockNonce" .= Consensus.praosStateLastEpochBlockNonce s
       ]
+
+deriving instance Show a => Show (Net.Tx.SubmitResult a)
 
 instance A.FromJSON V2.ParamName where
   parseJSON = A.withText "ParamName" parsePlutusParamName

--- a/cardano-api/src/Cardano/Api/Internal/Script.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Script.hs
@@ -1039,9 +1039,9 @@ instance HasTypeProxy lang => HasTypeProxy (PlutusScript lang) where
 -- do any additional transformation on Plutus script bytes.
 instance HasTypeProxy lang => SerialiseAsRawBytes (PlutusScript lang) where
   serialiseToRawBytes = serialiseToCBOR
-  deserialiseFromRawBytes asType bs =
+  deserialiseFromRawBytes asType' bs =
     first (SerialiseAsRawBytesError . show . B.sformat B.build) $
-      deserialiseFromCBOR asType bs
+      deserialiseFromCBOR asType' bs
 
 instance IsPlutusScriptLanguage lang => HasTextEnvelope (PlutusScript lang) where
   textEnvelopeType _ =
@@ -1492,7 +1492,7 @@ parsePaymentKeyHash :: Text -> Aeson.Parser (Hash PaymentKey)
 parsePaymentKeyHash =
   failEitherWith
     (\e -> "Error deserialising payment key hash: " ++ displayError e)
-    . deserialiseFromRawBytesHex (AsHash AsPaymentKey)
+    . deserialiseFromRawBytesHex
     . Text.encodeUtf8
 
 -- ----------------------------------------------------------------------------

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseBech32.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseBech32.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Bech32 Serialisation
 module Cardano.Api.Internal.SerialiseBech32
@@ -53,15 +54,16 @@ serialiseToBech32 a =
             ++ show err
 
 deserialiseFromBech32
-  :: SerialiseAsBech32 a
-  => AsType a -> Text -> Either Bech32DecodeError a
-deserialiseFromBech32 asType bech32Str = do
+  :: forall a
+   . SerialiseAsBech32 a
+  => Text -> Either Bech32DecodeError a
+deserialiseFromBech32 bech32Str = do
   (prefix, dataPart) <-
     Bech32.decodeLenient bech32Str
       ?!. Bech32DecodingError
 
   let actualPrefix = Bech32.humanReadablePartToText prefix
-      permittedPrefixes = bech32PrefixesPermitted asType
+      permittedPrefixes = bech32PrefixesPermitted (asType @a)
   guard (actualPrefix `elem` permittedPrefixes)
     ?! Bech32UnexpectedPrefix actualPrefix (fromList permittedPrefixes)
 

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseJSON.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseJSON.hs
@@ -16,7 +16,6 @@ module Cardano.Api.Internal.SerialiseJSON
 where
 
 import Cardano.Api.Internal.Error
-import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.Pretty
 
 import Control.Monad.Trans.Except (runExceptT)
@@ -44,24 +43,22 @@ prettyPrintJSON = LBS.toStrict . encodePretty
 
 deserialiseFromJSON
   :: FromJSON a
-  => AsType a
-  -> ByteString
+  => ByteString
   -> Either JsonDecodeError a
-deserialiseFromJSON _proxy =
+deserialiseFromJSON =
   either (Left . JsonDecodeError) Right
     . Aeson.eitherDecodeStrict'
 
 readFileJSON
   :: FromJSON a
-  => AsType a
-  -> FilePath
+  => FilePath
   -> IO (Either (FileError JsonDecodeError) a)
-readFileJSON ttoken path =
+readFileJSON path =
   runExceptT $ do
     content <- fileIOExceptT path BS.readFile
     firstExceptT (FileError path) $
       hoistEither $
-        deserialiseFromJSON ttoken content
+        deserialiseFromJSON content
 
 writeFileJSON
   :: ToJSON a

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseLedgerCddl.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -160,12 +159,12 @@ deserialiseByronTxCddl tec =
 serialiseWitnessLedgerCddl :: forall era. ShelleyBasedEra era -> KeyWitness era -> TextEnvelope
 serialiseWitnessLedgerCddl sbe kw =
   shelleyBasedEraConstraints sbe $
-    serialiseToTextEnvelope (Just (TextEnvelopeDescr $ T.unpack $ genDesc kw)) kw
+    serialiseToTextEnvelope (Just $ TextEnvelopeDescr desc) kw
  where
-  genDesc :: KeyWitness era -> Text
-  genDesc ByronKeyWitness{} = case sbe of {}
-  genDesc ShelleyBootstrapWitness{} = "Key BootstrapWitness ShelleyEra"
-  genDesc ShelleyKeyWitness{} = "Key Witness ShelleyEra"
+  desc :: String
+  desc = shelleyBasedEraConstraints sbe $ case kw of
+    ShelleyBootstrapWitness{} -> "Key BootstrapWitness ShelleyEra"
+    ShelleyKeyWitness{} -> "Key Witness ShelleyEra"
 
 deserialiseWitnessLedgerCddl
   :: forall era

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseLedgerCddl.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseLedgerCddl.hs
@@ -34,7 +34,6 @@ where
 
 import Cardano.Api.Internal.Eon.ShelleyBasedEra
 import Cardano.Api.Internal.Error
-import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.IO
 import Cardano.Api.Internal.Pretty
 import Cardano.Api.Internal.Serialise.Cbor.Canonical
@@ -175,12 +174,9 @@ deserialiseWitnessLedgerCddl sbe te =
   shelleyBasedEraConstraints sbe $
     legacyDecoding te $
       mapLeft textEnvelopeErrorToTextEnvelopeCddlError $
-        deserialiseFromTextEnvelope asType te
+        deserialiseFromTextEnvelope te
  where
-  asType :: AsType (KeyWitness era)
-  asType = shelleyBasedEraConstraints sbe $ proxyToAsType Proxy
-
-  -- \| This wrapper ensures that we can still decode the key witness
+  -- This wrapper ensures that we can still decode the key witness
   -- that were serialized before we migrated to using 'serialiseToTextEnvelope'
   legacyDecoding
     :: TextEnvelope
@@ -309,9 +305,7 @@ deserialiseFromTextEnvelopeCddlAnyOf types teCddl =
      . ShelleyBasedEra era
     -> TextEnvelope
     -> Either TextEnvelopeError (Tx era)
-  deserialiseTxLedgerCddl era =
-    shelleyBasedEraConstraints era $
-      deserialiseFromTextEnvelope (shelleyBasedEraConstraints era $ proxyToAsType Proxy)
+  deserialiseTxLedgerCddl era = shelleyBasedEraConstraints era deserialiseFromTextEnvelope
 
 -- Parse the text into types because this will increase code readability and
 -- will make it easier to keep track of the different Cddl descriptions via

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseUsing.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseUsing.hs
@@ -103,15 +103,12 @@ instance SerialiseAsBech32 a => Show (UsingBech32 a) where
 
 instance SerialiseAsBech32 a => IsString (UsingBech32 a) where
   fromString str =
-    case deserialiseFromBech32 ttoken (Text.pack str) of
+    case deserialiseFromBech32 (Text.pack str) of
       Right x -> UsingBech32 x
       Left e ->
         error $
           docToString $
             "fromString: " <> pretty str <> ": " <> prettyError e
-   where
-    ttoken :: AsType a
-    ttoken = proxyToAsType Proxy
 
 instance SerialiseAsBech32 a => ToJSON (UsingBech32 a) where
   toJSON (UsingBech32 x) = toJSON (serialiseToBech32 x)
@@ -119,11 +116,10 @@ instance SerialiseAsBech32 a => ToJSON (UsingBech32 a) where
 instance SerialiseAsBech32 a => FromJSON (UsingBech32 a) where
   parseJSON =
     Aeson.withText tname $ \str ->
-      case deserialiseFromBech32 ttoken str of
+      case deserialiseFromBech32 str of
         Right x -> return (UsingBech32 x)
         Left e -> fail $ docToString $ pretty str <> ": " <> prettyError e
    where
-    ttoken = proxyToAsType (Proxy :: Proxy a)
     tname = (tyConName . typeRepTyCon . typeRep) (Proxy :: Proxy a)
 
 instance SerialiseAsBech32 a => ToJSONKey (UsingBech32 a)

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -970,13 +970,8 @@ toShelleyTxOut
   => ShelleyBasedEra era
   -> TxOut CtxUTxO era
   -> Ledger.TxOut ledgerera
-toShelleyTxOut _ = \case
-  -- jky simplify
-  TxOut _ (TxOutValueByron _) _ _ ->
-    -- TODO: Temporary until we have basic tx
-    -- construction functionality
-    error "toShelleyTxOut: Expected a Shelley value"
-  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
+toShelleyTxOut sbe = shelleyBasedEraConstraints sbe $ \case
+  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
     caseShelleyToMaryOrAlonzoEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       ( \case
@@ -1165,7 +1160,7 @@ deriving instance Show (TxInsReference era)
 data TxOutValue era where
   TxOutValueByron
     :: L.Coin
-    -> TxOutValue era
+    -> TxOutValue ByronEra
   TxOutValueShelleyBased
     :: ( Eq (Ledger.Value (ShelleyLedgerEra era))
        , Show (Ledger.Value (ShelleyLedgerEra era))
@@ -3658,12 +3653,8 @@ toShelleyTxOutAny
   => ShelleyBasedEra era
   -> TxOut ctx era
   -> Ledger.TxOut ledgerera
-toShelleyTxOutAny _ = \case
-  TxOut _ (TxOutValueByron _) _ _ ->
-    -- TODO: Temporary until we have basic tx
-    -- construction functionality
-    error "toShelleyTxOutAny: Expected a Shelley value"
-  TxOut addr (TxOutValueShelleyBased sbe value) txoutdata refScript ->
+toShelleyTxOutAny sbe = shelleyBasedEraConstraints sbe $ \case
+  TxOut addr (TxOutValueShelleyBased _ value) txoutdata refScript ->
     caseShelleyToMaryOrAlonzoEraOnwards
       (const $ L.mkBasicTxOut (toShelleyAddr addr) value)
       ( \case

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -1317,11 +1317,11 @@ deriving instance Show (TxOutDatum ctx era)
 
 {-# COMPLETE TxOutDatumNone, TxOutDatumHash, TxOutSupplementalDatum, TxOutDatumInline #-}
 
-parseHash :: SerialiseAsRawBytes (Hash a) => AsType (Hash a) -> Parsec.Parser (Hash a)
-parseHash asType = do
+parseHash :: SerialiseAsRawBytes (Hash a) => Parsec.Parser (Hash a)
+parseHash = do
   str <- some Parsec.hexDigit <?> "hash"
   failEitherWith (\e -> "Failed to parse hash: " ++ displayError e) $
-    deserialiseFromRawBytesHex asType (BSC.pack str)
+    deserialiseFromRawBytesHex (BSC.pack str)
 
 -- ----------------------------------------------------------------------------
 -- Transaction fees

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -2638,9 +2638,9 @@ fromBabbageTxOut w txdatums txout =
   resolveDatumInTx dh
     | Just d <- Map.lookup dh txdatums =
         TxOutSupplementalDatum
-          (babbageEraOnwardsToAlonzoEraOnwards w)
+          (convert w)
           (fromAlonzoData d)
-    | otherwise = TxOutDatumHash (babbageEraOnwardsToAlonzoEraOnwards w) (ScriptDataHash dh)
+    | otherwise = TxOutDatumHash (convert w) (ScriptDataHash dh)
 
 fromLedgerTxTotalCollateral
   :: ShelleyBasedEra era
@@ -3599,7 +3599,7 @@ makeShelleyTransactionBody
     scriptdata :: [HashableScriptData]
     scriptdata =
       [d | TxOut _ _ (TxOutSupplementalDatum _ d) _ <- txOuts]
-        ++ [ d
+        <> [ d
            | ( _
                , AnyScriptWitness
                    ( PlutusScriptWitness

--- a/cardano-api/src/Cardano/Api/Internal/TxIn.hs
+++ b/cardano-api/src/Cardano/Api/Internal/TxIn.hs
@@ -127,7 +127,7 @@ parseTxId = do
   str <- some Parsec.hexDigit <?> "transaction id (hexadecimal)"
   failEitherWith
     (\e -> docToString $ "Incorrect transaction id format: " <> prettyError e)
-    (deserialiseFromRawBytesHex AsTxId $ BSC.pack str)
+    (deserialiseFromRawBytesHex $ BSC.pack str)
 
 parseTxIn :: Parsec.Parser TxIn
 parseTxIn = TxIn <$> parseTxId <*> (Parsec.char '#' *> parseTxIx)

--- a/cardano-api/src/Cardano/Api/Internal/Utils.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Utils.hs
@@ -14,6 +14,8 @@
 module Cardano.Api.Internal.Utils
   ( (?!)
   , (?!.)
+  , (<<$>>)
+  , (<<<$>>>)
   , formatParsecError
   , failEither
   , failEitherWith
@@ -53,6 +55,15 @@ Just x ?! _ = Right x
 (?!.) :: Either e a -> (e -> e') -> Either e' a
 Left e ?!. f = Left (f e)
 Right x ?!. _ = Right x
+
+infixl 4 <<$>>
+(<<$>>) :: (Functor f, Functor g) => (a -> b) -> f (g a) -> f (g b)
+(<<$>>) = fmap . fmap
+
+infixl 4 <<<$>>>
+(<<<$>>>) :: (Functor f, Functor g, Functor h) => (a -> b) -> f (g (h a)) -> f (g (h b))
+(<<<$>>>) = fmap . fmap . fmap
+
 
 {-# NOINLINE noInlineMaybeToStrictMaybe #-}
 noInlineMaybeToStrictMaybe :: Maybe a -> StrictMaybe a

--- a/cardano-api/src/Cardano/Api/Internal/Value.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Value.hs
@@ -458,7 +458,7 @@ instance FromJSON ValueNestedRep where
       sHash <-
         failEitherWith
           (\e -> "Failure when deserialising PolicyId: " ++ displayError e)
-          $ deserialiseFromRawBytesHex AsScriptHash
+          $ deserialiseFromRawBytesHex
           $ Text.encodeUtf8 pid
       ValueNestedBundle (PolicyId sHash) <$> parseJSON quantityBundleJson
      where

--- a/cardano-api/src/Cardano/Api/Internal/ValueParser.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ValueParser.hs
@@ -167,7 +167,7 @@ parseAssetName = do
   hexText <- many hexDigit
   failEitherWith
     (\e -> "AssetName deserisalisation failed: " ++ displayError e)
-    $ deserialiseFromRawBytesHex AsAssetName
+    $ deserialiseFromRawBytesHex
     $ BSC.pack hexText
 
 -- | Policy ID parser.
@@ -186,7 +186,7 @@ parsePolicyId = do
  where
   textToPolicyId =
     fmap PolicyId
-      . deserialiseFromRawBytesHex AsScriptHash
+      . deserialiseFromRawBytesHex
       . Text.encodeUtf8
       . Text.pack
 

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -102,7 +102,7 @@ txid1 :: TxId
 txid1 =
   fromJust $
     hush $
-      deserialiseFromRawBytesHex AsTxId "210c0a4bb6391baf606843e67863d1474cc462374ab12c42d55f78a0b55b56e0"
+      deserialiseFromRawBytesHex "210c0a4bb6391baf606843e67863d1474cc462374ab12c42d55f78a0b55b56e0"
 
 txin1 :: TxIn
 txin1 = TxIn txid1 (TxIx 1)
@@ -146,7 +146,6 @@ poolId =
   fromJust $
     hush $
       deserialiseFromRawBytesHex
-        (AsHash AsStakePoolKey)
         "9e734b6c2263c0917bfc550e9c949f41afa3fe000377243bd29df399"
 
 test_Bech32DecodeError :: TestTree

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Address.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Address.hs
@@ -165,7 +165,7 @@ roundtrip_serialise_address
      , Show a
      )
   => AsType a -> H.Gen a -> Property
-roundtrip_serialise_address asType g =
+roundtrip_serialise_address _ g =
   H.property $ do
     v <- H.forAll g
     H.tripping v serialiseAddress (deserialiseAddress asType)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Bech32.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Bech32.hs
@@ -3,8 +3,6 @@ module Test.Cardano.Api.Bech32
   )
 where
 
-import Cardano.Api (AsType (AsAddress, AsShelleyAddr, AsStakeAddress))
-
 import Test.Gen.Cardano.Api.Typed (genAddressShelley, genStakeAddress)
 
 import Hedgehog (Property)
@@ -13,10 +11,10 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
 prop_roundtrip_Address_Shelley :: Property
-prop_roundtrip_Address_Shelley = roundtrip_Bech32 (AsAddress AsShelleyAddr) genAddressShelley
+prop_roundtrip_Address_Shelley = roundtrip_Bech32 genAddressShelley
 
 prop_roundtrip_StakeAddress :: Property
-prop_roundtrip_StakeAddress = roundtrip_Bech32 AsStakeAddress genStakeAddress
+prop_roundtrip_StakeAddress = roundtrip_Bech32 genStakeAddress
 
 tests :: TestTree
 tests =

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/CBOR.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/CBOR.hs
@@ -58,7 +58,7 @@ prop_txbody_backwards_compatibility = H.property $ do
     ( H.tripping
         x
         (serialiseTxLedgerCddl era)
-        (deserialiseFromTextEnvelope (shelleyBasedEraConstraints era $ proxyToAsType Proxy))
+        deserialiseFromTextEnvelope
     )
  where
   -- This is the old implementation of serialisation for txbodies, and it is
@@ -93,7 +93,7 @@ prop_text_envelope_roundtrip_txbody_CBOR = H.property $ do
     ( H.tripping
         x
         (serialiseToTextEnvelope (Just (TextEnvelopeDescr "Ledger Cddl Format")))
-        (deserialiseFromTextEnvelope (shelleyBasedEraConstraints era $ proxyToAsType Proxy))
+        deserialiseFromTextEnvelope
     )
 
 prop_text_envelope_roundtrip_tx_CBOR :: Property
@@ -105,7 +105,7 @@ prop_text_envelope_roundtrip_tx_CBOR = H.property $ do
     ( H.tripping
         x
         (serialiseToTextEnvelope (Just (TextEnvelopeDescr "Ledger Cddl Format")))
-        (deserialiseFromTextEnvelope (shelleyBasedEraConstraints era $ proxyToAsType Proxy))
+        deserialiseFromTextEnvelope
     )
 
 prop_roundtrip_tx_CBOR :: Property

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Envelope.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Envelope.hs
@@ -101,7 +101,7 @@ roundtrip_VerificationKey_envelope roletoken =
     H.tripping
       vkey
       (serialiseToTextEnvelope Nothing)
-      (deserialiseFromTextEnvelope (AsVerificationKey roletoken))
+      deserialiseFromTextEnvelope
 
 roundtrip_SigningKey_envelope
   :: ( Key keyrole
@@ -115,7 +115,7 @@ roundtrip_SigningKey_envelope roletoken =
     H.tripping
       vkey
       (serialiseToTextEnvelope Nothing)
-      (deserialiseFromTextEnvelope (AsSigningKey roletoken))
+      deserialiseFromTextEnvelope
 
 -- -----------------------------------------------------------------------------
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -226,7 +226,6 @@ getExampleSrcTxId = do
   srcTxId <-
     H.evalEither $
       Api.deserialiseFromRawBytesHex
-        Api.AsTxId
         "be6efd42a3d7b9a00d09d77a5d41e55ceaf0bd093a8aa8a893ce70d9caafd978"
   let srcTxIx = Api.TxIx 0
   return $ Api.TxIn srcTxId srcTxIx
@@ -280,5 +279,4 @@ exampleSigningKey :: H.MonadTest m => m (Api.SigningKey Api.PaymentKey)
 exampleSigningKey =
   H.evalEither $
     Api.deserialiseFromBech32
-      (Api.AsSigningKey Api.AsPaymentKey)
       "addr_sk1648253w4tf6fv5fk28dc7crsjsaw7d9ymhztd4favg3cwkhz7x8sl5u3ms"

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/RawBytes.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/RawBytes.hs
@@ -81,7 +81,7 @@ roundtrip_raw_bytes
      , Show a
      )
   => AsType a -> H.Gen a -> Property
-roundtrip_raw_bytes asType g =
+roundtrip_raw_bytes _ g =
   H.property $ do
     v <- H.forAll g
     H.tripping v serialiseToRawBytes (deserialiseFromRawBytes asType)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -477,7 +477,7 @@ loadPlutusWitness
 loadPlutusWitness ceo = do
   envelope <-
     H.leftFailM $
-      fmap (deserialiseFromJSON AsTextEnvelope) . H.evalIO $
+      fmap (deserialiseFromJSON @TextEnvelope) . H.evalIO $
         B.readFile "test/cardano-api-test/files/input/plutus/v3.alwaysTrue.json"
   ScriptInAnyLang (PlutusScriptLanguage PlutusScriptV3) s@(PlutusScript PlutusScriptV3 script) <-
     H.leftFail $ deserialiseFromTextEnvelopeAnyOf textEnvTypes envelope


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    - Deprecate `shelleyToAlonzoEraToShelleyToBabbageEra`, `alonzoEraOnwardsToMaryEraOnwards`, `babbageEraOnwardsToMaryEraOnwards`, `babbageEraOnwardsToAlonzoEraOnwards`.
    - Add `asType` for easier obtaining of `HasTypeProxy` proxies
    - Remove unneded `AsType a` functions' arguments
    - Remove some `ByronEra`-related dead code.

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR contains few QoL changes. It should be reviewed on commit-by-commit basis.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
