### PR TITLE
Add nix output for web-grpc client bundled as a single JS file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,8 @@
           };
         inherit (nixpkgs) lib;
 
+        proto-js-bundle-drv = import ./nix/proto-to-js.nix { pkgs = nixpkgs; };
+
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
@@ -244,6 +246,9 @@
             inherit cabalProject nixpkgs;
             # also provide hydraJobs through legacyPackages to allow building without system prefix:
             inherit hydraJobs;
+          };
+          packages = lib.optionalAttrs (system != "aarch64-darwin") {
+            proto-js-bundle = proto-js-bundle-drv;
           };
           devShells = let
             # profiling shell

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
           };
         inherit (nixpkgs) lib;
 
-        proto-js-bundle-drv = import ./nix/proto-to-js.nix { pkgs = nixpkgs; };
+        proto-js-bundle-drv = import ./nix/proto-to-js.nix {pkgs = nixpkgs;};
 
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
@@ -152,7 +152,11 @@
                 };
               };
             })
-            ({pkgs, config, ...}: let
+            ({
+              pkgs,
+              config,
+              ...
+            }: let
               generatedExampleFiles = ["cardano-wasm/lib-wrapper/cardano-api.d.ts"];
               exportWasmPath = "export CARDANO_WASM=${config.hsPkgs.cardano-wasm.components.exes.cardano-wasm}/bin/cardano-wasm${pkgs.stdenv.hostPlatform.extensions.executable}";
             in {
@@ -210,16 +214,16 @@
             };
           };
         playwrightShell = let
-           playwright-pkgs = inputs.nixpkgs.legacyPackages.${system};
-          in {
-            playwright = playwright-pkgs.mkShell {
-              packages = [
-                playwright-pkgs.playwright-test
-                playwright-pkgs.python313Packages.docopt
-                playwright-pkgs.python313Packages.httpserver
-              ];
-            };
+          playwright-pkgs = inputs.nixpkgs.legacyPackages.${system};
+        in {
+          playwright = playwright-pkgs.mkShell {
+            packages = [
+              playwright-pkgs.playwright-test
+              playwright-pkgs.python313Packages.docopt
+              playwright-pkgs.python313Packages.httpserver
+            ];
           };
+        };
         flakeWithWasmShell = nixpkgs.lib.recursiveUpdate flake {
           devShells = wasmShell;
           hydraJobs = {devShells = wasmShell;};
@@ -240,7 +244,14 @@
                 // {
                   # This ensure hydra send a status for the required job (even if no change other than commit hash)
                   revision = nixpkgs.writeText "revision" (inputs.self.rev or "dirty");
+                  proto-js-bundle = proto-js-bundle-drv;
                 };
+            }
+            // lib.optionalAttrs (system != "aarch64-darwin")
+            {
+              packages = {
+                proto-js-bundle = proto-js-bundle-drv;
+              };
             };
           legacyPackages = {
             inherit cabalProject nixpkgs;

--- a/nix/npm-deps/package-lock.json
+++ b/nix/npm-deps/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "npm-deps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "google-protobuf": "^3.21.4",
+        "grpc-web": "^1.5.0"
+      }
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==",
+      "license": "(BSD-3-Clause AND Apache-2.0)"
+    },
+    "node_modules/grpc-web": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.5.0.tgz",
+      "integrity": "sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/nix/npm-deps/package.json
+++ b/nix/npm-deps/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "google-protobuf": "^3.21.4",
+    "grpc-web": "^1.5.0"
+  }
+}

--- a/nix/proto-to-js.nix
+++ b/nix/proto-to-js.nix
@@ -1,0 +1,88 @@
+# proto-to-js.nix
+
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+
+  # Node dependencies
+  node-deps = pkgs.buildNpmPackage {
+    version = "1.0.0";
+    name = "proto-js-dependencies";
+    src = ../nix/npm-deps;
+    npmDepsHash = "sha256-b8x9xZ0dCu1cvILF0HPVVLfkCGHOWCcPUKyC2x1gQ+c=";
+    dontNpmBuild = true;
+    dontNpmInstall = true;
+    installPhase = ''
+      mkdir -p $out
+      cp -r node_modules $out/
+    '';
+  };
+
+  cardano-rpc-src = ../cardano-rpc;
+
+in pkgs.stdenv.mkDerivation {
+  pname = "cardano-rpc-proto-js-bundle";
+  version = "0.1.0";
+
+  src = cardano-rpc-src;
+
+  nativeBuildInputs = [
+    pkgs.protobuf
+    pkgs.protoc-gen-js
+    pkgs.protoc-gen-grpc-web
+    pkgs.nodePackages.browserify
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    PROTO_INCLUDE_PATH=$src/proto
+    GEN_JS_PATH=./generated-js
+    BUNDLE_PATH=./bundled-js
+
+    mkdir -p $GEN_JS_PATH
+    mkdir -p $BUNDLE_PATH
+
+    PROTO_FILE=$PROTO_INCLUDE_PATH/cardano/rpc/node.proto
+
+    echo "--- Compiling .proto file: $PROTO_FILE ---"
+
+    protoc \
+      -I=$PROTO_INCLUDE_PATH \
+      --js_out=import_style=commonjs,binary:$GEN_JS_PATH \
+      --grpc-web_out=import_style=commonjs,mode=grpcwebtext:$GEN_JS_PATH \
+      $PROTO_FILE
+
+    echo "--- Compilation finished. Generated files are in $GEN_JS_PATH ---"
+    ls -R $GEN_JS_PATH
+
+    GENERATED_GRPC_FILE=$GEN_JS_PATH/cardano/rpc/node_grpc_web_pb.js
+
+    if [ ! -f "$GENERATED_GRPC_FILE" ]; then
+        echo "Error: Protoc did not generate the expected gRPC-Web file!"
+        exit 1
+    fi
+
+    echo "--- Setting up node_modules for browserify ---"
+    ln -s ${node-deps}/node_modules ./node_modules
+
+    echo "--- Bundling generated JS with browserify ---"
+
+    browserify --standalone grpc $GENERATED_GRPC_FILE > $BUNDLE_PATH/node_grpc_web_pb.js
+
+    echo "--- Bundling complete. Final file is in $BUNDLE_PATH ---"
+    ls $BUNDLE_PATH
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp ./bundled-js/node_grpc_web_pb.js $out/
+    runHook postInstall
+  '';
+
+  dontConfigure = true;
+}
+


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add nix output that produces a bundle with a web-grpc client for `cardano-rpc`
  type:
  - feature
```

# Context

In order to use `cardano-grpc` from JS in the browser, we need a library that can be embedded in vanilla JS. This PR introduces a nix output that produces a self-contained bundle JS file from the `.proto` file.

# How to trust this PR

It is basically reviewing the nix, and testing it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
