### PR TITLE
Add `Convert` instance for `ConwayEraOnwards` to `Era`

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Experimental/Eras.hs
@@ -34,6 +34,7 @@ where
 import Cardano.Api.Internal.Eon.AlonzoEraOnwards
 import Cardano.Api.Internal.Eon.BabbageEraOnwards
 import Cardano.Api.Internal.Eon.Convert
+import Cardano.Api.Internal.Eon.ConwayEraOnwards
 import Cardano.Api.Internal.Eon.ShelleyBasedEra (ShelleyBasedEra (..), ShelleyLedgerEra)
 import Cardano.Api.Internal.Eras qualified as Api
 import Cardano.Api.Internal.Eras.Core (BabbageEra, ConwayEra, Eon (..))
@@ -210,6 +211,10 @@ instance Convert Era AlonzoEraOnwards where
 instance Convert Era BabbageEraOnwards where
   convert = \case
     ConwayEra -> BabbageEraOnwardsConway
+
+instance Convert ConwayEraOnwards Era where
+  convert = \case
+    ConwayEraOnwardsConway -> ConwayEra
 
 newtype DeprecatedEra era
   = DeprecatedEra (ShelleyBasedEra era)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added an instance for `Convert ConwayEraOnwards Era`
  type:
  - feature        # introduces a new feature
```

# Context

[This PR](https://github.com/IntersectMBO/cardano-api/pull/828) removed the instance `Convert BabbageEraOnwards Era` and didn't add an instance for `Convert ConwayEraOnwards Era`, this makes it very difficult to do the conversion. The current PR address this lack

# How to trust this PR

It is very simple and it follows the same pattern as before.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
