### PR TITLE
Use sum type to represent TypeScript types

### DIFF
--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
@@ -7,6 +7,7 @@ module Cardano.Wasm.Internal.Api.Info
   , MethodInfo (..)
   , ParamInfo (..)
   , MethodReturnTypeInfo (..)
+  , tsTypeAsString
   )
 where
 
@@ -15,6 +16,30 @@ import Data.Text qualified as Text
 
 -- * API Information Data Types
 
+-- | TypeScript types that are not defined by this code.
+data TSType
+  = TSString
+  | TSNumber
+  | TSBigInt
+  | TSAny
+  | TSUtxoList
+  | TSUtxosForAddressList
+  deriving (Show, Eq)
+
+tsTypeAsString :: TSType -> String
+tsTypeAsString TSString = "string"
+tsTypeAsString TSNumber = "number"
+tsTypeAsString TSBigInt = "bigint"
+tsTypeAsString TSAny = "any"
+tsTypeAsString TSUtxoList =
+  "{ address: string, txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
+tsTypeAsString TSUtxosForAddressList =
+  "{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
+
+instance Aeson.ToJSON TSType where
+  toJSON :: TSType -> Aeson.Value
+  toJSON = Aeson.String . Text.pack . tsTypeAsString
+
 -- | Describes the return type of a method.
 data MethodReturnTypeInfo
   = -- | Returns an instance of the same object type (fluent interface).
@@ -22,7 +47,7 @@ data MethodReturnTypeInfo
   | -- | Returns a new instance of a specified virtual object type.
     NewObject String
   | -- | Returns a non-virtual-object type (e.g., JSString, number).
-    OtherType String
+    OtherType TSType
   deriving (Show, Eq)
 
 instance Aeson.ToJSON MethodReturnTypeInfo where
@@ -35,7 +60,7 @@ instance Aeson.ToJSON MethodReturnTypeInfo where
 data ParamInfo = ParamInfo
   { paramName :: String
   -- ^ Name of the parameter.
-  , paramType :: String
+  , paramType :: TSType
   -- ^ Type of the parameter (as a TypeScript type).
   , paramDoc :: String
   -- ^ Documentation for the parameter.
@@ -138,7 +163,7 @@ apiInfo =
                   { methodName = "getAddressBech32"
                   , methodDoc = "Get the Bech32 representation of the address. (Can be shared for receiving funds.)"
                   , methodParams = []
-                  , methodReturnType = OtherType "string"
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc = "The Bech32 representation of the address."
                   }
               , MethodInfo
@@ -146,7 +171,7 @@ apiInfo =
                   , methodDoc =
                       "Get the Bech32 representation of the verification key of the wallet. (Can be shared for verification.)"
                   , methodParams = []
-                  , methodReturnType = OtherType "string"
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc = "The Bech32 representation of the verification key."
                   }
               , MethodInfo
@@ -154,14 +179,14 @@ apiInfo =
                   , methodDoc =
                       "Get the Bech32 representation of the signing key of the wallet. (Must be kept secret.)"
                   , methodParams = []
-                  , methodReturnType = OtherType "string"
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc = "The Bech32 representation of the signing key."
                   }
               , MethodInfo
                   { methodName = "getBase16ForVerificationKeyHash"
                   , methodDoc = "Get the base16 representation of the hash of the verification key of the wallet."
                   , methodParams = []
-                  , methodReturnType = OtherType "string"
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc = "The base16 representation of the verification key hash."
                   }
               ]
@@ -176,8 +201,8 @@ apiInfo =
                   { methodName = "addTxInput"
                   , methodDoc = "Adds a simple transaction input to the transaction."
                   , methodParams =
-                      [ ParamInfo "txId" "string" "The transaction ID of the input UTxO."
-                      , ParamInfo "txIx" "number" "The index of the input within the UTxO."
+                      [ ParamInfo "txId" TSString "The transaction ID of the input UTxO."
+                      , ParamInfo "txIx" TSNumber "The index of the input within the UTxO."
                       ]
                   , methodReturnType = Fluent
                   , methodReturnDoc = "The `UnsignedTx` object with the added input."
@@ -186,8 +211,8 @@ apiInfo =
                   { methodName = "addSimpleTxOut"
                   , methodDoc = "Adds a simple transaction output to the transaction."
                   , methodParams =
-                      [ ParamInfo "destAddr" "string" "The destination address."
-                      , ParamInfo "lovelaceAmount" "bigint" "The amount in lovelaces to output."
+                      [ ParamInfo "destAddr" TSString "The destination address."
+                      , ParamInfo "lovelaceAmount" TSBigInt "The amount in lovelaces to output."
                       ]
                   , methodReturnType = Fluent
                   , methodReturnDoc = "The `UnsignedTx` object with the added output."
@@ -195,7 +220,7 @@ apiInfo =
               , MethodInfo
                   { methodName = "setFee"
                   , methodDoc = "Sets the fee for the transaction."
-                  , methodParams = [ParamInfo "lovelaceAmount" "bigint" "The fee amount in lovelaces."]
+                  , methodParams = [ParamInfo "lovelaceAmount" TSBigInt "The fee amount in lovelaces."]
                   , methodReturnType = Fluent
                   , methodReturnDoc = "The `UnsignedTx` object with the set fee."
                   }
@@ -203,21 +228,21 @@ apiInfo =
                   { methodName = "estimateMinFee"
                   , methodDoc = "Estimates the minimum fee for the transaction."
                   , methodParams =
-                      [ ParamInfo "protocolParams" "any" "The protocol parameters."
+                      [ ParamInfo "protocolParams" TSAny "The protocol parameters."
                       , ParamInfo
                           "numKeyWitnesses"
-                          "number"
+                          TSNumber
                           "The number of key witnesses."
-                      , ParamInfo "numByronKeyWitnesses" "number" "The number of Byron key witnesses."
-                      , ParamInfo "totalRefScriptSize" "number" "The total size of reference scripts in bytes."
+                      , ParamInfo "numByronKeyWitnesses" TSNumber "The number of Byron key witnesses."
+                      , ParamInfo "totalRefScriptSize" TSNumber "The total size of reference scripts in bytes."
                       ]
-                  , methodReturnType = OtherType "bigint"
+                  , methodReturnType = OtherType TSBigInt
                   , methodReturnDoc = "A promise that resolves to the estimated minimum fee in lovelaces."
                   }
               , MethodInfo
                   { methodName = "signWithPaymentKey"
                   , methodDoc = "Signs the transaction with a payment key."
-                  , methodParams = [ParamInfo "signingKey" "string" "The signing key to witness the transaction."]
+                  , methodParams = [ParamInfo "signingKey" TSString "The signing key to witness the transaction."]
                   , methodReturnType = NewObject signedTxObjectName
                   , methodReturnDoc = "A promise that resolves to a `SignedTx` object."
                   }
@@ -232,7 +257,7 @@ apiInfo =
               [ MethodInfo
                   { methodName = "alsoSignWithPaymentKey"
                   , methodDoc = "Adds an extra signature to the transaction with a payment key."
-                  , methodParams = [ParamInfo "signingKey" "string" "The signing key to witness the transaction."]
+                  , methodParams = [ParamInfo "signingKey" TSString "The signing key to witness the transaction."]
                   , methodReturnType = Fluent
                   , methodReturnDoc = "The `SignedTx` object with the additional signature."
                   }
@@ -240,7 +265,7 @@ apiInfo =
                   { methodName = "txToCbor"
                   , methodDoc = "Converts the signed transaction to its CBOR representation."
                   , methodParams = []
-                  , methodReturnType = OtherType "string"
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc =
                       "A promise that resolves to the CBOR representation of the transaction as a hex string."
                   }
@@ -256,14 +281,14 @@ apiInfo =
                   { methodName = "getEra"
                   , methodDoc = "Get the era from the Cardano Node using a GRPC-web client."
                   , methodParams = []
-                  , methodReturnType = OtherType "number"
+                  , methodReturnType = OtherType TSNumber
                   , methodReturnDoc = "A promise that resolves to the current era number."
                   }
               , MethodInfo
                   { methodName = "submitTx"
                   , methodDoc = "Submit a signed and CBOR-encoded transaction to the Cardano node."
-                  , methodParams = [ParamInfo "txCbor" "string" "The CBOR-encoded transaction as a hex string."]
-                  , methodReturnType = OtherType "string"
+                  , methodParams = [ParamInfo "txCbor" TSString "The CBOR-encoded transaction as a hex string."]
+                  , methodReturnType = OtherType TSString
                   , methodReturnDoc = "A promise that resolves to the transaction ID."
                   }
               , MethodInfo
@@ -271,7 +296,7 @@ apiInfo =
                   , methodDoc =
                       "Get the protocol parameters in the cardano-ledger format from the Cardano Node using a GRPC-web client."
                   , methodParams = []
-                  , methodReturnType = OtherType "any"
+                  , methodReturnType = OtherType TSAny
                   , methodReturnDoc = "A promise that resolves to the current protocol parameters."
                   }
               , MethodInfo
@@ -281,16 +306,16 @@ apiInfo =
                   , methodParams = []
                   , methodReturnType =
                       OtherType
-                        "{ address: string, txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
+                        TSUtxoList
                   , methodReturnDoc = "A promise that resolves to the current UTXO set."
                   }
               , MethodInfo
                   { methodName = "getUtxosForAddress"
                   , methodDoc = "Get UTXOs for a given address using a GRPC-web client."
-                  , methodParams = [ParamInfo "address" "string" "The address to get UTXOs for."]
+                  , methodParams = [ParamInfo "address" TSString "The address to get UTXOs for."]
                   , methodReturnType =
                       OtherType
-                        "{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
+                        TSUtxosForAddressList
                   , methodReturnDoc = "A promise that resolves to the UTXOs for the given address."
                   }
               ]
@@ -311,7 +336,7 @@ apiInfo =
                   , MethodInfo
                       { methodName = "newGrpcConnection"
                       , methodDoc = "Create a new client connection for communicating with a Cardano node through gRPC-web."
-                      , methodParams = [ParamInfo "webGrpcUrl" "string" "The URL of the gRPC-web server."]
+                      , methodParams = [ParamInfo "webGrpcUrl" TSString "The URL of the gRPC-web server."]
                       , methodReturnType = NewObject grpcConnectionName
                       , methodReturnDoc = "A promise that resolves to a new `GrpcConnection`."
                       }
@@ -325,14 +350,14 @@ apiInfo =
                   , MethodInfo
                       { methodName = "restorePaymentWalletFromSigningKeyBech32"
                       , methodDoc = "Restore a mainnet payment wallet from a Bech32 encoded signing key."
-                      , methodParams = [ParamInfo "signingKeyBech32" "string" "The Bech32 encoded signing key."]
+                      , methodParams = [ParamInfo "signingKeyBech32" TSString "The Bech32 encoded signing key."]
                       , methodReturnType = NewObject walletObjectName
                       , methodReturnDoc = "A promise that resolves to a new `Wallet` object."
                       }
                   , MethodInfo
                       { methodName = "generateTestnetPaymentWallet"
                       , methodDoc = "Generate a simple payment wallet for testnet, given the testnet's network magic."
-                      , methodParams = [ParamInfo "networkMagic" "number" "The network magic for the testnet."]
+                      , methodParams = [ParamInfo "networkMagic" TSNumber "The network magic for the testnet."]
                       , methodReturnType = NewObject walletObjectName
                       , methodReturnDoc = "A promise that resolves to a new `Wallet` object."
                       }
@@ -340,8 +365,8 @@ apiInfo =
                       { methodName = "restoreTestnetPaymentWalletFromSigningKeyBech32"
                       , methodDoc = "Restore a testnet payment wallet from a Bech32 encoded signing key."
                       , methodParams =
-                          [ ParamInfo "networkMagic" "number" "The network magic for the testnet."
-                          , ParamInfo "signingKeyBech32" "string" "The Bech32 encoded signing key."
+                          [ ParamInfo "networkMagic" TSNumber "The network magic for the testnet."
+                          , ParamInfo "signingKeyBech32" TSString "The Bech32 encoded signing key."
                           ]
                       , methodReturnType = NewObject walletObjectName
                       , methodReturnDoc = "A promise that resolves to a new `Wallet` object."

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/InfoToTypeScript.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/InfoToTypeScript.hs
@@ -1,5 +1,6 @@
 module Cardano.Wasm.Internal.Api.InfoToTypeScript where
 
+import Cardano.Wasm.Internal.Api.Info (tsTypeAsString)
 import Cardano.Wasm.Internal.Api.Info qualified as Info
 import Cardano.Wasm.Internal.Api.TypeScriptDefs qualified as TypeScript
 
@@ -63,10 +64,10 @@ paramInfoToFunctionParam :: Info.ParamInfo -> TypeScript.FunctionParam
 paramInfoToFunctionParam p =
   TypeScript.FunctionParam
     { TypeScript.paramName = Info.paramName p
-    , TypeScript.paramType = Info.paramType p
+    , TypeScript.paramType = tsTypeAsString $ Info.paramType p
     }
 
 methodReturnTypeToString :: String -> Info.MethodReturnTypeInfo -> String
 methodReturnTypeToString selfTypeName Info.Fluent = selfTypeName
 methodReturnTypeToString _ (Info.NewObject objTypeName) = "Promise<" <> objTypeName <> ">"
-methodReturnTypeToString _ (Info.OtherType typeName) = "Promise<" <> typeName <> ">"
+methodReturnTypeToString _ (Info.OtherType typeName) = "Promise<" <> tsTypeAsString typeName <> ">"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Refactored Haskell code to use a sum type to represent TypeScript types (instead of just `String`)
  type:
  - refactoring
```

# Context

See the following issue for details: https://github.com/IntersectMBO/cardano-api/issues/929

# How to trust this PR

It is a refactoring, and both the CI and I checked that the output typescript file didn't change, so that gives me very high confidence. Other than that, it is mainly a matter of ensuring the code style is fitting, that the namings are intuitive, and the comments are appropriate.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
