### PR TITLE
Add support for submitting transactions through gRPC-web to the `cardano-wasm` API

### DIFF
--- a/cardano-wasm/cardano-wasm.cabal
+++ b/cardano-wasm/cardano-wasm.cabal
@@ -54,6 +54,8 @@ executable cardano-wasm
   build-depends:
     aeson,
     base,
+    base16-bytestring,
+    base64-bytestring,
     bytestring,
     cardano-api,
     cardano-crypto-class,

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -95,6 +95,13 @@ declare interface GrpcConnection {
      * @returns A promise that resolves to the current era number.
      */
     getEra(): Promise<number>;
+
+    /**
+     * Submit a signed and CBOR-encoded transaction to the Cardano node.
+     * @param txCbor The CBOR-encoded transaction as a hex string.
+     * @returns A promise that resolves to the transaction ID.
+     */
+    submitTx(txCbor: string): Promise<string>;
 }
 
 /**

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
@@ -259,6 +259,13 @@ apiInfo =
                   , methodReturnType = OtherType "number"
                   , methodReturnDoc = "A promise that resolves to the current era number."
                   }
+              , MethodInfo
+                  { methodName = "submitTx"
+                  , methodDoc = "Submit a signed and CBOR-encoded transaction to the Cardano node."
+                  , methodParams = [ParamInfo "txCbor" "string" "The CBOR-encoded transaction as a hex string."]
+                  , methodReturnType = OtherType "string"
+                  , methodReturnDoc = "A promise that resolves to the transaction ID."
+                  }
               ]
           }
    in ApiInfo

--- a/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
@@ -21,7 +21,7 @@ import Cardano.Wasm.Internal.Api.GRPC qualified as Wasm
 import Cardano.Wasm.Internal.Api.Info (apiInfo)
 import Cardano.Wasm.Internal.Api.Tx qualified as Wasm
 import Cardano.Wasm.Internal.ExceptionHandling (rightOrError)
-import Cardano.Wasm.Internal.JavaScript.GRPC (js_getEra, js_newWebGrpcClient)
+import Cardano.Wasm.Internal.JavaScript.GRPC (js_getEra, js_newWebGrpcClient, js_submitTx)
 import Cardano.Wasm.Internal.JavaScript.GRPCTypes (JSGRPCClient)
 
 import Control.Exception (evaluate)
@@ -357,6 +357,9 @@ foreign export javascript "newGrpcConnection"
 foreign export javascript "getEra"
   getEra :: JSGrpc -> IO Int
 
+foreign export javascript "submitTx"
+  submitTx :: JSGrpc -> JSString -> IO JSString
+
 -- | Create a new gRPC object for making Conway era transactions.
 newGrpcConnection :: HasCallStack => JSString -> IO JSGrpc
 newGrpcConnection webGrpcUrl = toJSVal =<< join (Wasm.newGrpcConnectionImpl js_newWebGrpcClient <$> fromJSVal webGrpcUrl)
@@ -364,6 +367,10 @@ newGrpcConnection webGrpcUrl = toJSVal =<< join (Wasm.newGrpcConnectionImpl js_n
 -- | Get the era from the Cardano Node using GRPC-web.
 getEra :: HasCallStack => JSGrpc -> IO Int
 getEra grpcObject = Wasm.getEraImpl js_getEra =<< fromJSVal grpcObject
+
+-- | Submit a transaction to the Cardano Node using GRPC-web.
+submitTx :: HasCallStack => JSGrpc -> JSString -> IO JSString
+submitTx grpcObject tx = toJSVal =<< join (Wasm.submitTxImpl js_submitTx <$> fromJSVal grpcObject <*> fromJSVal tx)
 
 -- * API Information
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added support for submitting transactions through gRPC-web to the `cardano-wasm` API
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  projects:
  - cardano-wasm
```

# Context

This PR expands the gRPC-web support functionality to include submission of transactions that can already be built by using existing functionalities. It was already possible to do this by using a web browser wallet, but this makes it easier to do it without one.

# How to trust this PR

It is a small PR. It is possible to test it by using the code in the [submit-tx-example](https://github.com/IntersectMBO/cardano-api/tree/submit-tx-example) branch, but it is tricky to set up. I would review the code and see if it makes sense, if you can spot any issues, and if the code style is nicely organised. We'll be testing this functionality many times in the near future as other functionalities are added anyway.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
