### PR TITLE
Update TxInsReference haddock to mention public key inputs

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Tx/Body.hs
@@ -579,16 +579,16 @@ data TxInsReference build era where
     -> [TxIn]
     -- ^ A list of reference inputs
     -> TxInsReferenceDatums build
-    -- ^ A set of datums, whose hashes are referenced in UTXO of reference inputs. Those datums will be inserted
-    -- to the datum map available to the scripts. Note that inserting a datum with hash not present in the reference
-    -- input will result in an error on transaction submission.
+    -- ^ A set of public key inputs resolved datums, whose hashes are referenced in UTXO of reference inputs. Those
+    -- datums will be inserted to the datum map available to the scripts. Note that inserting a datum with hash not
+    -- present in the reference input will result in an error on transaction submission.
     -> TxInsReference build era
 
 deriving instance Eq (TxInsReference build era)
 
 deriving instance Show (TxInsReference build era)
 
--- | The actual datums, referenced by hash in the transaction reference inputs.
+-- | The public key inputs' resolved datums, referenced by hash in the transaction reference inputs.
 type TxInsReferenceDatums build = BuildTxWith build (Set HashableScriptData)
 
 getReferenceInputDatumMap
@@ -3090,8 +3090,8 @@ collectTxBodyScriptWitnessRequirements
 -- 1. supplemental datums from transaction outputs
 -- 2. datums from reference inputs
 --
--- Note that this function does not check whose datum datum hashes are present in the reference inputs. This means
--- if there are redundant datums in 'TxInsReference', a submission of such transaction will fail.
+-- Note that this function does not check whose datum hashes are present in the reference inputs. This means if there
+-- are redundant datums in 'TxInsReference', a submission of such transaction will fail.
 getDatums
   :: AlonzoEraOnwards era
   -> TxInsReference BuildTx era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update TxInsReference haddock to mention public key inputs
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
   - documentation  # change in code docs, haddocks...
```

# Context

https://github.com/IntersectMBO/cardano-node/pull/6174#discussion_r2109107088

Adds clarification public key resolved datum-related types.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
