### PR TITLE
cardano-wasm | Add getProtocolParams query to cardano-wasm

### DIFF
--- a/cardano-wasm/grpc-example/example.js
+++ b/cardano-wasm/grpc-example/example.js
@@ -46,6 +46,11 @@ async function do_async_work() {
     log("Era number:");
     log(eraNum);
 
+    let pparams = await grpcApi.getProtocolParams();
+    log("Protocol Parameters:");
+    log(pparams);
+    console.log(typeof pparams);
+
     finish_test();
 }
 

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -102,6 +102,12 @@ declare interface GrpcConnection {
      * @returns A promise that resolves to the transaction ID.
      */
     submitTx(txCbor: string): Promise<string>;
+
+    /**
+     * Get the protocol parameters in the cardano-ledger format from the Cardano Node using a GRPC-web client.
+     * @returns A promise that resolves to the current protocol parameters.
+     */
+    getProtocolParams(): Promise<any>;
 }
 
 /**

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/GRPC.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/GRPC.hs
@@ -1,5 +1,6 @@
 module Cardano.Wasm.Internal.Api.GRPC where
 
+import Cardano.Wasm.Internal.Api.Tx qualified as Wasm
 import Cardano.Wasm.Internal.ExceptionHandling (rightOrError, toMonadFail)
 import Cardano.Wasm.Internal.JavaScript.GRPCTypes (JSGRPCClient)
 
@@ -19,6 +20,11 @@ newGrpcConnectionImpl createClientJsFunc host = GrpcObject <$> createClientJsFun
 -- | Get the era from the Cardano Node using GRPC-web.
 getEraImpl :: (JSGRPCClient -> IO Int) -> GrpcObject -> IO Int
 getEraImpl getEraJsFunc (GrpcObject client) = getEraJsFunc client
+
+-- | Get the protocol parameters from the Cardano Node using GRPC-web.
+getProtocolParamsImpl
+  :: (JSGRPCClient -> IO Wasm.ProtocolParamsJSON) -> GrpcObject -> IO Wasm.ProtocolParamsJSON
+getProtocolParamsImpl getProtocolParamsJsFunc (GrpcObject client) = getProtocolParamsJsFunc client
 
 -- | Submit a transaction to the Cardano Node using GRPC-web.
 submitTxImpl

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
@@ -266,6 +266,14 @@ apiInfo =
                   , methodReturnType = OtherType "string"
                   , methodReturnDoc = "A promise that resolves to the transaction ID."
                   }
+              , MethodInfo
+                  { methodName = "getProtocolParams"
+                  , methodDoc =
+                      "Get the protocol parameters in the cardano-ledger format from the Cardano Node using a GRPC-web client."
+                  , methodParams = []
+                  , methodReturnType = OtherType "any"
+                  , methodReturnDoc = "A promise that resolves to the current protocol parameters."
+                  }
               ]
           }
    in ApiInfo

--- a/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/GRPC.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/GRPC.hs
@@ -4,9 +4,10 @@
 module Cardano.Wasm.Internal.JavaScript.GRPC where
 #else
 
-module Cardano.Wasm.Internal.JavaScript.GRPC (js_newWebGrpcClient, js_getEra, js_submitTx) where
+module Cardano.Wasm.Internal.JavaScript.GRPC (js_newWebGrpcClient, js_getEra, js_submitTx, js_getProtocolParams) where
 
 import GHC.Wasm.Prim
+import Cardano.Wasm.Internal.Api.Tx (ProtocolParamsJSON(..))
 
 -- | Create a GRPC-web client for the Cardano API.
 foreign import javascript safe "{ node: new cardano_node.node.NodePromiseClient($1, null, null), \
@@ -21,6 +22,13 @@ js_newWebGrpcClient = js_newWebGrpcClientImpl . toJSString
 -- | Get the era from the Cardano API using a GRPC-web client.
 foreign import javascript safe "($1).node.getEra(new proto.Empty(), {})"
   js_getEra :: JSVal -> IO Int
+
+foreign import javascript safe "atob((await ($1).node.getProtocolParamsJson(new proto.Empty(), {})).toObject().json)"
+  js_getProtocolParamsImpl :: JSVal -> IO JSString
+
+js_getProtocolParams :: JSVal -> IO ProtocolParamsJSON
+js_getProtocolParams client =
+  ProtocolParamsJSON . fromJSString <$> js_getProtocolParamsImpl client
 
 -- | Submit a transaction to the Cardano API using a GRPC-web client.
 foreign import javascript safe "{ let tx = new cardano_node.submit.AnyChainTx(); \


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    cardano-wasm | Add getProtocolParams query to cardano-wasm
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
  projects:
  - cardano-wasm
```

# Context

This PR is stacked on top of: 
- https://github.com/IntersectMBO/cardano-api/pull/919

This PR is targeting the following branch:
- https://github.com/IntersectMBO/cardano-api/pull/920

This PR exposes `getProtocolParams` query through JS API which returns protocol parameters object, as it is produced by `cardano-ledger` `ToJSON` instance.

<img width="1728" height="1528" alt="screenshot-20250729_182000" src="https://github.com/user-attachments/assets/3690b67c-f616-4bda-a6e3-fc9f54a8d01e" />


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
