### PR TITLE
Add extra functions to `Cardano.Api.Tx.UTxO`.

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
@@ -102,6 +102,10 @@ fromList = UTxO . Map.fromList
 toList :: UTxO era -> [(TxIn, TxOut CtxUTxO era)]
 toList (UTxO xs) = Map.toList xs
 
+-- | Convert to a Map of TxIn/TxOut.
+toMap :: UTxO era -> Map TxIn (TxOut CtxUTxO era)
+toMap = unUTxO
+
 -- | Convert from a `cardano-api` `UTxO` to a `cardano-ledger` UTxO.
 toShelleyUTxO :: ShelleyBasedEra era -> UTxO era -> Ledger.UTxO (ShelleyLedgerEra era)
 toShelleyUTxO sbe =

--- a/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/UTxO.hs
@@ -74,6 +74,10 @@ singleton i o = UTxO $ Map.singleton i o
 lookup :: TxIn -> UTxO era -> Maybe (TxOut CtxUTxO era)
 lookup k = Map.lookup k . unUTxO
 
+-- | Synonym for `lookup`.
+resolveTxIn :: TxIn -> UTxO era -> Maybe (TxOut CtxUTxO era)
+resolveTxIn = Cardano.Api.Internal.Tx.UTxO.lookup
+
 -- | Filter all `TxOut` that satisfy the predicate.
 filter :: (TxOut CtxUTxO era -> Bool) -> UTxO era -> UTxO era
 filter fn = UTxO . Map.filter fn . unUTxO

--- a/cardano-api/src/Cardano/Api/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Tx/UTxO.hs
@@ -3,6 +3,7 @@ module Cardano.Api.Tx.UTxO
   , UTxO.empty
   , UTxO.singleton
   , UTxO.lookup
+  , UTxO.resolveTxIn
   , UTxO.filter
   , UTxO.filterWithKey
   , UTxO.inputSet

--- a/cardano-api/src/Cardano/Api/Tx/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/Tx/UTxO.hs
@@ -10,6 +10,7 @@ module Cardano.Api.Tx.UTxO
   , UTxO.difference
   , UTxO.fromList
   , UTxO.toList
+  , UTxO.toMap
   , UTxO.fromShelleyUTxO
   , UTxO.toShelleyUTxO
   )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `toMap` synonym for `unUTxO`, `resolveTxIn` synonym for `lookup` functions to `Cardano.Api.Tx.UTxO`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We find the synonym `toMap` to be more appropriate than `unUTxO` to use qualified, as in `UTxO.toMap`. We also find `resolveTxIn` to be more appropriate than `lookup` as it is domain specific.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
