### PR TITLE
cardano-rpc | Encode coin as String in JavaScript

### DIFF
--- a/cardano-rpc/proto/utxorpc/v1alpha/cardano/cardano.proto
+++ b/cardano-rpc/proto/utxorpc/v1alpha/cardano/cardano.proto
@@ -5,7 +5,7 @@ package utxorpc.v1alpha.cardano;
 // Represents a transaction output in the Cardano blockchain.
 message TxOutput {
   bytes address = 1; // Address receiving the output.
-  uint64 coin = 2; // Amount of ADA in the output.
+  uint64 coin = 2 [jstype = JS_STRING]; // Amount of ADA in the output.
   repeated MultiAsset assets = 3; // Additional native (non-ADA) assets in the output.
   Datum datum = 4; // Plutus data associated with the output.
   Script script = 5; // Script associated with the output.
@@ -22,12 +22,13 @@ message Datum {
   bytes original_cbor = 3; // Original cbor-encoded data as seen on-chain
 }
 
-// TODO u5c: mint_coin made optional
 // Represents a custom asset in the Cardano blockchain.
 message Asset {
   bytes name = 1; // Name of the custom asset.
-  uint64 output_coin = 2; // Quantity of the custom asset in case of an output.
-  optional int64 mint_coin = 3; // Quantity of the custom asset in case of a mint.
+  oneof quantity {
+    uint64 output_coin = 2 [jstype = JS_STRING]; // Quantity of the custom asset in case of an output.
+    int64 mint_coin = 3 [jstype = JS_STRING]; // Quantity of the custom asset in case of a mint.
+  }
 }
 
 // TODO u5c: redeemer was removed
@@ -51,8 +52,8 @@ message Script {
 // Represents a rational number as a fraction.
 // TODO u5c increased precision to 64 bits
 message RationalNumber {
-  int64 numerator = 1;
-  uint64 denominator = 2;
+  int64 numerator = 1 [jstype = JS_STRING];
+  uint64 denominator = 2 [jstype = JS_STRING];
 }
 
 // PARAMS
@@ -88,24 +89,24 @@ message VotingThresholds {
 }
 
 message PParams {
-  uint64 coins_per_utxo_byte = 1; // The number of coins per UTXO byte.
-  uint64 max_tx_size = 2; // The maximum transaction size.
-  uint64 min_fee_coefficient = 3; // The minimum fee coefficient.
-  uint64 min_fee_constant = 4; // The minimum fee constant.
-  uint64 max_block_body_size = 5; // The maximum block body size.
-  uint64 max_block_header_size = 6; // The maximum block header size.
-  uint64 stake_key_deposit = 7; // The stake key deposit.
-  uint64 pool_deposit = 8; // The pool deposit.
+  uint64 coins_per_utxo_byte = 1 [jstype = JS_STRING]; // The number of coins per UTXO byte.
+  uint64 max_tx_size = 2 [jstype = JS_STRING]; // The maximum transaction size.
+  uint64 min_fee_coefficient = 3 [jstype = JS_STRING]; // The minimum fee coefficient.
+  uint64 min_fee_constant = 4 [jstype = JS_STRING]; // The minimum fee constant.
+  uint64 max_block_body_size = 5 [jstype = JS_STRING]; // The maximum block body size.
+  uint64 max_block_header_size = 6 [jstype = JS_STRING]; // The maximum block header size.
+  uint64 stake_key_deposit = 7 [jstype = JS_STRING]; // The stake key deposit.
+  uint64 pool_deposit = 8 [jstype = JS_STRING]; // The pool deposit.
   uint64 pool_retirement_epoch_bound = 9; // The pool retirement epoch bound.
   uint64 desired_number_of_pools = 10; // The desired number of pools.
   RationalNumber pool_influence = 11; // The pool influence.
   RationalNumber monetary_expansion = 12; // The monetary expansion.
   RationalNumber treasury_expansion = 13; // The treasury expansion.
-  uint64 min_pool_cost = 14; // The minimum pool cost.
-  ProtocolVersion protocol_version = 15; // The maximum value size in an output.
-  uint64 max_value_size = 16; // The maximum value size.
-  uint64 collateral_percentage = 17; // Percentage of the txfee which must be provided as collateral when including non-native scripts.
-  uint64 max_collateral_inputs = 18; // The maximum collateral inputs.
+  uint64 min_pool_cost = 14 [jstype = JS_STRING]; // The minimum pool cost.
+  ProtocolVersion protocol_version = 15; // The protocol version.
+  uint64 max_value_size = 16 [jstype = JS_STRING]; // The maximum value size.
+  uint64 collateral_percentage = 17 [jstype = JS_STRING]; // The collateral percentage.
+  uint64 max_collateral_inputs = 18 [jstype = JS_STRING]; // The maximum collateral inputs.
   CostModels cost_models = 19; // The cost models.
   ExPrices prices = 20; // The prices.
   ExUnits max_execution_units_per_transaction = 21; // The maximum execution units per transaction.
@@ -116,8 +117,8 @@ message PParams {
   uint32 min_committee_size = 26; // The minimum committee size.
   uint64 committee_term_limit = 27; // The committee term limit.
   uint64 governance_action_validity_period = 28; // The governance action validity period.
-  uint64 governance_action_deposit = 29; // The governance action deposit.
-  uint64 drep_deposit = 30; // The drep deposit.
+  uint64 governance_action_deposit = 29 [jstype = JS_STRING]; // The governance action deposit.
+  uint64 drep_deposit = 30 [jstype = JS_STRING]; // The drep deposit.
   uint64 drep_inactivity_period = 31; // The drep inactivity period.
 }
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Encode coin as String in JavaScript
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  # - cardano-api
  # - cardano-api-gen
   - cardano-rpc
  # - cardano-wasm
```

# Context

Because `protobuf-javascript` encodes integers in protobuf as `number`, it can cause precision loss and `number` in addition to that is a floating point type. To work around that one has to annotate the proto fields with `[jstype = JS_BIGINT]`. Related issues:
- https://github.com/protocolbuffers/protobuf-javascript/issues/74#issuecomment-1128002166
- https://github.com/protocolbuffers/protobuf-javascript/issues/67

Upstream PRs ported here:
- https://github.com/utxorpc/spec/pull/168
- https://github.com/utxorpc/spec/pull/166

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
