### PR TITLE
Fix missing zlib in WASM nix shell

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -152,6 +152,11 @@ if arch(wasm32)
   package crypton
     ghc-options: -optc-DARGON2_NO_THREADS
 
+  -- make digest not look for zlib in pkg-config, which is desired on WASM
+  package digest
+     flags: -pkg-config
+
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.

--- a/flake.nix
+++ b/flake.nix
@@ -206,6 +206,7 @@
             wasm = wasm-pkgs.mkShell {
               packages = [
                 wasm-pkgs.curl
+                wasm-pkgs.git
                 inputs.ghc-wasm-meta.packages.${system}.all_9_10
                 wasm-pkgs.pkg-config
                 wasm.libsodium


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix missing zlib in WASM nix shell
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

For some reason haskell package `digest` was trying to find `zlib` in `pkg-config` output, which does not succeed on WASM platform. We can tell it to not use `pkg-config` for that: https://hackage.haskell.org/package/digest-0.0.2.1

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
