### PR TITLE
Add `Pretty` instance to `Url`

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Pretty.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Pretty.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Cardano.Api.Internal.Pretty
   ( Ann
   , Doc
@@ -23,6 +25,8 @@ module Cardano.Api.Internal.Pretty
 where
 
 import Cardano.Api.Internal.Via.ShowOf
+
+import Cardano.Ledger.BaseTypes qualified as L
 
 import Control.Exception.Safe
 import Data.Text qualified as Text
@@ -74,3 +78,6 @@ pshow = viaShow
 -- | Short hand for @'pretty' . 'displayException'@
 prettyException :: Exception a => a -> Doc ann
 prettyException = pretty . displayException
+
+instance Pretty L.Url where
+  pretty url = pretty (L.urlToText url)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added `Pretty` instance to `Url`.
  type:
  - compatible
```

# Context

It is often necessary to print `Url`s and having a `Pretty` instance would make it more convenient. See [this example](https://github.com/IntersectMBO/cardano-cli/pull/951/files#r1824034838).

# How to trust this PR

It is a very small change. The most controversial part of it is probably that the instance is an orphan.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
