### PR TITLE
cardano-rpc | Add getProtocolParamsJson gRPC endpoint

### DIFF
--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -61,6 +61,7 @@ library
     Cardano.Rpc.Server.Internal.Env
     Cardano.Rpc.Server.Internal.Error
     Cardano.Rpc.Server.Internal.Monad
+    Cardano.Rpc.Server.Internal.Node
     Cardano.Rpc.Server.Internal.UtxoRpc.Query
     Cardano.Rpc.Server.Internal.UtxoRpc.Submit
     Cardano.Rpc.Server.Internal.UtxoRpc.Type
@@ -89,6 +90,7 @@ library
     Proto.Utxorpc.V1alpha.Submit.Submit_Fields
 
   build-depends:
+    aeson,
     base,
     bytestring,
     cardano-api >=10.17,

--- a/cardano-rpc/proto/cardano/rpc/node.proto
+++ b/cardano-rpc/proto/cardano/rpc/node.proto
@@ -5,9 +5,9 @@ package cardano.rpc;
 import "google/protobuf/empty.proto";
 
 service Node {
-
     rpc GetEra(google.protobuf.Empty) returns (CurrentEra) {}
 
+    rpc GetProtocolParamsJson(google.protobuf.Empty) returns (ProtocolParamsJson) {}
 }
 
 enum Era {
@@ -22,5 +22,9 @@ enum Era {
 
 
 message CurrentEra {
-   Era era = 1;
+    Era era = 1;
+}
+
+message ProtocolParamsJson {
+    bytes json = 1; // JSON representation of the protocol parameters
 }

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Node.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Node.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Rpc.Server.Internal.Node
+  ( getEraMethod
+  , getProtocolParamsJsonMethod
+  )
+where
+
+import Cardano.Api
+import Cardano.Api.Experimental.Era
+import Cardano.Rpc.Proto.Api.Node qualified as Rpc
+import Cardano.Rpc.Server.Internal.Error
+import Cardano.Rpc.Server.Internal.Monad
+import Cardano.Rpc.Server.Internal.Orphans ()
+
+import RIO hiding (toList)
+
+import Data.Aeson qualified as A
+import Data.ByteString.Lazy qualified as BL
+import Data.Default
+import Data.ProtoLens (defMessage)
+import Network.GRPC.Spec
+
+import Proto.Google.Protobuf.Empty
+
+getEraMethod :: MonadRpc e m => Proto Empty -> m (Proto Rpc.CurrentEra)
+getEraMethod _ = pure . Proto $ defMessage & #era .~ Rpc.Conway
+
+getProtocolParamsJsonMethod :: MonadRpc e m => Proto Empty -> m (Proto Rpc.ProtocolParamsJson)
+getProtocolParamsJsonMethod _ = do
+  nodeConnInfo <- grab
+  AnyCardanoEra era <- liftIO . throwExceptT $ determineEra nodeConnInfo
+  eon <- forEraInEon @Era era (error "getProtocolParamsJsonMethod: Minimum Conway era required") pure
+  let sbe = convert eon
+
+  let target = VolatileTip
+  pparams <-
+    liftIO . (throwEither =<<) $
+      executeLocalStateQueryExpr nodeConnInfo target $
+        throwEither =<< throwEither =<< queryProtocolParameters sbe
+
+  let pparamsJson = obtainCommonConstraints eon $ A.encode pparams
+
+  pure $
+    def
+      & #json .~ BL.toStrict pparamsJson

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
@@ -25,6 +25,7 @@ import Cardano.Rpc.Server.Internal.UtxoRpc.Type
 
 import RIO hiding (toList)
 
+import Data.Default
 import Data.ProtoLens (defMessage)
 import Data.Text.Encoding qualified as T
 import GHC.IsList
@@ -51,7 +52,7 @@ readParamsMethod _req = do
     pure (pparams, chainPoint, blockNo)
 
   pure $
-    defMessage
+    def
       & #ledgerTip .~ mkChainPointMsg chainPoint blockNo
       & #values . #cardano .~ conwayEraOnwardsConstraints eon (inject pparams)
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    cardano-rpc | Add getProtocolParamsJson gRPC endpoint
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Adds gRPC endpoint returning protocol parameters in the ledger format. Using utxorpc endpoint providing protocol parameters is inconvenient, as it's in a different format than ledger's json format and would require transforming it, before using in a transaction.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
