### PR TITLE
Add minimal API for creating transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,6 @@ The changelogs of constituent packages:
 
 ### `cardano-rpc`
 [./cardano-rpc/CHANGELOG.md](./cardano-rpc/CHANGELOG.md)
+
+### `cardano-wasm`
+[./cardano-wasm/CHANGELOG.md](./cardano-wasm/CHANGELOG.md)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -208,8 +209,7 @@ instance
       :: Ledger.DecoderError -> SerialiseAsRawBytesError
     wrapError = SerialiseAsRawBytesError . displayException
 
-instance Show (UnsignedTx era) where
-  showsPrec p (UnsignedTx tx) = showsPrec p tx
+deriving instance Show (UnsignedTx era)
 
 newtype UnsignedTxError
   = UnsignedTxError TxBodyError
@@ -337,6 +337,8 @@ makeKeyWitness era (UnsignedTx unsignedTx) wsk =
 -- | A transaction that has been witnesssed
 data SignedTx era
   = L.EraTx (LedgerEra era) => SignedTx (Ledger.Tx (LedgerEra era))
+
+deriving instance Show (SignedTx era)
 
 instance HasTypeProxy era => HasTypeProxy (SignedTx era) where
   data AsType (SignedTx era) = AsSignedTx (AsType era)

--- a/cardano-wasm/CHANGELOG.md
+++ b/cardano-wasm/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog for cardano-wasm

--- a/cardano-wasm/app/Main.hs
+++ b/cardano-wasm/app/Main.hs
@@ -1,7 +1,4 @@
 module Main (main) where
 
-import Cardano.Api.Experimental qualified as Exp
-
 main :: IO ()
-main =
-  print Exp.ConwayEra
+main = pure ()

--- a/cardano-wasm/cardano-wasm.cabal
+++ b/cardano-wasm/cardano-wasm.cabal
@@ -37,7 +37,24 @@ executable cardano-wasm
     ghc-options:
       -no-hs-main
       -optl-mexec-model=reactor
-      "-optl-Wl,--strip-all"
+      "-optl-Wl,--strip-all,--export=newConwayTx,--export=addTxInput,--export=addSimpleTxOut,--export=setFee,--export=signWithPaymentKey,--export=alsoSignWithPaymentKey,--export=txToCbor"
+  other-modules:
+    Cardano.Wasm.Internal.Api.Tx
+    Cardano.Wasm.Internal.ExceptionHandling
+    Cardano.Wasm.Internal.JavaScript.Bridge
+
   build-depends:
+    aeson,
     base,
     cardano-api,
+    cardano-ledger-api,
+    cardano-strict-containers,
+    containers,
+    exceptions,
+    microlens,
+    text,
+
+  if arch(wasm32)
+    build-depends:
+      ghc-experimental,
+      utf8-string,

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Tx.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Tx.hs
@@ -1,0 +1,193 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Wasm.Internal.Api.Tx
+  ( newConwayTxImpl
+  , addTxInputImpl
+  , addSimpleTxOutImpl
+  , setFeeImpl
+  , signWithPaymentKeyImpl
+  , alsoSignWithPaymentKeyImpl
+  , toCborImpl
+  )
+where
+
+import Cardano.Api (FromJSON)
+import Cardano.Api qualified as Api
+import Cardano.Api.Experimental (obtainCommonConstraints)
+import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Ledger qualified as Ledger
+import Cardano.Api.Plutus qualified as Shelley
+import Cardano.Api.Tx qualified as TxBody
+
+import Cardano.Ledger.Api qualified as Ledger
+import Cardano.Wasm.Internal.ExceptionHandling (justOrError, rightOrError)
+
+import Control.Monad.Catch (Exception (displayException), MonadThrow)
+import Data.Aeson (ToJSON (toJSON), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
+import Data.Sequence.Strict qualified as StrictSeq
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import GHC.Stack (HasCallStack)
+import Lens.Micro ((%~), (&), (.~), (<>~))
+
+-- * @UnsignedTx@ object
+
+-- | An object representing a transaction that is being built and hasn't
+-- been signed yet. It abstracts over the era of the transaction.
+-- It is meant to be an opaque object in JavaScript API.
+data UnsignedTxObject
+  = forall era. UnsignedTxObject (Exp.Era era) (Exp.UnsignedTx era)
+
+deriving instance Show UnsignedTxObject
+
+instance ToJSON UnsignedTxObject where
+  toJSON :: UnsignedTxObject -> Aeson.Value
+  toJSON (UnsignedTxObject era utx) =
+    obtainCommonConstraints era $
+      Aeson.object
+        [ "era" .= Exp.Some era
+        , "tx" .= Text.decodeUtf8 (Api.serialiseToRawBytesHex utx)
+        ]
+
+instance FromJSON UnsignedTxObject where
+  parseJSON :: HasCallStack => Aeson.Value -> Aeson.Parser UnsignedTxObject
+  parseJSON = Aeson.withObject "UnsignedTxObject" $ \o -> do
+    Exp.Some era <- o Aeson..: "era"
+    tx :: Text.Text <- o Aeson..: "tx"
+    obtainCommonConstraints era $ do
+      UnsignedTxObject
+        era
+        <$> toMonadFail (rightOrError $ Api.deserialiseFromRawBytesHex $ Text.encodeUtf8 tx)
+
+-- | Create a new unsigned transaction object for making a Conway era transaction.
+newConwayTxImpl :: UnsignedTxObject
+newConwayTxImpl = UnsignedTxObject Exp.ConwayEra (Exp.UnsignedTx (Ledger.mkBasicTx Ledger.mkBasicTxBody))
+
+-- | Add a simple transaction input to an unsigned transaction object.
+addTxInputImpl :: UnsignedTxObject -> Api.TxId -> Api.TxIx -> UnsignedTxObject
+addTxInputImpl (UnsignedTxObject era (Exp.UnsignedTx tx)) txId txIx =
+  obtainCommonConstraints era $
+    let txIn = Api.TxIn txId txIx
+        tx' = tx & Ledger.bodyTxL . Ledger.inputsTxBodyL %~ (<> Set.fromList [TxBody.toShelleyTxIn txIn])
+     in UnsignedTxObject era $ Exp.UnsignedTx tx'
+
+-- | Add a simple transaction output to an unsigned transaction object.
+-- It takes a destination address and an amount in lovelace.
+addSimpleTxOutImpl
+  :: (HasCallStack, MonadThrow m) => UnsignedTxObject -> String -> Ledger.Coin -> m UnsignedTxObject
+addSimpleTxOutImpl (UnsignedTxObject era (Exp.UnsignedTx tx)) destAddr lovelaceAmount =
+  obtainCommonConstraints era $ do
+    destAddress <- deserialiseAddress era destAddr
+    let sbe = Api.convert era
+        txOut =
+          Api.TxOut
+            destAddress
+            (Api.lovelaceToTxOutValue sbe lovelaceAmount)
+            Api.TxOutDatumNone
+            Shelley.ReferenceScriptNone
+        shelleyTxOut = TxBody.toShelleyTxOutAny sbe txOut
+        tx' = tx & Ledger.bodyTxL . Ledger.outputsTxBodyL %~ (<> StrictSeq.fromList [shelleyTxOut])
+    return $ UnsignedTxObject era $ Exp.UnsignedTx tx'
+ where
+  deserialiseAddress
+    :: (HasCallStack, MonadThrow m, Exp.EraCommonConstraints era)
+    => Exp.Era era -> String -> m (Api.AddressInEra era)
+  deserialiseAddress _eon destAddrStr =
+    justOrError
+      ("Couldn't deserialise destination address: " ++ show destAddrStr)
+      $ Api.deserialiseAddress
+        (Api.AsAddressInEra Api.asType)
+        (Text.pack destAddrStr)
+
+-- | Set the fee for an unsigned transaction object.
+setFeeImpl :: UnsignedTxObject -> Ledger.Coin -> UnsignedTxObject
+setFeeImpl (UnsignedTxObject era (Exp.UnsignedTx tx)) fee =
+  obtainCommonConstraints era $
+    let tx' = tx & Ledger.bodyTxL . Ledger.feeTxBodyL .~ fee
+     in UnsignedTxObject era $ Exp.UnsignedTx tx'
+
+-- | Sign an unsigned transaction using a payment key.
+signWithPaymentKeyImpl
+  :: UnsignedTxObject -> Api.SigningKey Api.PaymentKey -> SignedTxObject
+signWithPaymentKeyImpl (UnsignedTxObject era unsignedTx@(Exp.UnsignedTx tx)) signingKey =
+  obtainCommonConstraints era $
+    let witness = Exp.makeKeyWitness era unsignedTx . Api.WitnessPaymentKey $ signingKey
+        txWits =
+          Ledger.mkBasicTxWits
+            & Ledger.addrTxWitsL
+              .~ Set.fromList [witness]
+        txWithWits =
+          obtainCommonConstraints
+            era
+            (tx & Ledger.witsTxL .~ txWits)
+     in SignedTxObject
+          era
+          (Exp.SignedTx txWithWits)
+
+-- * @SignedTx@ object
+
+-- | An object representing a signed transaction.
+data SignedTxObject
+  = forall era. SignedTxObject (Exp.Era era) (Exp.SignedTx era)
+
+deriving instance Show SignedTxObject
+
+instance ToJSON SignedTxObject where
+  toJSON :: SignedTxObject -> Aeson.Value
+  toJSON (SignedTxObject era tx) =
+    obtainCommonConstraints era $
+      Aeson.object
+        [ "era" .= Exp.Some era
+        , "tx" .= Text.decodeUtf8 (Api.serialiseToRawBytesHex tx)
+        ]
+
+instance FromJSON SignedTxObject where
+  parseJSON :: HasCallStack => Aeson.Value -> Aeson.Parser SignedTxObject
+  parseJSON = Aeson.withObject "SignedTxObject" $ \o -> do
+    Exp.Some era <- o Aeson..: "era"
+    tx :: Text.Text <- o Aeson..: "tx"
+    obtainCommonConstraints era $ do
+      decodedTx <- toMonadFail (rightOrError $ Api.deserialiseFromRawBytesHex $ Text.encodeUtf8 tx)
+      return $
+        SignedTxObject era decodedTx
+
+-- | Add an extra signature to an already signed transaction using a payment key.
+alsoSignWithPaymentKeyImpl
+  :: SignedTxObject -> Api.SigningKey Api.PaymentKey -> SignedTxObject
+alsoSignWithPaymentKeyImpl (SignedTxObject era (Exp.SignedTx tx)) signingKey =
+  obtainCommonConstraints era $
+    let witness = Exp.makeKeyWitness era (Exp.UnsignedTx tx) . Api.WitnessPaymentKey $ signingKey
+        txWits =
+          Ledger.mkBasicTxWits
+            & Ledger.addrTxWitsL
+              .~ Set.fromList [witness]
+        txWithWits =
+          obtainCommonConstraints
+            era
+            (tx & Ledger.witsTxL <>~ txWits)
+     in SignedTxObject
+          era
+          (Exp.SignedTx txWithWits)
+
+-- | Convert an 'Either' value to a 'MonadFail' monad. This can be useful for converting
+-- MonadThrow monads into Aeson Parser monads, but it loses the stack trace information.
+toMonadFail :: (Exception e, MonadFail m) => Either e a -> m a
+toMonadFail (Left e) = fail $ displayException e
+toMonadFail (Right a) = return a
+
+-- | Convert a signed transaction object to a base16 encoded string of its CBOR representation.
+toCborImpl :: SignedTxObject -> String
+toCborImpl (SignedTxObject era signedTx) =
+  obtainCommonConstraints era $
+    Text.unpack $
+      Text.decodeUtf8 (Api.serialiseToRawBytesHex signedTx)

--- a/cardano-wasm/src/Cardano/Wasm/Internal/ExceptionHandling.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/ExceptionHandling.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE InstanceSigs #-}
+
+module Cardano.Wasm.Internal.ExceptionHandling where
+
+import Control.Exception (Exception)
+import Control.Monad.Catch (MonadThrow (..))
+import GHC.Exception (CallStack, prettyCallStack)
+import GHC.Stack (HasCallStack, callStack, withFrozenCallStack)
+
+data ExpectedJustException = HasCallStack => ExpectedJustException CallStack String
+
+instance Show ExpectedJustException where
+  show :: ExpectedJustException -> String
+  show (ExpectedJustException cs msg) = "Expected Just, got Nothing: " ++ msg ++ "\n" ++ prettyCallStack cs
+
+instance Exception ExpectedJustException
+
+data ExpectedRightException = HasCallStack => ExpectedRightException CallStack String
+
+instance Show ExpectedRightException where
+  show :: ExpectedRightException -> String
+  show (ExpectedRightException cs msg) = "Expected Right, got Left: " ++ msg ++ "\n" ++ prettyCallStack cs
+
+instance Exception ExpectedRightException
+
+justOrError :: (HasCallStack, MonadThrow m) => String -> Maybe a -> m a
+justOrError e Nothing = withFrozenCallStack $ throwM $ ExpectedJustException callStack e
+justOrError _ (Just a) = return a
+
+rightOrError :: (HasCallStack, MonadThrow m, Show e) => Either e a -> m a
+rightOrError (Left e) = withFrozenCallStack $ throwM $ ExpectedRightException callStack $ show e
+rightOrError (Right a) = return a

--- a/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE CPP #-}
+
+#if !defined(wasm32_HOST_ARCH)
+module Cardano.Wasm.Internal.JavaScript.Bridge where
+#else
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Wasm.Internal.JavaScript.Bridge where
+
+import Cardano.Api qualified as Api
+import Cardano.Api.Ledger qualified as Ledger
+
+import Cardano.Wasm.Internal.Api.Tx qualified as Wasm
+import Cardano.Wasm.Internal.ExceptionHandling (rightOrError)
+
+import Control.Exception (evaluate)
+import Control.Monad (join)
+import Data.Aeson qualified as Aeson
+import Data.ByteString.UTF8 (fromString, toString)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Typeable (Typeable, typeRep)
+import GHC.Stack (HasCallStack)
+import GHC.Wasm.Prim
+
+-- * JS helper functions
+
+-- | Parse the JSON stored in a JavaScript string (@JSString@)
+-- and return it as a JavaScript object (@JSVal@).
+foreign import javascript unsafe "JSON.parse($1)"
+  js_parse :: JSString -> IO JSVal
+
+-- | Serialise a JavaScript object (@JSVal@) to a JSON string (@JSString@).
+foreign import javascript unsafe "JSON.stringify($1)"
+  js_stringify :: JSVal -> IO JSString
+
+-- | Call the @toString@ method on a JavaScript object and return it as a @JSString@.
+-- This can be used to convert a @BigInt@ to its string representation.
+foreign import javascript unsafe "($1).toString()"
+  js_toString :: JSVal -> IO JSString
+
+-- * Primitive Haskell JS conversion functions.
+
+-- | Convert a @BigInt@ (@JSVal@) to a Haskell @Integer@ without loss of precision.
+fromJSBigInt :: HasCallStack => JSVal -> IO Integer
+fromJSBigInt val = do
+  jsString <- js_toString val
+  let str = fromJSString jsString
+  case reads str of
+    [(n, "")] -> return n
+    _ -> error ("Wrong format for argument when deserialising, expected integer but got: " ++ show str)
+
+-- | Convert a Haskell value with @ToJSON@ instance to a JavaScript object (@JSVal)
+jsonToJSVal :: Api.ToJSON a => a -> IO JSVal
+jsonToJSVal =
+  js_parse . toJSString . toString . Api.serialiseToJSON
+
+-- | Convert a JavaScript object (@JSVal@) to a Haskell value with @FromJSON@ instance.
+jsValToJSON :: (Api.FromJSON a, HasCallStack) => String -> JSVal -> IO a
+jsValToJSON expectedType val = do
+  jsString <- js_stringify val
+  let jsonString = fromJSString jsString
+  case Aeson.eitherDecodeStrict' (fromString jsonString) of
+    Left err ->
+      error
+        ( "Wrong format for argument when decoding JSON for parameter of type "
+            ++ expectedType
+            ++ ": "
+            ++ show (Api.JsonDecodeError err)
+        )
+    Right a -> evaluate a
+
+-- | Convert a JavaScript object (@JSVal@) to a Haskell type that has a @TextEnvelope@ instance.
+jsValToType :: (HasCallStack, Api.HasTextEnvelope a) => String -> JSVal -> IO a
+jsValToType expectedType val = do
+  envelope <- jsValToJSON expectedType val
+  case Api.deserialiseFromTextEnvelope envelope of
+    Left err ->
+      error
+        ("Error deserialising text envelope for parameter of type " ++ expectedType ++ ": " ++ show err)
+    Right type_ -> return type_
+
+-- * Type Synonyms for JSVal representations
+
+type JSUnsignedTx = JSVal
+
+type JSSignedTx = JSVal
+
+type JSTxId = JSString
+
+type JSTxIx = Int
+
+type JSCoin = JSVal
+
+type JSSigningKey = JSString
+
+-- * High-level definitions for conversion between Haskell and JS
+
+-- | Type class that provides functions to convert values from Haskell to JavaScript.
+class ToJSVal haskellType jsType where
+  toJSVal :: HasCallStack => haskellType -> IO jsType
+
+instance Api.ToJSON a => ToJSVal a JSVal where
+  toJSVal :: a -> IO JSVal
+  toJSVal = jsonToJSVal
+
+instance ToJSVal String JSString where
+  toJSVal :: String -> IO JSString
+  toJSVal = return . toJSString
+
+-- |  Type class that provides functions to convert values from JavaScript to Haskell.
+class FromJSVal jsType haskellType where
+  fromJSVal :: HasCallStack => jsType -> IO haskellType
+
+instance {-# OVERLAPPING #-} FromJSVal JSCoin Ledger.Coin where
+  fromJSVal :: HasCallStack => JSCoin -> IO Ledger.Coin
+  fromJSVal = fmap (Ledger.Coin . fromInteger) . fromJSBigInt
+
+instance FromJSVal JSString Text where
+  fromJSVal :: JSString -> IO Text
+  fromJSVal = return . Text.pack . fromJSString
+
+instance FromJSVal JSString String where
+  fromJSVal :: JSString -> IO String
+  fromJSVal = return . fromJSString
+
+instance (Api.FromJSON a, Typeable a) => FromJSVal JSVal a where
+  fromJSVal :: HasCallStack => JSVal -> IO a
+  fromJSVal = jsValToJSON (show . typeRep $ (Api.Proxy :: Api.Proxy a))
+
+instance FromJSVal JSSigningKey (Api.SigningKey Api.PaymentKey) where
+  fromJSVal :: HasCallStack => JSSigningKey -> IO (Api.SigningKey Api.PaymentKey)
+  fromJSVal jsString = do
+    rightOrError $ Api.deserialiseFromBech32 (Text.pack (fromJSString jsString))
+
+instance FromJSVal JSTxId Api.TxId where
+  fromJSVal :: HasCallStack => JSTxId -> IO Api.TxId
+  fromJSVal jsString = do
+    rightOrError $ Api.deserialiseFromRawBytesHex (fromString (fromJSString jsString))
+
+instance FromJSVal JSTxIx Api.TxIx where
+  fromJSVal :: JSTxIx -> IO Api.TxIx
+  fromJSVal = return . Api.TxIx . fromIntegral
+
+-- * UnsignedTxObject
+
+foreign export javascript "newConwayTx"
+  newConwayTx :: IO JSUnsignedTx
+
+foreign export javascript "addTxInput"
+  addTxInput :: JSUnsignedTx -> JSTxId -> JSTxIx -> IO JSUnsignedTx
+
+foreign export javascript "addSimpleTxOut"
+  addSimpleTxOut :: JSUnsignedTx -> JSString -> JSCoin -> IO JSUnsignedTx
+
+foreign export javascript "setFee"
+  setFee :: JSUnsignedTx -> JSCoin -> IO JSUnsignedTx
+
+foreign export javascript "signWithPaymentKey"
+  signWithPaymentKey :: JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
+
+-- | Create a new Conway era unsigned transaction.
+newConwayTx :: HasCallStack => IO JSUnsignedTx
+newConwayTx = toJSVal Wasm.newConwayTxImpl
+
+-- | Add a transaction input to an unsigned transaction.
+addTxInput :: HasCallStack => JSUnsignedTx -> JSTxId -> JSTxIx -> IO JSUnsignedTx
+addTxInput jsUnsignedTx jsTxId jsTxIx =
+  toJSVal
+    =<< Wasm.addTxInputImpl
+      <$> fromJSVal jsUnsignedTx
+      <*> fromJSVal jsTxId
+      <*> fromJSVal jsTxIx
+
+-- | Add a simple transaction output (address and lovelace amount) to an unsigned transaction.
+addSimpleTxOut :: HasCallStack => JSUnsignedTx -> JSString -> JSCoin -> IO JSUnsignedTx
+addSimpleTxOut jsUnsignedTx jsDestAddr jsCoin =
+  toJSVal
+    =<< join
+      ( Wasm.addSimpleTxOutImpl
+          <$> fromJSVal jsUnsignedTx
+          <*> fromJSVal jsDestAddr
+          <*> fromJSVal jsCoin
+      )
+
+-- | Set the transaction fee for an unsigned transaction.
+setFee :: HasCallStack => JSUnsignedTx -> JSCoin -> IO JSUnsignedTx
+setFee jsUnsignedTx jsCoin =
+  toJSVal
+    =<< ( Wasm.setFeeImpl
+            <$> fromJSVal jsUnsignedTx
+            <*> fromJSVal jsCoin
+        )
+
+-- | Sign an unsigned transaction with a payment key.
+signWithPaymentKey :: HasCallStack => JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
+signWithPaymentKey jsUnsignedTx jsSigningKey =
+  toJSVal
+    =<< ( Wasm.signWithPaymentKeyImpl
+            <$> fromJSVal jsUnsignedTx
+            <*> fromJSVal jsSigningKey
+        )
+
+-- *  SignedTxObject
+
+foreign export javascript "alsoSignWithPaymentKey"
+  alsoSignWithPaymentKey :: JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
+
+foreign export javascript "txToCbor"
+  txToCbor :: JSSignedTx -> IO JSString
+
+-- | Sign an unsigned transaction with a payment key.
+alsoSignWithPaymentKey :: HasCallStack => JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
+alsoSignWithPaymentKey jsUnsignedTx jsSigningKey =
+  toJSVal
+    =<< ( Wasm.alsoSignWithPaymentKeyImpl
+            <$> fromJSVal jsUnsignedTx
+            <*> fromJSVal jsSigningKey
+        )
+
+-- | Convert a signed transaction to its CBOR representation (hex-encoded string).
+txToCbor :: HasCallStack => JSSignedTx -> IO JSString
+txToCbor jsSignedTx =
+  toJSVal . Wasm.toCborImpl =<< fromJSVal jsSignedTx
+
+#endif


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add basic transaction creation functions to wasm API
  type:
  - feature
```

# Context

This PR builds on https://github.com/IntersectMBO/cardano-api/pull/852 and adds a basic API to `cardano-wasm` to allow creation of very simple transactions.

# How to trust this PR

It think the best way is testing it, and also checking the code structure is sensible.

You can see the tests in https://github.com/IntersectMBO/cardano-api/pull/894.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
