### PR TITLE
Export `AsTxMetadata`

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -819,6 +819,7 @@ module Cardano.Api.Tx
   , TxMetadata (..)
 
     -- ** Constructing metadata
+  , AsTxMetadata (..)
   , TxMetadataValue (..)
   , makeTransactionMetadata
   , mergeTransactionMetadata


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Re-export `asTxMetadata`
  type:
  - feature
```

# Context

As part of the work in https://github.com/IntersectMBO/cardano-cli/issues/1268 we need access to the `asTxMetadata` function from `cardano-cli`. This PR exposes it. The branch [[cardano-cli] restore-spo-polloing](https://github.com/IntersectMBO/cardano-cli/tree/restore-spo-polling) uses this (see backported branch [[cardano-api] backport/restore-spo-polling](https://github.com/IntersectMBO/cardano-api/tree/backport/restore-spo-polling)). Apparently this function was already exported in the past and it stopped being exported at some point.

# How to trust this PR

It is a simple change, but make sure that it was done in a consistent way.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
