### PR TITLE
Remove `BabbageEra` from experimental `Era` type

### DIFF
--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -31,7 +31,6 @@ module Cardano.Api.Experimental
   , LedgerEra
   , DeprecatedEra (..)
   , eraToSbe
-  , babbageEraOnwardsToEra
   , eraToBabbageEraOnwards
   , sbeToEra
 

--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Tx.hs
@@ -138,7 +138,6 @@ import Cardano.Api.Internal.Tx.Sign
 import Cardano.Crypto.Hash qualified as Hash
 import Cardano.Ledger.Alonzo.TxBody qualified as L
 import Cardano.Ledger.Api qualified as L
-import Cardano.Ledger.Babbage qualified as Ledger
 import Cardano.Ledger.Conway qualified as Ledger
 import Cardano.Ledger.Conway.TxBody qualified as L
 import Cardano.Ledger.Core qualified as Ledger
@@ -156,7 +155,6 @@ newtype UnsignedTx era
 
 instance IsEra era => Show (UnsignedTx era) where
   showsPrec p (UnsignedTx tx) = case useEra @era of
-    BabbageEra -> showsPrec p (tx :: Ledger.Tx Ledger.BabbageEra)
     ConwayEra -> showsPrec p (tx :: Ledger.Tx Ledger.ConwayEra)
 
 newtype UnsignedTxError
@@ -246,12 +244,6 @@ eraSpecificLedgerTxBody
   -> Ledger.TxBody (LedgerEra era)
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (Ledger.TxBody (LedgerEra era))
-eraSpecificLedgerTxBody BabbageEra ledgerbody bc = do
-  let sbe = convert BabbageEra
-
-  setUpdateProposal <- convTxUpdateProposal sbe (txUpdateProposal bc)
-
-  return $ ledgerbody & L.updateTxBodyL .~ setUpdateProposal
 eraSpecificLedgerTxBody ConwayEra ledgerbody bc =
   let propProcedures = txProposalProcedures bc
       voteProcedures = txVotingProcedures bc


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removed Babbage era from `Experimental` API together with `babbageEraOnwardsToEra` function.
  type:
  - breaking
```

# Context

This PR addresses https://github.com/IntersectMBO/cardano-api/issues/827. It is part of an effort to propagate the experimental API through `cardano-cli`. Because Babbage era is deprecated we are removing it from the experimental API. 

# How to trust this PR

Check just the right things are removed and the updates make sense. The fact that it typechecks already gives a lot of assurance in this particular case.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
