### PR TITLE
Remove partial instances

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -100,6 +100,7 @@ library
     Cardano.Api.Ledger
     Cardano.Api.Ledger.Lens
     Cardano.Api.Network
+    Cardano.Api.Parser.Text
     Cardano.Api.Shelley
     Cardano.Api.Tx.UTxO
 
@@ -322,6 +323,7 @@ test-suite cardano-api-test
   main-is: cardano-api-test.hs
   type: exitcode-stdio-1.0
   build-depends:
+    FailT,
     QuickCheck,
     aeson >=1.5.6.0,
     base16-bytestring,
@@ -420,7 +422,6 @@ test-suite cardano-api-golden
     hedgehog >=1.1,
     hedgehog-extras ^>=0.7,
     microlens,
-    parsec,
     plutus-core ^>=1.45,
     plutus-ledger-api,
     tasty,

--- a/cardano-api/src/Cardano/Api.hs
+++ b/cardano-api/src/Cardano/Api.hs
@@ -216,10 +216,10 @@ module Cardano.Api
   , StakeAddressReference (..)
   , PaymentKey
   , PaymentExtendedKey
+  , parseHexHash
 
     -- ** Addresses in any era
   , AddressAny (..)
-  , lexPlausibleAddressString
   , parseAddressAny
 
     -- ** Addresses in specific eras
@@ -376,13 +376,16 @@ module Cardano.Api
 
     -- ** Transaction Ids
   , TxId (..)
+  , parseTxId
   , getTxId
   , getTxIdByron
 
     -- ** Transaction inputs
   , TxIn (TxIn)
+  , parseTxIn
   , TxIns
   , TxIx (TxIx)
+  , parseTxIx
   , renderTxIn
   , getReferenceInputsSizeForTxIds
 
@@ -397,7 +400,6 @@ module Cardano.Api
   , txOutValueToValue
   , lovelaceToTxOutValue
   , TxOutDatum (..)
-  , parseHash
 
     -- ** Other transaction body types
   , TxInsCollateral (..)
@@ -643,6 +645,7 @@ module Cardano.Api
   , getScriptData
   , unsafeHashableScriptData
   , ScriptData (..)
+  , parseScriptDataHash
 
     -- ** Validation
   , ScriptDataRangeError (..)
@@ -669,6 +672,7 @@ module Cardano.Api
 
     -- | Making addresses from scripts.
   , ScriptHash (..)
+  , parseScriptHash
   , hashScript
 
     -- * Serialisation
@@ -735,6 +739,7 @@ module Cardano.Api
   , serialiseToRawBytesHex
   , deserialiseFromRawBytesHex
   , serialiseToRawBytesHexText
+  , parseRawBytesHex
   , RawBytesHexError (..)
   , UsingRawBytes (..)
   , UsingRawBytesHex (..)
@@ -995,7 +1000,6 @@ module Cardano.Api
   , fromLedgerTxOuts
   , toLedgerUTxO
   , fromLedgerUTxO
-  , runParsecParser
   , SlotsInEpoch (..)
   , SlotsToEpochEnd (..)
   , slotToEpoch

--- a/cardano-api/src/Cardano/Api/Internal/Address.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Address.hs
@@ -248,10 +248,10 @@ instance SerialiseAsRawBytes (Address ShelleyAddr) where
       Just (Shelley.Addr nw pc scr) -> Right (ShelleyAddress nw pc scr)
 
 instance SerialiseAsBech32 (Address ShelleyAddr) where
-  bech32PrefixFor (ShelleyAddress Shelley.Mainnet _ _) = "addr"
-  bech32PrefixFor (ShelleyAddress Shelley.Testnet _ _) = "addr_test"
+  bech32PrefixFor (ShelleyAddress Shelley.Mainnet _ _) = unsafeHumanReadablePartFromText "addr"
+  bech32PrefixFor (ShelleyAddress Shelley.Testnet _ _) = unsafeHumanReadablePartFromText "addr_test"
 
-  bech32PrefixesPermitted (AsAddress AsShelleyAddr) = ["addr", "addr_test"]
+  bech32PrefixesPermitted (AsAddress AsShelleyAddr) = unsafeHumanReadablePartFromText <$> ["addr", "addr_test"]
 
 instance SerialiseAddress (Address ByronAddr) where
   serialiseAddress addr@ByronAddress{} =
@@ -579,10 +579,10 @@ instance SerialiseAsRawBytes StakeAddress where
       Just (Shelley.RewardAccount nw sc) -> Right (StakeAddress nw sc)
 
 instance SerialiseAsBech32 StakeAddress where
-  bech32PrefixFor (StakeAddress Shelley.Mainnet _) = "stake"
-  bech32PrefixFor (StakeAddress Shelley.Testnet _) = "stake_test"
+  bech32PrefixFor (StakeAddress Shelley.Mainnet _) = unsafeHumanReadablePartFromText "stake"
+  bech32PrefixFor (StakeAddress Shelley.Testnet _) = unsafeHumanReadablePartFromText "stake_test"
 
-  bech32PrefixesPermitted AsStakeAddress = ["stake", "stake_test"]
+  bech32PrefixesPermitted AsStakeAddress = unsafeHumanReadablePartFromText <$> ["stake", "stake_test"]
 
 instance SerialiseAddress StakeAddress where
   serialiseAddress addr@StakeAddress{} =

--- a/cardano-api/src/Cardano/Api/Internal/Block.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Block.hs
@@ -81,7 +81,6 @@ import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as BS
 import Data.ByteString.Short qualified as SBS
 import Data.Foldable (Foldable (toList))
-import Data.String (IsString)
 import Data.Text (Text)
 
 {- HLINT ignore "Use lambda" -}
@@ -236,7 +235,6 @@ data BlockHeader
 newtype instance Hash BlockHeader = HeaderHash SBS.ShortByteString
   deriving (Eq, Ord, Show)
   deriving (ToJSON, FromJSON) via UsingRawBytesHex (Hash BlockHeader)
-  deriving IsString via UsingRawBytesHex (Hash BlockHeader)
 
 instance SerialiseAsRawBytes (Hash BlockHeader) where
   serialiseToRawBytes (HeaderHash bs) = SBS.fromShort bs

--- a/cardano-api/src/Cardano/Api/Internal/CIP/Cip129.hs
+++ b/cardano-api/src/Cardano/Api/Internal/CIP/Cip129.hs
@@ -54,13 +54,6 @@ class (SerialiseAsRawBytes a, HasTypeProxy a) => Cip129 a where
   default cip129Bech32PrefixesPermitted :: AsType a -> [Text]
   cip129Bech32PrefixesPermitted = return . Bech32.humanReadablePartToText . cip129Bech32PrefixFor
 
--- | The human readable part of the Bech32 encoding for the credential. This will
--- error if the prefix is not valid.
-unsafeHumanReadablePartFromText :: Text -> Bech32.HumanReadablePart
-unsafeHumanReadablePartFromText =
-  either (error . ("Error while parsing Bech32: " <>) . show) id
-    . Bech32.humanReadablePartFromText
-
 instance Cip129 (Credential L.ColdCommitteeRole) where
   cip129Bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold"
   cip129Bech32PrefixesPermitted AsColdCommitteeCredential = ["cc_cold"]

--- a/cardano-api/src/Cardano/Api/Internal/Error.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Error.hs
@@ -8,6 +8,7 @@
 module Cardano.Api.Internal.Error
   ( Error (..)
   , throwErrorAsException
+  , failEitherError
   , ErrorAsException (..)
   , FileError (..)
   , fileIOExceptT
@@ -16,6 +17,7 @@ module Cardano.Api.Internal.Error
 where
 
 import Cardano.Api.Internal.Pretty
+import Cardano.Api.Internal.Utils
 
 import Control.Exception (Exception (..), IOException, throwIO)
 import Control.Monad.Except (throwError)
@@ -35,6 +37,9 @@ instance Error () where
 -- necessary use IO exceptions.
 throwErrorAsException :: Error e => e -> IO a
 throwErrorAsException e = throwIO (ErrorAsException e)
+
+failEitherError :: MonadFail m => Error e => Either e a -> m a
+failEitherError = failEitherWith displayError
 
 data ErrorAsException where
   ErrorAsException :: Error e => e -> ErrorAsException

--- a/cardano-api/src/Cardano/Api/Internal/Governance/Poll.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Governance/Poll.hs
@@ -41,6 +41,7 @@ import Cardano.Api.Internal.Eras
 import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.Hash
 import Cardano.Api.Internal.Keys.Shelley
+import Cardano.Api.Internal.Pretty
 import Cardano.Api.Internal.Serialise.Cbor
 import Cardano.Api.Internal.SerialiseRaw
 import Cardano.Api.Internal.SerialiseTextEnvelope
@@ -60,7 +61,6 @@ import Control.Monad (foldM, when)
 import Data.Either.Combinators (maybeToRight)
 import Data.Function ((&))
 import Data.Map.Strict qualified as Map
-import Data.String (IsString (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as Text.Lazy
@@ -185,7 +185,7 @@ instance SerialiseAsCBOR GovernancePoll where
 newtype instance Hash GovernancePoll
   = GovernancePollHash {unGovernancePollHash :: Hash.Hash HASH GovernancePoll}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GovernancePoll)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GovernancePoll)
 
 instance SerialiseAsRawBytes (Hash GovernancePoll) where
   serialiseToRawBytes =

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Byron.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Byron.hs
@@ -32,6 +32,7 @@ import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.Hash
 import Cardano.Api.Internal.Keys.Class
 import Cardano.Api.Internal.Keys.Shelley
+import Cardano.Api.Internal.Pretty
 import Cardano.Api.Internal.Serialise.Cbor
 import Cardano.Api.Internal.SerialiseRaw
 import Cardano.Api.Internal.SerialiseTextEnvelope
@@ -52,7 +53,6 @@ import Control.Monad
 import Data.Bifunctor
 import Data.ByteString.Lazy qualified as LB
 import Data.Either.Combinators
-import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Formatting (build, formatToString)
@@ -95,13 +95,13 @@ instance Key ByronKey where
   newtype VerificationKey ByronKey
     = ByronVerificationKey Crypto.VerificationKey
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey ByronKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey ByronKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey ByronKey
     = ByronSigningKey Crypto.SigningKey
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey ByronKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey ByronKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -147,7 +147,7 @@ instance SerialiseAsRawBytes (SigningKey ByronKey) where
 
 newtype instance Hash ByronKey = ByronKeyHash Crypto.KeyHash
   deriving (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash ByronKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash ByronKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash ByronKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -186,13 +186,13 @@ instance Key ByronKeyLegacy where
   newtype VerificationKey ByronKeyLegacy
     = ByronVerificationKeyLegacy Crypto.VerificationKey
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey ByronKeyLegacy)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey ByronKeyLegacy)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey ByronKeyLegacy
     = ByronSigningKeyLegacy Crypto.SigningKey
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey ByronKeyLegacy)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey ByronKeyLegacy)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -222,7 +222,7 @@ instance HasTextEnvelope (SigningKey ByronKeyLegacy) where
 
 newtype instance Hash ByronKeyLegacy = ByronKeyHashLegacy Crypto.KeyHash
   deriving (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash ByronKeyLegacy)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash ByronKeyLegacy)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash ByronKeyLegacy)
   deriving anyclass SerialiseAsCBOR
 

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Praos.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Praos.hs
@@ -106,12 +106,12 @@ instance SerialiseAsRawBytes (SigningKey KesKey) where
       KesSigningKey <$> Crypto.rawDeserialiseUnsoundPureSignKeyKES bs
 
 instance SerialiseAsBech32 (VerificationKey KesKey) where
-  bech32PrefixFor _ = "kes_vk"
-  bech32PrefixesPermitted _ = ["kes_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "kes_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["kes_vk"]
 
 instance SerialiseAsBech32 (SigningKey KesKey) where
-  bech32PrefixFor _ = "kes_sk"
-  bech32PrefixesPermitted _ = ["kes_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "kes_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["kes_sk"]
 
 newtype instance Hash KesKey
   = KesKeyHash
@@ -218,12 +218,12 @@ instance SerialiseAsRawBytes (SigningKey VrfKey) where
       VrfSigningKey <$> Crypto.rawDeserialiseSignKeyVRF bs
 
 instance SerialiseAsBech32 (VerificationKey VrfKey) where
-  bech32PrefixFor _ = "vrf_vk"
-  bech32PrefixesPermitted _ = ["vrf_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "vrf_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["vrf_vk"]
 
 instance SerialiseAsBech32 (SigningKey VrfKey) where
-  bech32PrefixFor _ = "vrf_sk"
-  bech32PrefixesPermitted _ = ["vrf_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "vrf_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["vrf_sk"]
 
 newtype instance Hash VrfKey
   = VrfKeyHash

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Praos.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Praos.hs
@@ -28,6 +28,7 @@ where
 import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.Hash
 import Cardano.Api.Internal.Keys.Class
+import Cardano.Api.Internal.Pretty
 import Cardano.Api.Internal.Serialise.Cbor
 import Cardano.Api.Internal.SerialiseBech32
 import Cardano.Api.Internal.SerialiseRaw
@@ -59,13 +60,13 @@ instance Key KesKey where
   newtype VerificationKey KesKey
     = KesVerificationKey (Crypto.VerKeyKES (KES StandardCrypto))
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey KesKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey KesKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey KesKey
     = KesSigningKey (Crypto.UnsoundPureSignKeyKES (KES StandardCrypto))
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey KesKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey KesKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -120,7 +121,7 @@ newtype instance Hash KesKey
           (Crypto.VerKeyKES (KES StandardCrypto))
       )
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash KesKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash KesKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash KesKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -172,13 +173,13 @@ instance Key VrfKey where
   newtype VerificationKey VrfKey
     = VrfVerificationKey (Crypto.VerKeyVRF (VRF StandardCrypto))
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey VrfKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey VrfKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey VrfKey
     = VrfSigningKey (Crypto.SignKeyVRF (VRF StandardCrypto))
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey VrfKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey VrfKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -232,7 +233,7 @@ newtype instance Hash VrfKey
           (Crypto.VerKeyVRF (VRF StandardCrypto))
       )
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash VrfKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash VrfKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash VrfKey)
   deriving anyclass SerialiseAsCBOR
 

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -45,6 +45,7 @@ module Cardano.Api.Internal.Keys.Shelley
   , anyStakePoolVerificationKeyHash
   , AnyStakePoolSigningKey (..)
   , anyStakePoolSigningKeyToVerificationKey
+  , parseHexHash
   )
 where
 
@@ -59,6 +60,7 @@ import Cardano.Api.Internal.SerialiseJSON
 import Cardano.Api.Internal.SerialiseRaw
 import Cardano.Api.Internal.SerialiseTextEnvelope
 import Cardano.Api.Internal.SerialiseUsing
+import Cardano.Api.Parser.Text qualified as P
 
 import Cardano.Crypto.DSIGN qualified as DSIGN
 import Cardano.Crypto.DSIGN.Class qualified as Crypto
@@ -98,13 +100,13 @@ instance Key PaymentKey where
   newtype VerificationKey PaymentKey
     = PaymentVerificationKey (Shelley.VKey Shelley.Payment)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey PaymentKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey PaymentKey
     = PaymentSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey PaymentKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -158,7 +160,7 @@ instance SerialiseAsBech32 (SigningKey PaymentKey) where
 newtype instance Hash PaymentKey
   = PaymentKeyHash {unPaymentKeyHash :: Shelley.KeyHash Shelley.Payment}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash PaymentKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash PaymentKey)
   deriving (ToJSONKey, ToJSON, FromJSON) via UsingRawBytesHex (Hash PaymentKey)
   deriving anyclass SerialiseAsCBOR
@@ -218,12 +220,12 @@ instance Key PaymentExtendedKey where
     = PaymentExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
 
   newtype SigningKey PaymentExtendedKey
     = PaymentExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
 
   deterministicSigningKey
     :: AsType PaymentExtendedKey
@@ -309,7 +311,7 @@ newtype instance Hash PaymentExtendedKey
   = PaymentExtendedKeyHash
   {unPaymentExtendedKeyHash :: Shelley.KeyHash Shelley.Payment}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash PaymentExtendedKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash PaymentExtendedKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash PaymentExtendedKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -356,13 +358,13 @@ instance Key StakeKey where
     deriving stock Eq
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakeKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey StakeKey)
 
   newtype SigningKey StakeKey
     = StakeSigningKey (DSIGN.SignKeyDSIGN DSIGN)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakeKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey StakeKey)
 
   deterministicSigningKey :: AsType StakeKey -> Crypto.Seed -> SigningKey StakeKey
   deterministicSigningKey AsStakeKey seed =
@@ -411,7 +413,7 @@ instance SerialiseAsBech32 (SigningKey StakeKey) where
 newtype instance Hash StakeKey
   = StakeKeyHash {unStakeKeyHash :: Shelley.KeyHash Shelley.Staking}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash StakeKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash StakeKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakeKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -469,12 +471,12 @@ instance Key StakeExtendedKey where
     = StakeExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakeExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey StakeExtendedKey)
 
   newtype SigningKey StakeExtendedKey
     = StakeExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakeExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey StakeExtendedKey)
 
   deterministicSigningKey
     :: AsType StakeExtendedKey
@@ -559,7 +561,7 @@ instance SerialiseAsBech32 (SigningKey StakeExtendedKey) where
 newtype instance Hash StakeExtendedKey
   = StakeExtendedKeyHash {unStakeExtendedKeyHash :: Shelley.KeyHash Shelley.Staking}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash StakeExtendedKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash StakeExtendedKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakeExtendedKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -603,13 +605,13 @@ instance Key GenesisKey where
   newtype VerificationKey GenesisKey
     = GenesisVerificationKey (Shelley.VKey Shelley.Genesis)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey GenesisKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey GenesisKey
     = GenesisSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey GenesisKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -652,7 +654,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisKey) where
 newtype instance Hash GenesisKey
   = GenesisKeyHash {unGenesisKeyHash :: Shelley.KeyHash Shelley.Genesis}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GenesisKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisKey)
   deriving (ToJSONKey, ToJSON, FromJSON) via UsingRawBytesHex (Hash GenesisKey)
   deriving anyclass SerialiseAsCBOR
@@ -699,13 +701,13 @@ instance Key CommitteeHotKey where
   newtype VerificationKey CommitteeHotKey
     = CommitteeHotVerificationKey (Shelley.VKey Shelley.HotCommitteeRole)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey CommitteeHotKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey CommitteeHotKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey CommitteeHotKey
     = CommitteeHotSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey CommitteeHotKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey CommitteeHotKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -751,7 +753,7 @@ newtype instance Hash CommitteeHotKey
   = CommitteeHotKeyHash
   {unCommitteeHotKeyHash :: Shelley.KeyHash Shelley.HotCommitteeRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeHotKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash CommitteeHotKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeHotKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -810,13 +812,13 @@ instance Key CommitteeColdKey where
   newtype VerificationKey CommitteeColdKey
     = CommitteeColdVerificationKey (Shelley.VKey Shelley.ColdCommitteeRole)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey CommitteeColdKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey CommitteeColdKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey CommitteeColdKey
     = CommitteeColdSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey CommitteeColdKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey CommitteeColdKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -862,7 +864,7 @@ newtype instance Hash CommitteeColdKey
   = CommitteeColdKeyHash
   {unCommitteeColdKeyHash :: Shelley.KeyHash Shelley.ColdCommitteeRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeColdKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash CommitteeColdKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeColdKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -921,12 +923,12 @@ instance Key CommitteeColdExtendedKey where
     = CommitteeColdExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
 
   newtype SigningKey CommitteeColdExtendedKey
     = CommitteeColdExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
 
   deterministicSigningKey
     :: AsType CommitteeColdExtendedKey
@@ -962,7 +964,7 @@ newtype instance Hash CommitteeColdExtendedKey
   = CommitteeColdExtendedKeyHash
   {unCommitteeColdExtendedKeyHash :: Shelley.KeyHash Shelley.ColdCommitteeRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeColdKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash CommitteeColdKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeColdKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1056,12 +1058,12 @@ instance Key CommitteeHotExtendedKey where
     = CommitteeHotExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
 
   newtype SigningKey CommitteeHotExtendedKey
     = CommitteeHotExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
 
   deterministicSigningKey
     :: AsType CommitteeHotExtendedKey
@@ -1097,7 +1099,7 @@ newtype instance Hash CommitteeHotExtendedKey
   = CommitteeHotExtendedKeyHash
   {unCommitteeHotExtendedKeyHash :: Shelley.KeyHash Shelley.HotCommitteeRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash CommitteeHotKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash CommitteeHotKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash CommitteeHotKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1204,12 +1206,12 @@ instance Key GenesisExtendedKey where
     = GenesisExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey GenesisExtendedKey)
 
   newtype SigningKey GenesisExtendedKey
     = GenesisExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey GenesisExtendedKey)
 
   deterministicSigningKey
     :: AsType GenesisExtendedKey
@@ -1286,7 +1288,7 @@ newtype instance Hash GenesisExtendedKey
   = GenesisExtendedKeyHash
   {unGenesisExtendedKeyHash :: Shelley.KeyHash Shelley.Staking}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisExtendedKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GenesisExtendedKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisExtendedKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1330,13 +1332,13 @@ instance Key GenesisDelegateKey where
   newtype VerificationKey GenesisDelegateKey
     = GenesisDelegateVerificationKey (Shelley.VKey Shelley.GenesisDelegate)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisDelegateKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey GenesisDelegateKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey GenesisDelegateKey
     = GenesisDelegateSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisDelegateKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey GenesisDelegateKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -1380,7 +1382,7 @@ newtype instance Hash GenesisDelegateKey
   = GenesisDelegateKeyHash
   {unGenesisDelegateKeyHash :: Shelley.KeyHash Shelley.GenesisDelegate}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisDelegateKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GenesisDelegateKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisDelegateKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1447,12 +1449,12 @@ instance Key GenesisDelegateExtendedKey where
     = GenesisDelegateExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisDelegateExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey GenesisDelegateExtendedKey)
 
   newtype SigningKey GenesisDelegateExtendedKey
     = GenesisDelegateExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisDelegateExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey GenesisDelegateExtendedKey)
 
   deterministicSigningKey
     :: AsType GenesisDelegateExtendedKey
@@ -1535,7 +1537,7 @@ newtype instance Hash GenesisDelegateExtendedKey
   = GenesisDelegateExtendedKeyHash
   {unGenesisDelegateExtendedKeyHash :: Shelley.KeyHash Shelley.Staking}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisDelegateExtendedKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GenesisDelegateExtendedKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisDelegateExtendedKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1579,13 +1581,13 @@ instance Key GenesisUTxOKey where
   newtype VerificationKey GenesisUTxOKey
     = GenesisUTxOVerificationKey (Shelley.VKey Shelley.Payment)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey GenesisUTxOKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey GenesisUTxOKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey GenesisUTxOKey
     = GenesisUTxOSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey GenesisUTxOKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey GenesisUTxOKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -1627,7 +1629,7 @@ instance SerialiseAsRawBytes (SigningKey GenesisUTxOKey) where
 newtype instance Hash GenesisUTxOKey
   = GenesisUTxOKeyHash {unGenesisUTxOKeyHash :: Shelley.KeyHash Shelley.Payment}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash GenesisUTxOKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash GenesisUTxOKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash GenesisUTxOKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1703,13 +1705,13 @@ instance Key StakePoolKey where
   newtype VerificationKey StakePoolKey
     = StakePoolVerificationKey (Shelley.VKey Shelley.StakePool)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakePoolKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey StakePoolKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey StakePoolKey
     = StakePoolSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakePoolKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey StakePoolKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -1762,7 +1764,7 @@ instance SerialiseAsBech32 (SigningKey StakePoolKey) where
 newtype instance Hash StakePoolKey
   = StakePoolKeyHash {unStakePoolKeyHash :: Shelley.KeyHash Shelley.StakePool}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash StakePoolKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash StakePoolKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash StakePoolKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -1827,12 +1829,12 @@ instance Key StakePoolExtendedKey where
   newtype VerificationKey StakePoolExtendedKey
     = StakePoolExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey StakePoolExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey StakePoolExtendedKey)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey StakePoolExtendedKey
     = StakePoolExtendedSigningKey Crypto.HD.XPrv
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey StakePoolExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey StakePoolExtendedKey)
     deriving anyclass SerialiseAsCBOR
 
   deterministicSigningKey
@@ -1989,13 +1991,13 @@ instance Key DRepKey where
   newtype VerificationKey DRepKey
     = DRepVerificationKey (Shelley.VKey Shelley.DRepRole)
     deriving stock Eq
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey DRepKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey DRepKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
   newtype SigningKey DRepKey
     = DRepSigningKey (DSIGN.SignKeyDSIGN DSIGN)
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey DRepKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey DRepKey)
     deriving newtype (ToCBOR, FromCBOR)
     deriving anyclass SerialiseAsCBOR
 
@@ -2048,7 +2050,7 @@ instance SerialiseAsBech32 (SigningKey DRepKey) where
 newtype instance Hash DRepKey
   = DRepKeyHash {unDRepKeyHash :: Shelley.KeyHash Shelley.DRepRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash DRepKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash DRepKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash DRepKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -2114,12 +2116,12 @@ instance Key DRepExtendedKey where
     = DRepExtendedVerificationKey Crypto.HD.XPub
     deriving stock Eq
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (VerificationKey PaymentExtendedKey)
 
   newtype SigningKey DRepExtendedKey
     = DRepExtendedSigningKey Crypto.HD.XPrv
     deriving anyclass SerialiseAsCBOR
-    deriving (Show, IsString) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
+    deriving (Show, Pretty) via UsingRawBytesHex (SigningKey PaymentExtendedKey)
 
   deterministicSigningKey
     :: AsType DRepExtendedKey
@@ -2154,7 +2156,7 @@ instance Key DRepExtendedKey where
 newtype instance Hash DRepExtendedKey
   = DRepExtendedKeyHash {unDRepExtendedKeyHash :: Shelley.KeyHash Shelley.DRepRole}
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash DRepKey)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash DRepKey)
   deriving (ToCBOR, FromCBOR) via UsingRawBytes (Hash DRepKey)
   deriving anyclass SerialiseAsCBOR
 
@@ -2233,3 +2235,7 @@ instance CastVerificationKeyRole DRepExtendedKey DRepKey where
    where
     impossible =
       error "castVerificationKey (DRep): byron and shelley key sizes do not match!"
+
+-- | Parse hex representation of any 'Hash'
+parseHexHash :: SerialiseAsRawBytes (Hash a) => P.Parser (Hash a)
+parseHexHash = parseRawBytesHex

--- a/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Keys/Shelley.hs
@@ -148,12 +148,12 @@ instance SerialiseAsRawBytes (SigningKey PaymentKey) where
       (Crypto.rawDeserialiseSignKeyDSIGN bs)
 
 instance SerialiseAsBech32 (VerificationKey PaymentKey) where
-  bech32PrefixFor _ = "addr_vk"
-  bech32PrefixesPermitted _ = ["addr_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "addr_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["addr_vk"]
 
 instance SerialiseAsBech32 (SigningKey PaymentKey) where
-  bech32PrefixFor _ = "addr_sk"
-  bech32PrefixesPermitted _ = ["addr_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "addr_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["addr_sk"]
 
 newtype instance Hash PaymentKey
   = PaymentKeyHash {unPaymentKeyHash :: Shelley.KeyHash Shelley.Payment}
@@ -298,12 +298,12 @@ instance SerialiseAsRawBytes (SigningKey PaymentExtendedKey) where
       (PaymentExtendedSigningKey <$> Crypto.HD.xprv bs)
 
 instance SerialiseAsBech32 (VerificationKey PaymentExtendedKey) where
-  bech32PrefixFor _ = "addr_xvk"
-  bech32PrefixesPermitted _ = ["addr_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "addr_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["addr_xvk"]
 
 instance SerialiseAsBech32 (SigningKey PaymentExtendedKey) where
-  bech32PrefixFor _ = "addr_xsk"
-  bech32PrefixesPermitted _ = ["addr_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "addr_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["addr_xsk"]
 
 newtype instance Hash PaymentExtendedKey
   = PaymentExtendedKeyHash
@@ -401,12 +401,12 @@ instance SerialiseAsRawBytes (SigningKey StakeKey) where
       StakeSigningKey <$> Crypto.rawDeserialiseSignKeyDSIGN bs
 
 instance SerialiseAsBech32 (VerificationKey StakeKey) where
-  bech32PrefixFor _ = "stake_vk"
-  bech32PrefixesPermitted _ = ["stake_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "stake_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["stake_vk"]
 
 instance SerialiseAsBech32 (SigningKey StakeKey) where
-  bech32PrefixFor _ = "stake_sk"
-  bech32PrefixesPermitted _ = ["stake_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "stake_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["stake_sk"]
 
 newtype instance Hash StakeKey
   = StakeKeyHash {unStakeKeyHash :: Shelley.KeyHash Shelley.Staking}
@@ -549,12 +549,12 @@ instance SerialiseAsRawBytes (SigningKey StakeExtendedKey) where
       $ StakeExtendedSigningKey <$> Crypto.HD.xprv bs
 
 instance SerialiseAsBech32 (VerificationKey StakeExtendedKey) where
-  bech32PrefixFor _ = "stake_xvk"
-  bech32PrefixesPermitted _ = ["stake_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "stake_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["stake_xvk"]
 
 instance SerialiseAsBech32 (SigningKey StakeExtendedKey) where
-  bech32PrefixFor _ = "stake_xsk"
-  bech32PrefixesPermitted _ = ["stake_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "stake_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["stake_xsk"]
 
 newtype instance Hash StakeExtendedKey
   = StakeExtendedKeyHash {unStakeExtendedKeyHash :: Shelley.KeyHash Shelley.Staking}
@@ -785,16 +785,16 @@ instance CastVerificationKeyRole CommitteeHotKey PaymentKey where
     PaymentVerificationKey (Shelley.VKey vk)
 
 instance SerialiseAsBech32 (Hash CommitteeHotKey) where
-  bech32PrefixFor _ = "cc_hot"
-  bech32PrefixesPermitted _ = ["cc_hot"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_hot"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_hot"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeHotKey) where
-  bech32PrefixFor _ = "cc_hot_vk"
-  bech32PrefixesPermitted _ = ["cc_hot_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_hot_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_hot_vk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeHotKey) where
-  bech32PrefixFor _ = "cc_hot_sk"
-  bech32PrefixesPermitted _ = ["cc_hot_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_hot_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_hot_sk"]
 
 --
 -- Constitutional Committee Cold Keys
@@ -896,16 +896,16 @@ instance CastVerificationKeyRole CommitteeColdKey PaymentKey where
     PaymentVerificationKey (Shelley.VKey vk)
 
 instance SerialiseAsBech32 (Hash CommitteeColdKey) where
-  bech32PrefixFor _ = "cc_cold"
-  bech32PrefixesPermitted _ = ["cc_cold"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_cold"]
 
 instance SerialiseAsBech32 (VerificationKey CommitteeColdKey) where
-  bech32PrefixFor _ = "cc_cold_vk"
-  bech32PrefixesPermitted _ = ["cc_cold_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_cold_vk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeColdKey) where
-  bech32PrefixFor _ = "cc_cold_sk"
-  bech32PrefixesPermitted _ = ["cc_cold_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_cold_sk"]
 
 ---
 --- Committee cold extended keys
@@ -1023,12 +1023,12 @@ instance HasTextEnvelope (SigningKey CommitteeColdExtendedKey) where
   textEnvelopeType _ = "ConstitutionalCommitteeColdExtendedSigningKey_ed25519_bip32"
 
 instance SerialiseAsBech32 (VerificationKey CommitteeColdExtendedKey) where
-  bech32PrefixFor _ = "cc_cold_xvk"
-  bech32PrefixesPermitted _ = ["cc_cold_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_cold_xvk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeColdExtendedKey) where
-  bech32PrefixFor _ = "cc_cold_xsk"
-  bech32PrefixesPermitted _ = ["cc_cold_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_cold_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_cold_xsk"]
 
 instance CastVerificationKeyRole CommitteeColdExtendedKey CommitteeColdKey where
   castVerificationKey (CommitteeColdExtendedVerificationKey vk) =
@@ -1158,12 +1158,12 @@ instance HasTextEnvelope (SigningKey CommitteeHotExtendedKey) where
   textEnvelopeType _ = "ConstitutionalCommitteeHotExtendedSigningKey_ed25519_bip32"
 
 instance SerialiseAsBech32 (VerificationKey CommitteeHotExtendedKey) where
-  bech32PrefixFor _ = "cc_hot_xvk"
-  bech32PrefixesPermitted _ = ["cc_hot_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_hot_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_hot_xvk"]
 
 instance SerialiseAsBech32 (SigningKey CommitteeHotExtendedKey) where
-  bech32PrefixFor _ = "cc_hot_xsk"
-  bech32PrefixesPermitted _ = ["cc_hot_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "cc_hot_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["cc_hot_xsk"]
 
 instance CastVerificationKeyRole CommitteeHotExtendedKey CommitteeHotKey where
   castVerificationKey (CommitteeHotExtendedVerificationKey vk) =
@@ -1752,12 +1752,12 @@ instance SerialiseAsRawBytes (SigningKey StakePoolKey) where
       (Crypto.rawDeserialiseSignKeyDSIGN bs)
 
 instance SerialiseAsBech32 (VerificationKey StakePoolKey) where
-  bech32PrefixFor _ = "pool_vk"
-  bech32PrefixesPermitted _ = ["pool_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool_vk"]
 
 instance SerialiseAsBech32 (SigningKey StakePoolKey) where
-  bech32PrefixFor _ = "pool_sk"
-  bech32PrefixesPermitted _ = ["pool_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool_sk"]
 
 newtype instance Hash StakePoolKey
   = StakePoolKeyHash {unStakePoolKeyHash :: Shelley.KeyHash Shelley.StakePool}
@@ -1776,8 +1776,8 @@ instance SerialiseAsRawBytes (Hash StakePoolKey) where
       (StakePoolKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs)
 
 instance SerialiseAsBech32 (Hash StakePoolKey) where
-  bech32PrefixFor _ = "pool"
-  bech32PrefixesPermitted _ = ["pool"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool"]
 
 instance ToJSON (Hash StakePoolKey) where
   toJSON = toJSON . serialiseToBech32
@@ -1928,8 +1928,8 @@ instance SerialiseAsRawBytes (Hash StakePoolExtendedKey) where
       (StakePoolExtendedKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs)
 
 instance SerialiseAsBech32 (Hash StakePoolExtendedKey) where
-  bech32PrefixFor _ = "pool_xvkh"
-  bech32PrefixesPermitted _ = ["pool_xvkh"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool_xvkh"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool_xvkh"]
 
 instance HasTextEnvelope (VerificationKey StakePoolExtendedKey) where
   textEnvelopeType _ = "StakePoolExtendedVerificationKey_ed25519_bip32"
@@ -1938,12 +1938,12 @@ instance HasTextEnvelope (SigningKey StakePoolExtendedKey) where
   textEnvelopeType _ = "StakePoolExtendedSigningKey_ed25519_bip32"
 
 instance SerialiseAsBech32 (VerificationKey StakePoolExtendedKey) where
-  bech32PrefixFor _ = "pool_xvk"
-  bech32PrefixesPermitted _ = ["pool_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool_xvk"]
 
 instance SerialiseAsBech32 (SigningKey StakePoolExtendedKey) where
-  bech32PrefixFor _ = "pool_xsk"
-  bech32PrefixesPermitted _ = ["pool_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "pool_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["pool_xsk"]
 
 instance ToJSON (Hash StakePoolExtendedKey) where
   toJSON = toJSON . serialiseToBech32
@@ -2038,12 +2038,12 @@ instance SerialiseAsRawBytes (SigningKey DRepKey) where
       (Crypto.rawDeserialiseSignKeyDSIGN bs)
 
 instance SerialiseAsBech32 (VerificationKey DRepKey) where
-  bech32PrefixFor _ = "drep_vk"
-  bech32PrefixesPermitted _ = ["drep_vk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "drep_vk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["drep_vk"]
 
 instance SerialiseAsBech32 (SigningKey DRepKey) where
-  bech32PrefixFor _ = "drep_sk"
-  bech32PrefixesPermitted _ = ["drep_sk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "drep_sk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["drep_sk"]
 
 newtype instance Hash DRepKey
   = DRepKeyHash {unDRepKeyHash :: Shelley.KeyHash Shelley.DRepRole}
@@ -2062,8 +2062,8 @@ instance SerialiseAsRawBytes (Hash DRepKey) where
       (DRepKeyHash . Shelley.KeyHash <$> Crypto.hashFromBytes bs)
 
 instance SerialiseAsBech32 (Hash DRepKey) where
-  bech32PrefixFor _ = "drep"
-  bech32PrefixesPermitted _ = ["drep"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "drep"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["drep"]
 
 instance ToJSON (Hash DRepKey) where
   toJSON = toJSON . serialiseToBech32
@@ -2215,12 +2215,12 @@ instance HasTextEnvelope (SigningKey DRepExtendedKey) where
   textEnvelopeType _ = "DRepExtendedSigningKey_ed25519_bip32"
 
 instance SerialiseAsBech32 (VerificationKey DRepExtendedKey) where
-  bech32PrefixFor _ = "drep_xvk"
-  bech32PrefixesPermitted _ = ["drep_xvk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "drep_xvk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["drep_xvk"]
 
 instance SerialiseAsBech32 (SigningKey DRepExtendedKey) where
-  bech32PrefixFor _ = "drep_xsk"
-  bech32PrefixesPermitted _ = ["drep_xsk"]
+  bech32PrefixFor _ = unsafeHumanReadablePartFromText "drep_xsk"
+  bech32PrefixesPermitted _ = unsafeHumanReadablePartFromText <$> ["drep_xsk"]
 
 instance CastVerificationKeyRole DRepExtendedKey DRepKey where
   castVerificationKey (DRepExtendedVerificationKey vk) =

--- a/cardano-api/src/Cardano/Api/Internal/Pretty.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Pretty.hs
@@ -8,6 +8,7 @@ module Cardano.Api.Internal.Pretty
   , docToLazyText
   , docToText
   , docToString
+  , prettyShow
   , pshow
   , prettyException
   , hsep
@@ -40,6 +41,10 @@ type Ann = AnsiStyle
 
 docToString :: Doc AnsiStyle -> String
 docToString = show
+
+-- | Render a 'Pretty' to a 'String'
+prettyShow :: Pretty a => a -> String
+prettyShow = docToString . pretty
 
 docToLazyText :: Doc AnsiStyle -> TextLazy.Text
 docToLazyText = renderLazy . layoutPretty defaultLayoutOptions

--- a/cardano-api/src/Cardano/Api/Internal/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ProtocolParameters.hs
@@ -151,7 +151,6 @@ import Data.Int (Int64)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe.Strict (StrictMaybe (..))
-import Data.String (IsString)
 import Data.Text (Text)
 import Data.Word
 import GHC.Exts (IsList (..))
@@ -892,7 +891,7 @@ instance FromCBOR ProtocolParametersUpdate where
 
 newtype PraosNonce = PraosNonce {unPraosNonce :: Hash.Hash HASH ByteString}
   deriving stock (Eq, Ord, Generic)
-  deriving (Show, IsString) via UsingRawBytesHex PraosNonce
+  deriving (Show, Pretty) via UsingRawBytesHex PraosNonce
   deriving (ToJSON, FromJSON) via UsingRawBytesHex PraosNonce
   deriving (ToCBOR, FromCBOR) via UsingRawBytes PraosNonce
 

--- a/cardano-api/src/Cardano/Api/Internal/ScriptData.hs
+++ b/cardano-api/src/Cardano/Api/Internal/ScriptData.hs
@@ -16,6 +16,7 @@ module Cardano.Api.Internal.ScriptData
   , getScriptData
   , unsafeHashableScriptData
   , ScriptData (..)
+  , parseScriptDataHash
 
     -- * Validating metadata
   , validateScriptData
@@ -56,6 +57,7 @@ import Cardano.Api.Internal.SerialiseJSON
 import Cardano.Api.Internal.SerialiseRaw
 import Cardano.Api.Internal.SerialiseUsing
 import Cardano.Api.Internal.TxMetadata (pBytes, pSigned, parseAll)
+import Cardano.Api.Parser.Text qualified as P
 
 import Cardano.Binary qualified as CBOR
 import Cardano.Crypto.Hash.Class qualified as Crypto
@@ -84,7 +86,6 @@ import Data.Either.Combinators
 import Data.List qualified as List
 import Data.Maybe (fromMaybe)
 import Data.Scientific qualified as Scientific
-import Data.String (IsString)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
@@ -156,7 +157,7 @@ instance HasTypeProxy ScriptData where
 newtype instance Hash ScriptData
   = ScriptDataHash Plutus.DataHash
   deriving stock (Eq, Ord)
-  deriving (Show, IsString) via UsingRawBytesHex (Hash ScriptData)
+  deriving (Show, Pretty) via UsingRawBytesHex (Hash ScriptData)
   deriving (ToJSON, FromJSON) via UsingRawBytesHex (Hash ScriptData)
   deriving (ToJSONKey, FromJSONKey) via UsingRawBytesHex (Hash ScriptData)
 
@@ -180,6 +181,10 @@ instance ToCBOR ScriptData where
 instance FromCBOR ScriptData where
   fromCBOR :: CBOR.Decoder s ScriptData
   fromCBOR = fromPlutusData <$> decode @PlutusAPI.Data
+
+-- | Parser for hex representation
+parseScriptDataHash :: P.Parser (Hash ScriptData)
+parseScriptDataHash = parseRawBytesHex
 
 hashScriptDataBytes :: HashableScriptData -> Hash ScriptData
 hashScriptDataBytes =

--- a/cardano-api/src/Cardano/Api/Internal/SerialiseRaw.hs
+++ b/cardano-api/src/Cardano/Api/Internal/SerialiseRaw.hs
@@ -5,33 +5,29 @@
 
 -- | Raw binary serialisation
 module Cardano.Api.Internal.SerialiseRaw
-  ( RawBytesHexError (..)
-  , SerialiseAsRawBytes (..)
-  , SerialiseAsRawBytesError (..)
+  ( SerialiseAsRawBytes (..)
   , serialiseToRawBytesHex
   , deserialiseFromRawBytesHex
   , serialiseToRawBytesHexText
+  , parseRawBytesHex
+  , RawBytesHexError (..)
+  , SerialiseAsRawBytesError (..)
   )
 where
 
-import Cardano.Api.Internal.Error (Error, prettyError)
+import Cardano.Api.Internal.Error (Error, failEitherError, prettyError)
 import Cardano.Api.Internal.HasTypeProxy
 import Cardano.Api.Internal.Pretty
+import Cardano.Api.Parser.Text qualified as P
 
 import Data.Bifunctor (Bifunctor (..))
-import Data.ByteString (ByteString)
 import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 as BSC
 import Data.Data (typeRep)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Typeable (TypeRep, Typeable)
-
-newtype SerialiseAsRawBytesError = SerialiseAsRawBytesError
-  -- TODO We can do better than use String to carry the error message
-  { unSerialiseAsRawBytesError :: String
-  }
-  deriving (Eq, Show)
 
 class (HasTypeProxy a, Typeable a) => SerialiseAsRawBytes a where
   serialiseToRawBytes :: a -> ByteString
@@ -44,11 +40,29 @@ serialiseToRawBytesHex = Base16.encode . serialiseToRawBytes
 serialiseToRawBytesHexText :: SerialiseAsRawBytes a => a -> Text
 serialiseToRawBytesHexText = Text.decodeUtf8 . serialiseToRawBytesHex
 
+deserialiseFromRawBytesHex
+  :: forall a
+   . SerialiseAsRawBytes a
+  => ByteString -> Either RawBytesHexError a
+deserialiseFromRawBytesHex hex = do
+  let type' = typeRep $ asType @a
+  raw <- first (RawBytesHexErrorBase16DecodeFail hex type') $ Base16.decode hex
+  first (RawBytesHexErrorRawBytesDecodeFail hex type') $
+    deserialiseFromRawBytes asType raw
+
+-- | Parse hex representation of a value
+parseRawBytesHex :: SerialiseAsRawBytes a => P.Parser a
+parseRawBytesHex = do
+  input <- P.many P.hexDigit
+  failEitherError . deserialiseFromRawBytesHex $ BSC.pack input
+
 -- | The errors that the pure 'SerialiseAsRawBytes' parsing\/decoding functions can return.
 data RawBytesHexError
   = RawBytesHexErrorBase16DecodeFail
       ByteString
       -- ^ original input
+      TypeRep
+      -- ^ expected type
       String
       -- ^ error message
   | RawBytesHexErrorRawBytesDecodeFail
@@ -60,26 +74,24 @@ data RawBytesHexError
       -- ^ error message
   deriving Show
 
+newtype SerialiseAsRawBytesError = SerialiseAsRawBytesError
+  -- TODO We can do better than use String to carry the error message
+  { unSerialiseAsRawBytesError :: String
+  }
+  deriving (Eq, Show)
+
 instance Error RawBytesHexError where
   prettyError = \case
-    RawBytesHexErrorBase16DecodeFail input message ->
-      "Expected Base16-encoded bytestring, but got "
+    RawBytesHexErrorBase16DecodeFail input typeRep' message ->
+      "Failed to deserialise "
+        <> pshow typeRep'
+        <> ". Expected Base16-encoded bytestring, but got "
         <> pretty (toText input)
         <> "; "
         <> pretty message
     RawBytesHexErrorRawBytesDecodeFail input typeRep' (SerialiseAsRawBytesError e) ->
-      "Failed to deserialise " <> pretty (toText input) <> " as " <> pshow typeRep' <> ". " <> pretty e
+      "Failed to deserialise " <> pretty (toText input) <> " as " <> pshow typeRep' <> ": " <> pretty e
    where
     toText bs = case Text.decodeUtf8' bs of
       Right t -> Text.unpack t
       Left _ -> show bs
-
-deserialiseFromRawBytesHex
-  :: forall a
-   . SerialiseAsRawBytes a
-  => ByteString -> Either RawBytesHexError a
-deserialiseFromRawBytesHex hex = do
-  raw <- first (RawBytesHexErrorBase16DecodeFail hex) $ Base16.decode hex
-  case deserialiseFromRawBytes asType raw of
-    Left e -> Left $ RawBytesHexErrorRawBytesDecodeFail hex (typeRep $ asType @a) e
-    Right a -> Right a

--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -193,10 +193,9 @@ module Cardano.Api.Internal.Tx.Body
     -- @
 
     -- * Contents
-    parseTxId
 
     -- ** Transaction bodies
-  , TxBody (.., TxBody)
+    TxBody (.., TxBody)
   , createTransactionBody
   , createAndValidateTransactionBody
   , TxBodyContent (..)
@@ -270,15 +269,18 @@ module Cardano.Api.Internal.Tx.Body
 
     -- ** Transaction Ids
   , TxId (..)
+  , parseTxId
   , getTxId
   , getTxIdByron
   , getTxIdShelley
 
     -- ** Transaction inputs
   , TxIn (..)
+  , parseTxIn
   , TxIns
   , indexTxIns
   , TxIx (..)
+  , parseTxIx
   , genesisUTxOPseudoTxIn
   , getReferenceInputsSizeForTxIds
 
@@ -294,7 +296,6 @@ module Cardano.Api.Internal.Tx.Body
   , prettyRenderTxOut
   , txOutValueToLovelace
   , txOutValueToValue
-  , parseHash
   , TxOutInAnyEra (..)
   , txOutInAnyEra
 

--- a/cardano-api/src/Cardano/Api/Parser/Text.hs
+++ b/cardano-api/src/Cardano/Api/Parser/Text.hs
@@ -1,0 +1,68 @@
+module Cardano.Api.Parser.Text
+  ( module Cardano.Api.Parser.Text
+  , module Control.Applicative
+  , module Data.Functor
+  , module Text.Parsec
+  , module Text.Parsec.Char
+  , module Text.Parsec.Expr
+  , module Text.Parsec.Text
+  , module Text.ParserCombinators.Parsec.Combinator
+  , module Data.Char
+  )
+where
+
+import Cardano.Api.Internal.Utils
+
+import Control.Applicative
+import Data.Bifunctor (first)
+import Data.Char (digitToInt)
+import Data.Foldable qualified as F
+import Data.Functor
+import Data.Text (Text)
+import Data.Word (Word64)
+import Text.Parsec hiding (many, optional, runParser, (<|>))
+import Text.Parsec.Char
+import Text.Parsec.Error (errorMessages, showErrorMessages)
+import Text.Parsec.Expr (Assoc (..), Operator (..), buildExpressionParser)
+import Text.Parsec.Text (Parser)
+import Text.ParserCombinators.Parsec.Combinator (many1)
+
+-- | Run parser
+runParser
+  :: Parser a
+  -> Text
+  -- ^ input text
+  -> Either String a
+runParser parser input =
+  first formatParsecError $
+    parse (parser <* eof) "" input
+ where
+  formatParsecError :: ParseError -> String
+  formatParsecError err =
+    showErrorMessages
+      "or"
+      "unknown parse error"
+      "expecting"
+      "unexpected"
+      "end of input"
+      $ errorMessages err
+
+-- | Run parser in 'MonadFail'
+runParserFail :: MonadFail m => Parser a -> Text -> m a
+runParserFail p = failEither . runParser p
+
+-- | Word64 parser.
+parseWord64 :: Parser Integer
+parseWord64 = do
+  i <- parseDecimal
+  if i > fromIntegral (maxBound :: Word64)
+    then
+      fail $
+        "expecting word64, but the number exceeds the max bound: " <> show i
+    else return i
+
+-- | Non-negative decimal numbers parser
+parseDecimal :: Parser Integer
+parseDecimal = do
+  digits <- many1 digit
+  return $! F.foldl' (\x d -> 10 * x + toInteger (digitToInt d)) 0 digits

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Script.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Script.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Golden.Cardano.Api.Script
@@ -14,11 +15,14 @@ module Test.Golden.Cardano.Api.Script
 where
 
 import Cardano.Api
+import Cardano.Api.Parser.Text qualified as P
 import Cardano.Api.Shelley
 
 import Cardano.Ledger.Api.Era qualified as L
 
 import Data.Aeson
+import Data.Text (Text)
+import GHC.Stack
 import System.FilePath ((</>))
 
 import Test.Gen.Cardano.Api.Typed
@@ -34,48 +38,48 @@ import Test.Tasty.Hedgehog (testProperty)
 exampleSimpleScriptV1_All :: SimpleScript
 exampleSimpleScriptV1_All =
   RequireAllOf
-    [ RequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
-    , RequireSignature "a687dcc24e00dd3caafbeb5e68f97ca8ef269cb6fe971345eb951756"
-    , RequireSignature "0bd1d702b2e6188fe0857a6dc7ffb0675229bab58c86638ffa87ed6d"
-    , RequireSignature "dd0044a26cf7d4491ecea720fda11afb59d5725b53afa605fdf695e6"
-    , RequireSignature "cf223afe150cc8e89f11edaacbbd55b011ba44fbedef66fbd37d8c9d"
-    , RequireSignature "372643e7ef4b41fd2649ada30a89d35cb90b7c14cb5de252e6ce6cb7"
-    , RequireSignature "aa453dc184c5037d60e3fbbadb023f4a41bac112f249b76be9bb37ad"
-    , RequireSignature "6b732c60c267bab894854d6dd57a04a94e603fcc4c36274c9ed75952"
+    [ mkRequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
+    , mkRequireSignature "a687dcc24e00dd3caafbeb5e68f97ca8ef269cb6fe971345eb951756"
+    , mkRequireSignature "0bd1d702b2e6188fe0857a6dc7ffb0675229bab58c86638ffa87ed6d"
+    , mkRequireSignature "dd0044a26cf7d4491ecea720fda11afb59d5725b53afa605fdf695e6"
+    , mkRequireSignature "cf223afe150cc8e89f11edaacbbd55b011ba44fbedef66fbd37d8c9d"
+    , mkRequireSignature "372643e7ef4b41fd2649ada30a89d35cb90b7c14cb5de252e6ce6cb7"
+    , mkRequireSignature "aa453dc184c5037d60e3fbbadb023f4a41bac112f249b76be9bb37ad"
+    , mkRequireSignature "6b732c60c267bab894854d6dd57a04a94e603fcc4c36274c9ed75952"
     ]
 
 exampleSimpleScriptV1_Any :: SimpleScript
 exampleSimpleScriptV1_Any =
   RequireAnyOf
-    [ RequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
-    , RequireSignature "4d780ed1bfc88cbd4da3f48de91fe728c3530d662564bf5a284b5321"
-    , RequireSignature "3a94d6d4e786a3f5d439939cafc0536f6abc324fb8404084d6034bf8"
-    , RequireSignature "b12e094d1db7c0fba5121f22db193d0060efed8be43654f861bb68ae"
-    , RequireSignature "9be49d56442b4b8b16cab4e43e238bbdefc6c803d554c82fcd5facc3"
-    , RequireSignature "622be5fab3b5c3f371a50a535e4d3349c942a98cecee93b24e2fd11d"
+    [ mkRequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
+    , mkRequireSignature "4d780ed1bfc88cbd4da3f48de91fe728c3530d662564bf5a284b5321"
+    , mkRequireSignature "3a94d6d4e786a3f5d439939cafc0536f6abc324fb8404084d6034bf8"
+    , mkRequireSignature "b12e094d1db7c0fba5121f22db193d0060efed8be43654f861bb68ae"
+    , mkRequireSignature "9be49d56442b4b8b16cab4e43e238bbdefc6c803d554c82fcd5facc3"
+    , mkRequireSignature "622be5fab3b5c3f371a50a535e4d3349c942a98cecee93b24e2fd11d"
     ]
 
 exampleSimpleScriptV1_MofN :: SimpleScript
 exampleSimpleScriptV1_MofN =
   RequireMOf
     2
-    [ RequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
-    , RequireSignature "f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614"
-    , RequireSignature "b275b08c999097247f7c17e77007c7010cd19f20cc086ad99d398538"
-    , RequireSignature "686024aecb5884d73a11b9ae4e63931112ba737e878d74638b78513a"
+    [ mkRequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
+    , mkRequireSignature "f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614"
+    , mkRequireSignature "b275b08c999097247f7c17e77007c7010cd19f20cc086ad99d398538"
+    , mkRequireSignature "686024aecb5884d73a11b9ae4e63931112ba737e878d74638b78513a"
     ]
 
 exampleSimpleScriptV2_All :: SimpleScript
 exampleSimpleScriptV2_All =
   RequireAllOf
-    [ RequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
+    [ mkRequireSignature "e09d36c79dec9bd1b3d9e152247701cd0bb860b5ebfd1de8abb6735a"
     , RequireTimeBefore (SlotNo 42)
     ]
 
 exampleSimpleScriptV2_Any :: SimpleScript
 exampleSimpleScriptV2_Any =
   RequireAnyOf
-    [ RequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
+    [ mkRequireSignature "d92b712d1882c3b0f75b6f677e0b2cbef4fbc8b8121bb9dde324ff09"
     , RequireTimeAfter (SlotNo 42)
     ]
 
@@ -83,8 +87,8 @@ exampleSimpleScriptV2_MofN :: SimpleScript
 exampleSimpleScriptV2_MofN =
   RequireMOf
     1
-    [ RequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
-    , RequireSignature "f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614"
+    [ mkRequireSignature "2f3d4cf10d0471a1db9f2d2907de867968c27bca6272f062cd1c2413"
+    , mkRequireSignature "f856c0c5839bab22673747d53f1ae9eed84afafb085f086e8e988614"
     , RequireTimeBefore (SlotNo 42)
     ]
 
@@ -138,3 +142,8 @@ test_roundtrip_HashableScriptData_JSON =
   testProperty "roundtrip HashableScriptData" . H.property $ do
     sData <- H.forAll genHashableScriptData
     H.tripping sData scriptDataToJsonDetailedSchema scriptDataFromJsonDetailedSchema
+
+mkRequireSignature :: HasCallStack => Text -> SimpleScript
+mkRequireSignature t =
+  RequireSignature . either error id $
+    P.runParser parseRawBytesHex t

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Value.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Value.hs
@@ -17,6 +17,7 @@ import Cardano.Api
   )
 import Cardano.Api qualified as Api
 import Cardano.Api.Internal.Eras
+import Cardano.Api.Parser.Text qualified as P
 
 import Prelude
 
@@ -25,7 +26,6 @@ import Data.List (groupBy, sort)
 import Data.Map.Strict qualified as Map
 import Data.Text qualified as Text
 import GHC.Exts (IsList (..))
-import Text.Parsec qualified as Parsec (parse)
 
 import Test.Gen.Cardano.Api.Typed
 
@@ -43,7 +43,7 @@ hprop_roundtrip_txout_Value_parse_render =
     tripping
       value
       renderValue
-      (Parsec.parse parseTxOutMultiAssetValue "" . Text.unpack)
+      (P.runParser parseTxOutMultiAssetValue)
 
 hprop_roundtrip_txout_Value_parse_renderPretty :: Property
 hprop_roundtrip_txout_Value_parse_renderPretty =
@@ -52,7 +52,7 @@ hprop_roundtrip_txout_Value_parse_renderPretty =
     tripping
       value
       renderValuePretty
-      (Parsec.parse parseTxOutMultiAssetValue "" . Text.unpack)
+      (P.runParser parseTxOutMultiAssetValue)
 
 hprop_roundtrip_mint_Value_parse_render :: Property
 hprop_roundtrip_mint_Value_parse_render =
@@ -61,7 +61,7 @@ hprop_roundtrip_mint_Value_parse_render =
     tripping
       value
       renderMultiAsset
-      (Parsec.parse (parseMintingMultiAssetValue currentEra) "" . Text.unpack)
+      (P.runParser $ parseMintingMultiAssetValue currentEra)
 
 hprop_roundtrip_mint_Value_parse_renderPretty :: Property
 hprop_roundtrip_mint_Value_parse_renderPretty =
@@ -70,7 +70,7 @@ hprop_roundtrip_mint_Value_parse_renderPretty =
     tripping
       value
       renderMultiAssetPretty
-      (Parsec.parse (parseMintingMultiAssetValue currentEra) "" . Text.unpack)
+      (P.runParser (parseMintingMultiAssetValue currentEra))
 
 hprop_goldenValue_1_lovelace :: Property
 hprop_goldenValue_1_lovelace =
@@ -83,8 +83,10 @@ hprop_goldenValue_1_lovelace =
 hprop_goldenValue1 :: Property
 hprop_goldenValue1 =
   H.propertyOnce $ do
-    let policyId = Api.PolicyId "a0000000000000000000000000000000000000000000000000000000"
-        assetName = Api.AssetName "asset1"
+    policyId <-
+      H.leftFail $
+        P.runParser Api.parsePolicyId "a0000000000000000000000000000000000000000000000000000000"
+    let assetName = Api.UnsafeAssetName "asset1"
         valueList = [(Api.AssetId policyId assetName, 1)]
         value = Text.unpack $ Api.renderValuePretty $ fromList valueList
 

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -233,7 +233,10 @@ test_RawBytesHexError =
   testAllErrorMessages_
     "Cardano.Api.SerialiseRaw"
     "RawBytesHexError"
-    [ ("RawBytesHexErrorBase16DecodeFail", RawBytesHexErrorBase16DecodeFail bytestring string)
+    [
+      ( "RawBytesHexErrorBase16DecodeFail"
+      , RawBytesHexErrorBase16DecodeFail bytestring (typeRep AsTxId) string
+      )
     ,
       ( "RawBytesHexErrorRawBytesDecodeFail"
       , RawBytesHexErrorRawBytesDecodeFail

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.SerialiseRaw.RawBytesHexError/RawBytesHexErrorBase16DecodeFail.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.SerialiseRaw.RawBytesHexError/RawBytesHexErrorBase16DecodeFail.txt
@@ -1,1 +1,1 @@
-Expected Base16-encoded bytestring, but got <bytestring>; <string>
+Failed to deserialise TxId. Expected Base16-encoded bytestring, but got <bytestring>; <string>

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.SerialiseRaw.RawBytesHexError/RawBytesHexErrorRawBytesDecodeFail.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.SerialiseRaw.RawBytesHexError/RawBytesHexErrorRawBytesDecodeFail.txt
@@ -1,1 +1,1 @@
-Failed to deserialise <bytestring> as VerificationKey GenesisKey. <string>
+Failed to deserialise <bytestring> as VerificationKey GenesisKey: <string>

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Body.TxBodyError/TxBodyInIxOverflow.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Body.TxBodyError/TxBodyInIxOverflow.txt
@@ -1,1 +1,1 @@
-Transaction input index is too big, acceptable value is up to 2^32-1, in input TxIn "210c0a4bb6391baf606843e67863d1474cc462374ab12c42d55f78a0b55b56e0" (TxIx 1)
+Transaction input index is too big, acceptable value is up to 2^32-1, in input 210c0a4bb6391baf606843e67863d1474cc462374ab12c42d55f78a0b55b56e0#1

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Orphans.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Orphans.hs
@@ -1,18 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Api.Orphans () where
 
 import Cardano.Api.Shelley
-
-import Cardano.Ledger.Alonzo.Core qualified as L
-import Cardano.Ledger.Mary.Value qualified as L
-
-import Data.String (IsString (..))
 
 import Test.Cardano.Crypto.Orphans ()
 
@@ -35,7 +29,3 @@ deriving instance Eq (SigningKey GenesisUTxOKey)
 deriving instance Eq (SigningKey KesKey)
 
 deriving instance Eq (SigningKey VrfKey)
-
-deriving instance IsString L.AssetName
-
-deriving instance IsString (L.KeyHash r)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -20,6 +20,7 @@ import Cardano.Api.Internal.Fees
 import Cardano.Api.Internal.Script
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Ledger.Lens qualified as L
+import Cardano.Api.Parser.Text qualified as P
 import Cardano.Api.Shelley
   ( LedgerProtocolParameters (..)
   , collectTxBodyScriptWitnessRequirements
@@ -28,6 +29,7 @@ import Cardano.Api.Shelley
 
 import Cardano.Ledger.Alonzo.Core qualified as L
 import Cardano.Ledger.Coin qualified as L
+import Cardano.Ledger.Credential qualified as L
 import Cardano.Ledger.Mary.Value qualified as L
 import Cardano.Ledger.Val ((<->))
 import Cardano.Ledger.Val qualified as L
@@ -36,6 +38,7 @@ import Cardano.Slotting.Slot qualified as CS
 import Cardano.Slotting.Time qualified as CS
 
 import Control.Monad
+import Control.Monad.Trans.Fail (errorFail)
 import Data.Aeson (eitherDecodeStrict)
 import Data.Bifunctor (first)
 import Data.ByteString qualified as B
@@ -44,6 +47,7 @@ import Data.Function
 import Data.Map.Strict qualified as M
 import Data.Maybe
 import Data.Ratio ((%))
+import Data.Text (Text)
 import Data.Time.Format qualified as DT
 import GHC.Exts (IsList (..))
 import GHC.Stack
@@ -173,15 +177,13 @@ prop_make_transaction_body_autobalance_no_change = H.propertyOnce $ do
           (ShelleyAddressInEra sbe)
           ( ShelleyAddress
               L.Testnet
-              (L.KeyHashObj "ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+              (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
               L.StakeRefNull
           )
   let utxos =
         UTxO
           [
-            ( TxIn
-                "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53"
-                (TxIx 0)
+            ( mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
             , TxOut
                 address
                 ( TxOutValueShelleyBased
@@ -263,7 +265,7 @@ prop_make_transaction_body_autobalance_return_correct_fee_for_multi_asset = H.pr
   let txMint =
         TxMintValue
           meo
-          [(policyId', ([("eeee", 1)], BuildTxWith plutusWitness))]
+          [(policyId', ([(UnsafeAssetName "eeee", 1)], BuildTxWith plutusWitness))]
 
   -- tx body content without an asset in TxOut
   let content =
@@ -426,7 +428,7 @@ prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $
   let txMint =
         TxMintValue
           meo
-          [(policyId', ([("eeee", 1)], BuildTxWith plutusWitness))]
+          [(policyId', ([(UnsafeAssetName "eeee", 1)], BuildTxWith plutusWitness))]
 
   let content =
         defaultTxBodyContent sbe
@@ -467,7 +469,7 @@ prop_make_transaction_body_autobalance_multi_asset_collateral = H.propertyOnce $
   TxReturnCollateral _ (TxOut _ txOutValue _ _) <- H.noteShow $ txReturnCollateral balancedContent
   let assets = [a | a@(AssetId _ _, _) <- toList $ txOutValueToValue txOutValue]
   H.note_ "Check that all assets from UTXO, from the collateral txin, are in the return collateral."
-  [(AssetId policyId' "eeee", 1)] === assets
+  [(AssetId policyId' $ UnsafeAssetName "eeee", 1)] === assets
 
 -- | Implements collateral validation from Babbage spec, from
 -- https://github.com/IntersectMBO/cardano-ledger/releases, babbage-ledger.pdf, Figure 2.
@@ -574,7 +576,7 @@ prop_ensure_gov_actions_are_preserved_by_autobalance = H.propertyOnce $ do
           , L.pProcReturnAddr =
               L.RewardAccount
                 { L.raNetwork = L.Testnet
-                , L.raCredential = L.KeyHashObj "0b1b872f7953bccfc4245f3282b3363f3d19e9e001a5c41e307363d7"
+                , L.raCredential = mkCredential "keyHash-0b1b872f7953bccfc4245f3282b3363f3d19e9e001a5c41e307363d7"
                 }
           , L.pProcGovAction = L.InfoAction
           , L.pProcAnchor = anchor
@@ -621,15 +623,13 @@ mkSimpleUTxOs :: ShelleyBasedEra ConwayEra -> UTxO ConwayEra
 mkSimpleUTxOs sbe =
   UTxO
     [
-      ( TxIn
-          "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53"
-          (TxIx 0)
+      ( mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
       , TxOut
           ( AddressInEra
               (ShelleyAddressInEra sbe)
               ( ShelleyAddress
                   L.Testnet
-                  (L.KeyHashObj "ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+                  (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
                   L.StakeRefNull
               )
           )
@@ -685,15 +685,13 @@ mkUtxos beo mScriptHash = babbageEraOnwardsConstraints beo $ do
   let sbe = convert beo
   UTxO
     [
-      ( TxIn
-          "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53"
-          (TxIx 0)
+      ( mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
       , TxOut
           ( AddressInEra
               (ShelleyAddressInEra sbe)
               ( ShelleyAddress
                   L.Testnet
-                  (L.KeyHashObj "ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+                  (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
                   L.StakeRefNull
               )
           )
@@ -703,7 +701,7 @@ mkUtxos beo mScriptHash = babbageEraOnwardsConstraints beo $ do
                   (L.Coin 4_000_000)
                   ( L.MultiAsset $
                       fromList
-                        [(L.PolicyID scriptHash, [("eeee", 1)]) | scriptHash <- maybeToList mScriptHash]
+                        [(L.PolicyID scriptHash, [(L.AssetName "eeee", 1)]) | scriptHash <- maybeToList mScriptHash]
                   )
               )
           )
@@ -742,7 +740,7 @@ mkTxOutput beo address coin mScriptHash = babbageEraOnwardsConstraints beo $ do
               coin
               ( L.MultiAsset $
                   fromList
-                    [(L.PolicyID scriptHash, [("eeee", 2)]) | scriptHash <- maybeToList mScriptHash]
+                    [(L.PolicyID scriptHash, [(L.AssetName "eeee", 2)]) | scriptHash <- maybeToList mScriptHash]
               )
           )
       )
@@ -764,6 +762,12 @@ getTxOutCoin
 getTxOutCoin txout = withFrozenCallStack $ maryEraOnwardsConstraints (maryBasedEra @era) $ do
   TxOut _ (TxOutValueShelleyBased _ (L.MaryValue changeCoin _)) _ _ <- pure txout
   pure changeCoin
+
+mkCredential :: HasCallStack => Text -> L.Credential k
+mkCredential = errorFail @String . L.parseCredential
+
+mkTxIn :: HasCallStack => Text -> TxIn
+mkTxIn = either error id . P.runParser parseTxIn
 
 tests :: TestTree
 tests =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove partial `IsString` instances. Use `deserialiseFromRawBytesHex` or specialised parser instead.
    Make `SerialiseAsBech32` class use `HumanReadablePart` instead of `Text` for Bech32 prefix in `bech32PrefixFor` and `bech32PrefixesPermitted` functions.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`IsString` instances generated from `UsingRawBytesHex` were partial and could fail with runtime exception leading to hard to track errors. We were using `fromString` on types using those instances in `cardano-cli` and `cardano-testnet` already. This PR removes those and adds `parsec` parsers instead.

Because `IsString` was used in tests, it's replaced by specialised functions in tests only for example:
```haskell
mkCredential :: HasCallStack => Text -> L.Credential k
mkCredential = errorFail @String . L.parseCredential

mkTxIn :: HasCallStack => Text -> TxIn
mkTxIn = either error id . P.runParser parseTxIn
```
[ledger's `parseCredential`](https://github.com/IntersectMBO/cardano-ledger/blob/607a7fdad352eb72041bb79f37bc1cf389432b1d/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs#L143)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
