### PR TITLE
Deprecate `makeShelleyTransactionBody`

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -2172,6 +2172,7 @@ mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData =
         & L.auxDataHashTxBodyL
           .~ maybe SNothing (SJust . Ledger.hashTxAuxData) txAuxData
 
+{-# DEPRECATED makeShelleyTransactionBody "Use 'createTransactionBody' instead." #-}
 makeShelleyTransactionBody
   :: forall era
    . ()


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Deprecate `makeShelleyTransactionBody`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This duplicates `createTransactionBody` logic. `createTransactionBody` should be used insted.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
