### PR TITLE
Add roundtrip tests for `SerialiseAsRawBytes` for `SignedTx` and `UnsignedTx`

### DIFF
--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -209,6 +209,8 @@ instance
       :: Ledger.DecoderError -> SerialiseAsRawBytesError
     wrapError = SerialiseAsRawBytesError . displayException
 
+deriving instance Eq (UnsignedTx era)
+
 deriving instance Show (UnsignedTx era)
 
 newtype UnsignedTxError
@@ -337,6 +339,8 @@ makeKeyWitness era (UnsignedTx unsignedTx) wsk =
 -- | A transaction that has been witnesssed
 data SignedTx era
   = L.EraTx (LedgerEra era) => SignedTx (Ledger.Tx (LedgerEra era))
+
+deriving instance Eq (SignedTx era)
 
 deriving instance Show (SignedTx era)
 


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Added roundtrip tests for `SerialiseAsRawBytes` for `SignedTx` and `UnsignedTx`.
  type:
  - test
```

# Context

See this issue: https://github.com/IntersectMBO/cardano-api/issues/895. The comment was done when the serialisation was done in `wasm`,  but it has since been moved to `cardano-api` in the shape of `SerialiseAsRawBytes` instances.

The reason I limited the number of test cases generated to `20` is that, in my computer, with a default limit of `100`, it takes a whole minute. By limiting the number of tests to `20`, it takes 10 seconds, which is more in line with the rest of the tests.

# How to trust this PR

I've tested introducing a mistake (by removing the first character of the serialised string) and saw it failing. Other than that I think it is a matter of checking the coding style, and that the code that is being tested is the intended one.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
