### PR TITLE
Add wrapper for signed transactions in experimental API

### DIFF
--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -12,6 +12,7 @@ module Cardano.Api.Experimental
     -- ** Transaction-related
     UnsignedTx (..)
   , UnsignedTxError (..)
+  , SignedTx (..)
   , makeUnsignedTx
   , makeKeyWitness
   , signTx

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -95,7 +95,7 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
     let bootstrapWitnesses = []
         keyWitnesses = [witness]
 
-    let signedTx :: Ledger.Tx (Exp.LedgerEra Exp.ConwayEra) = Exp.signTx era bootstrapWitnesses keyWitnesses unsignedTx
+    let Exp.SignedTx (signedTx :: Ledger.Tx (Exp.LedgerEra Exp.ConwayEra)) = Exp.signTx era bootstrapWitnesses keyWitnesses unsignedTx
     return signedTx
 
 prop_balance_transaction_two_ways :: Property


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add wrapper `SignedTx` for signed transactions in experimental API
  type:
  - feature
```

# Context

Based on [this discussion](https://github.com/IntersectMBO/cardano-api/pull/893#discussion_r2194564686), we want to add a wrapper for signed transactions, so that they become first citizens and we can add non-orphan instances.

# How to trust this PR

Change is minimal and is analogous to what exists for `UnsignedTx`. I would just review there are no typos and the style and types are correct.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
