### PR TITLE
Fix capitalisation error in typescript declaration

### DIFF
--- a/cardano-wasm/example/example.js
+++ b/cardano-wasm/example/example.js
@@ -1,3 +1,4 @@
+//@ts-check
 import cardano_api from "./cardano-api.js";
 
 let promise = cardano_api();

--- a/cardano-wasm/grpc-example/example.js
+++ b/cardano-wasm/grpc-example/example.js
@@ -1,3 +1,4 @@
+//@ts-check
 import cardano_api from "./cardano-api.js";
 
 let promise = cardano_api();
@@ -9,18 +10,18 @@ document.body.appendChild(output);
 
 function log(out) {
     console.log(out);
-    if (typeof(out) == "object") {
-	output.innerText += "> [object] {\n";
-	for (let [key, val] of Object.entries(out)) {
-	    let text = val.toString();
-	    if (typeof(val) == "function") {
-		text = text.split("{")[0];
-	    }
-	    output.innerText += "    " + key + ": " + text + "\n";
-	}
-	output.innerText += "  }\n";
+    if (typeof (out) == "object") {
+        output.innerText += "> [object] {\n";
+        for (let [key, val] of Object.entries(out)) {
+            let text = val.toString();
+            if (typeof (val) == "function") {
+                text = text.split("{")[0];
+            }
+            output.innerText += "    " + key + ": " + text + "\n";
+        }
+        output.innerText += "  }\n";
     } else {
-	output.innerText += "> " + JSON.stringify(out) + "\n";
+        output.innerText += "> " + JSON.stringify(out) + "\n";
     }
 }
 

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -48,7 +48,7 @@ declare interface UnsignedTx {
      * @param totalRefScriptSize The total size of reference scripts in bytes.
      * @returns A promise that resolves to the estimated minimum fee in lovelaces.
      */
-    estimateMinFee(protocolParams: any, numKeyWitnesses: number, numByronKeyWitnesses: number, totalRefScriptSize: number): Promise<BigInt>;
+    estimateMinFee(protocolParams: any, numKeyWitnesses: number, numByronKeyWitnesses: number, totalRefScriptSize: number): Promise<bigint>;
 
     /**
      * Signs the transaction with a payment key.

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
@@ -211,7 +211,7 @@ apiInfo =
                       , ParamInfo "numByronKeyWitnesses" "number" "The number of Byron key witnesses."
                       , ParamInfo "totalRefScriptSize" "number" "The total size of reference scripts in bytes."
                       ]
-                  , methodReturnType = OtherType "BigInt"
+                  , methodReturnType = OtherType "bigint"
                   , methodReturnDoc = "A promise that resolves to the estimated minimum fee in lovelaces."
                   }
               , MethodInfo


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix capitalisation error in typescript declaration (it used BigInt instead of bigint, which is a different thing)
  type:
  - bugfix         # fixes a defect
```

# Context

When type-checking examples, it became obvious that this was mismatching, so this PR fixes it. We also add the `@ts-check` flag to the javascript files to get VSCode to check types for us in the future, and apply formatting.

# How to trust this PR

You can see that it is written in small letters everywhere else in the file, so this just adds consistency. Check that nothing else significative was checking (other than the flag and the whitespace)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
