### PR TITLE
Split change log entries among packages

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -22,19 +22,6 @@
   (compatible)
   [PR 890](https://github.com/IntersectMBO/cardano-api/pull/890)
 
-- cardano-rpc: Add cardano-rpc package with a dummy gRPC service
-  (feature)
-  [PR 885](https://github.com/IntersectMBO/cardano-api/pull/885)
-
-- Added support for compiling `cardano-api` to `wasm`
-  (feature)
-  [PR 852](https://github.com/IntersectMBO/cardano-api/pull/852)
-
-- Add `SerialiseAsRawBytes` instance to `UnsignedTx ConwayEra`
-  (feature)
-  [PR 880](https://github.com/IntersectMBO/cardano-api/pull/880)
-
-
 ## 10.17.1.0
 
 - Cardano.Api.Experimental: Fix missing key witnesses in certificates

--- a/cardano-rpc/CHANGELOG.md
+++ b/cardano-rpc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog for cardano-rpc
 
-## Unreleased
+## 10.0.0.0 (unreleased)
 
-- Initial version
+- cardano-rpc: Add cardano-rpc package with a dummy gRPC service
+  (feature)
+  [PR 885](https://github.com/IntersectMBO/cardano-api/pull/885)
+

--- a/cardano-wasm/CHANGELOG.md
+++ b/cardano-wasm/CHANGELOG.md
@@ -1,1 +1,14 @@
 # Changelog for cardano-wasm
+
+## 10.0.0.0 (unreleased)
+
+- Added support for compiling `cardano-api` to `wasm`
+  (feature)
+  [PR 852](https://github.com/IntersectMBO/cardano-api/pull/852)
+
+- Add `SerialiseAsRawBytes` instance to `UnsignedTx ConwayEra`
+  (feature)
+  [PR 880](https://github.com/IntersectMBO/cardano-api/pull/880)
+
+
+


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Reorganise change log entries to distribute changes between packages
  type:
  - maintenance
```

# Context

Currently, all entries in the change log are collected together. Last release included changes from the `cardano-rpc` and `cardano-wasm` packages in the `cardano-api` release. This PR updates retroactively redistributes the entries of the last release into their respective packages.

# How to trust this PR

Check no entries were lost, and that the redistribution is correct.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
