### PR TITLE
Cardano.Api.Experimental: Fix missing key witnesses in certificates

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -100,6 +100,7 @@ library
     Cardano.Api.Serialise.Raw
     Cardano.Api.Serialise.SerialiseUsing
     Cardano.Api.Serialise.TextEnvelope
+    Cardano.Api.Trace.Debug
     Cardano.Api.Tx
     Cardano.Api.UTxO
     Cardano.Api.Value
@@ -168,6 +169,7 @@ library
     ouroboros-network-protocols >=0.14,
     parsec,
     plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib} ^>=1.45,
+    pretty-simple,
     prettyprinter,
     prettyprinter-ansi-terminal,
     prettyprinter-configurable ^>=1.36,

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -31,7 +31,7 @@ module Cardano.Api.Experimental.Era
   )
 where
 
-import Cardano.Api qualified as Api
+import Cardano.Api.Era qualified as Api
 import Cardano.Api.Era.Internal.Core (BabbageEra, ConwayEra, Eon (..))
 import Cardano.Api.Era.Internal.Eon.AlonzoEraOnwards
 import Cardano.Api.Era.Internal.Eon.BabbageEraOnwards
@@ -268,6 +268,7 @@ type EraCommonConstraints era =
   , L.BabbageEraPParams (LedgerEra era)
   , L.BabbageEraTxBody (LedgerEra era)
   , L.ConwayEraTxCert (LedgerEra era)
+  , L.TxCert (LedgerEra era) ~ L.ConwayTxCert (LedgerEra era)
   , L.Era (LedgerEra era)
   , L.EraScript (LedgerEra era)
   , L.EraTx (LedgerEra era)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.Api.Experimental.Tx.Internal.AnyWitness
   ( -- * Any witness (key, simple script, plutus script).
@@ -46,6 +47,8 @@ data AnyWitness era where
   AnyKeyWitnessPlaceholder :: AnyWitness era
   AnySimpleScriptWitness :: SimpleScriptOrReferenceInput era -> AnyWitness era
   AnyPlutusScriptWitness :: PlutusScriptWitness lang purpose era -> AnyWitness era
+
+deriving instance Show (AnyWitness era)
 
 getAnyWitnessPlutusLanguage :: AnyWitness era -> Maybe L.Language
 getAnyWitnessPlutusLanguage AnyKeyWitnessPlaceholder = Nothing

--- a/cardano-api/src/Cardano/Api/Trace/Debug.hs
+++ b/cardano-api/src/Cardano/Api/Trace/Debug.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- | A collection of utility functions aiding debugging of the code.
+module Cardano.Api.Trace.Debug
+  ( traceIO'
+  , trace'
+  , pShow
+  )
+where
+
+import Control.Monad.IO.Class
+import Data.Text.Lazy qualified as TL
+import GHC.Stack
+import Text.Pretty.Simple (pShow)
+
+import Debug.Trace (traceIO, traceWith)
+
+-- | Trace a value in a 'MonadIO' monad. Colours and renders with indentation the showed vaule.
+traceIO'
+  :: (HasCallStack, MonadIO m, Show a)
+  => String
+  -- ^ label for the trace
+  -> a
+  -- ^ value to trace
+  -> m ()
+traceIO' l a =
+  withFrozenCallStack $
+    liftIO . traceIO $
+      "\r\n💎💎💎\r\n  "
+        <> callsite (getCallStack callStack)
+        <> "\r\n📜 "
+        <> l
+        <> ":\r\n"
+        <> TL.unpack (pShow a)
+        <> "\r\n"
+ where
+  callsite ((_, SrcLoc{srcLocFile, srcLocStartLine, srcLocStartCol}) : _) =
+    mconcat [srcLocFile, ":", show srcLocStartLine, ":", show srcLocStartCol]
+  callsite _ = ""
+{-# DEPRECATED traceIO' "traceIO' left in the code" #-}
+
+-- | Trace pure value. Colours and renders with indentation the showed vaule.
+trace'
+  :: Show a
+  => String
+  -- ^ label for the trace
+  -> a
+  -- ^ value to trace
+  -> a
+trace' l =
+  traceWith
+    (\x -> "📜 " <> l <> ":\r\n" <> TL.unpack (pShow x))
+{-# DEPRECATED trace' "trace' left in the code" #-}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Cardano.Api.Experimental: Fix missing key witnesses in certificates
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Certificates were missing key witnesses when using experimental API. 

This PR also adds `Cardano.Api.Trace.Debug` module which adds helper functions useful in debugging. Every time I've debugged cardano-cli or cardano-api I've spent some time adding those functions and `pretty-simple` dependency and removing them in the end. So the goal of this module is provide a ready to use debug module with pretty printing tracing functions. The functions added there are marked as `DEPRECATED` to avoid accidentally leaving them in the production code.

Related:
- https://github.com/IntersectMBO/cardano-cli/issues/1223

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
