### PR TITLE
Split TypeScript declaration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,8 @@ cardano-tracer/cardano-tracer-test
 
 cardano-wasm/examples/*/cardano-wasm.wasm
 cardano-wasm/examples/*/cardano-wasm.js
-cardano-wasm/examples/*/cardano-api.d.ts
+cardano-wasm/examples/*/*.d.ts
 cardano-wasm/examples/*/cardano-api.js
 cardano-wasm/examples/*/cardano_node_grpc_web_pb.js
 .ghc-wasm/
-
 

--- a/cardano-wasm/app/Main.hs
+++ b/cardano-wasm/app/Main.hs
@@ -24,4 +24,4 @@ parser =
 main :: IO ()
 main = do
   cmdArgs <- execParser (info (parser <**> helper) fullDesc)
-  writeTypeScriptToDir (outputDir cmdArgs) (apiInfoToTypeScriptFile apiInfo)
+  mapM_ (writeTypeScriptToDir (outputDir cmdArgs)) (apiInfoToTypeScriptFile apiInfo)

--- a/cardano-wasm/cardano-wasm.cabal
+++ b/cardano-wasm/cardano-wasm.cabal
@@ -61,6 +61,7 @@ executable cardano-wasm
     cardano-crypto-class,
     cardano-ledger-api,
     cardano-strict-containers,
+    casing,
     containers,
     exceptions,
     filepath,

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -1,20 +1,10 @@
 // cardano-api.d.ts
 
-/// <reference path="./unsigned-tx.d.ts" />
+import UnsignedTx from './unsigned-tx';
 
-/// <reference path="./signed-tx.d.ts" />
+import GrpcConnection from './grpc-connection';
 
-/// <reference path="./grpc-connection.d.ts" />
-
-/// <reference path="./wallet.d.ts" />
-
-export default initialise;
-
-/**
- * Initialises the Cardano API.
- * @returns A promise that resolves to the main `CardanoApi` object.
- */
-declare function initialise(): Promise<CardanoApi>;
+import Wallet from './wallet';
 
 /**
  * The main Cardano API object with static methods.
@@ -66,3 +56,11 @@ declare interface CardanoApi {
      */
     restoreTestnetPaymentWalletFromSigningKeyBech32(networkMagic: number, signingKeyBech32: string): Promise<Wallet>;
 }
+
+/**
+ * Initialises the Cardano API.
+ * @returns A promise that resolves to the main `CardanoApi` object.
+ */
+declare function initialise(): Promise<CardanoApi>;
+
+export default initialise;

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -1,5 +1,13 @@
 // cardano-api.d.ts
 
+/// <reference path="./unsigned-tx.d.ts" />
+
+/// <reference path="./signed-tx.d.ts" />
+
+/// <reference path="./grpc-connection.d.ts" />
+
+/// <reference path="./wallet.d.ts" />
+
 export default initialise;
 
 /**
@@ -7,155 +15,6 @@ export default initialise;
  * @returns A promise that resolves to the main `CardanoApi` object.
  */
 declare function initialise(): Promise<CardanoApi>;
-
-/**
- * Represents an unsigned transaction.
- */
-declare interface UnsignedTx {
-    /**
-     * The type of the object, used for identification (the "UnsignedTx" string).
-     */
-    objectType: string;
-
-    /**
-     * Adds a simple transaction input to the transaction.
-     * @param txId The transaction ID of the input UTxO.
-     * @param txIx The index of the input within the UTxO.
-     * @returns The `UnsignedTx` object with the added input.
-     */
-    addTxInput(txId: string, txIx: number): UnsignedTx;
-
-    /**
-     * Adds a simple transaction output to the transaction.
-     * @param destAddr The destination address.
-     * @param lovelaceAmount The amount in lovelaces to output.
-     * @returns The `UnsignedTx` object with the added output.
-     */
-    addSimpleTxOut(destAddr: string, lovelaceAmount: bigint): UnsignedTx;
-
-    /**
-     * Sets the fee for the transaction.
-     * @param lovelaceAmount The fee amount in lovelaces.
-     * @returns The `UnsignedTx` object with the set fee.
-     */
-    setFee(lovelaceAmount: bigint): UnsignedTx;
-
-    /**
-     * Estimates the minimum fee for the transaction.
-     * @param protocolParams The protocol parameters.
-     * @param numKeyWitnesses The number of key witnesses.
-     * @param numByronKeyWitnesses The number of Byron key witnesses.
-     * @param totalRefScriptSize The total size of reference scripts in bytes.
-     * @returns A promise that resolves to the estimated minimum fee in lovelaces.
-     */
-    estimateMinFee(protocolParams: any, numKeyWitnesses: number, numByronKeyWitnesses: number, totalRefScriptSize: number): Promise<bigint>;
-
-    /**
-     * Signs the transaction with a payment key.
-     * @param signingKey The signing key to witness the transaction.
-     * @returns A promise that resolves to a `SignedTx` object.
-     */
-    signWithPaymentKey(signingKey: string): Promise<SignedTx>;
-}
-
-/**
- * Represents a signed transaction.
- */
-declare interface SignedTx {
-    /**
-     * The type of the object, used for identification (the "SignedTx" string).
-     */
-    objectType: string;
-
-    /**
-     * Adds an extra signature to the transaction with a payment key.
-     * @param signingKey The signing key to witness the transaction.
-     * @returns The `SignedTx` object with the additional signature.
-     */
-    alsoSignWithPaymentKey(signingKey: string): SignedTx;
-
-    /**
-     * Converts the signed transaction to its CBOR representation.
-     * @returns A promise that resolves to the CBOR representation of the transaction as a hex string.
-     */
-    txToCbor(): Promise<string>;
-}
-
-/**
- * Represents a gRPC-web client connection to a Cardano node.
- */
-declare interface GrpcConnection {
-    /**
-     * The type of the object, used for identification (the "GrpcConnection" string).
-     */
-    objectType: string;
-
-    /**
-     * Get the era from the Cardano Node using a GRPC-web client.
-     * @returns A promise that resolves to the current era number.
-     */
-    getEra(): Promise<number>;
-
-    /**
-     * Submit a signed and CBOR-encoded transaction to the Cardano node.
-     * @param txCbor The CBOR-encoded transaction as a hex string.
-     * @returns A promise that resolves to the transaction ID.
-     */
-    submitTx(txCbor: string): Promise<string>;
-
-    /**
-     * Get the protocol parameters in the cardano-ledger format from the Cardano Node using a GRPC-web client.
-     * @returns A promise that resolves to the current protocol parameters.
-     */
-    getProtocolParams(): Promise<any>;
-
-    /**
-     * Get all UTXOs from the node using a GRPC-web client.
-     * @returns A promise that resolves to the current UTXO set.
-     */
-    getAllUtxos(): Promise<{ address: string, txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]>;
-
-    /**
-     * Get UTXOs for a given address using a GRPC-web client.
-     * @param address The address to get UTXOs for.
-     * @returns A promise that resolves to the UTXOs for the given address.
-     */
-    getUtxosForAddress(address: string): Promise<{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]>;
-}
-
-/**
- * Represents a wallet.
- */
-declare interface Wallet {
-    /**
-     * The type of the object, used for identification (the "Wallet" string).
-     */
-    objectType: string;
-
-    /**
-     * Get the Bech32 representation of the address. (Can be shared for receiving funds.)
-     * @returns The Bech32 representation of the address.
-     */
-    getAddressBech32(): Promise<string>;
-
-    /**
-     * Get the Bech32 representation of the verification key of the wallet. (Can be shared for verification.)
-     * @returns The Bech32 representation of the verification key.
-     */
-    getBech32ForVerificationKey(): Promise<string>;
-
-    /**
-     * Get the Bech32 representation of the signing key of the wallet. (Must be kept secret.)
-     * @returns The Bech32 representation of the signing key.
-     */
-    getBech32ForSigningKey(): Promise<string>;
-
-    /**
-     * Get the base16 representation of the hash of the verification key of the wallet.
-     * @returns The base16 representation of the verification key hash.
-     */
-    getBase16ForVerificationKeyHash(): Promise<string>;
-}
 
 /**
  * The main Cardano API object with static methods.

--- a/cardano-wasm/lib-wrapper/grpc-connection.d.ts
+++ b/cardano-wasm/lib-wrapper/grpc-connection.d.ts
@@ -41,3 +41,5 @@ declare interface GrpcConnection {
      */
     getUtxosForAddress(address: string): Promise<{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]>;
 }
+
+export default GrpcConnection;

--- a/cardano-wasm/lib-wrapper/grpc-connection.d.ts
+++ b/cardano-wasm/lib-wrapper/grpc-connection.d.ts
@@ -1,0 +1,43 @@
+// grpc-connection.d.ts
+
+/**
+ * Represents a gRPC-web client connection to a Cardano node.
+ */
+declare interface GrpcConnection {
+    /**
+     * The type of the object, used for identification (the "GrpcConnection" string).
+     */
+    objectType: string;
+
+    /**
+     * Get the era from the Cardano Node using a GRPC-web client.
+     * @returns A promise that resolves to the current era number.
+     */
+    getEra(): Promise<number>;
+
+    /**
+     * Submit a signed and CBOR-encoded transaction to the Cardano node.
+     * @param txCbor The CBOR-encoded transaction as a hex string.
+     * @returns A promise that resolves to the transaction ID.
+     */
+    submitTx(txCbor: string): Promise<string>;
+
+    /**
+     * Get the protocol parameters in the cardano-ledger format from the Cardano Node using a GRPC-web client.
+     * @returns A promise that resolves to the current protocol parameters.
+     */
+    getProtocolParams(): Promise<any>;
+
+    /**
+     * Get all UTXOs from the node using a GRPC-web client.
+     * @returns A promise that resolves to the current UTXO set.
+     */
+    getAllUtxos(): Promise<{ address: string, txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]>;
+
+    /**
+     * Get UTXOs for a given address using a GRPC-web client.
+     * @param address The address to get UTXOs for.
+     * @returns A promise that resolves to the UTXOs for the given address.
+     */
+    getUtxosForAddress(address: string): Promise<{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]>;
+}

--- a/cardano-wasm/lib-wrapper/signed-tx.d.ts
+++ b/cardano-wasm/lib-wrapper/signed-tx.d.ts
@@ -22,3 +22,5 @@ declare interface SignedTx {
      */
     txToCbor(): Promise<string>;
 }
+
+export default SignedTx;

--- a/cardano-wasm/lib-wrapper/signed-tx.d.ts
+++ b/cardano-wasm/lib-wrapper/signed-tx.d.ts
@@ -1,0 +1,24 @@
+// signed-tx.d.ts
+
+/**
+ * Represents a signed transaction.
+ */
+declare interface SignedTx {
+    /**
+     * The type of the object, used for identification (the "SignedTx" string).
+     */
+    objectType: string;
+
+    /**
+     * Adds an extra signature to the transaction with a payment key.
+     * @param signingKey The signing key to witness the transaction.
+     * @returns The `SignedTx` object with the additional signature.
+     */
+    alsoSignWithPaymentKey(signingKey: string): SignedTx;
+
+    /**
+     * Converts the signed transaction to its CBOR representation.
+     * @returns A promise that resolves to the CBOR representation of the transaction as a hex string.
+     */
+    txToCbor(): Promise<string>;
+}

--- a/cardano-wasm/lib-wrapper/unsigned-tx.d.ts
+++ b/cardano-wasm/lib-wrapper/unsigned-tx.d.ts
@@ -1,0 +1,51 @@
+// unsigned-tx.d.ts
+
+/**
+ * Represents an unsigned transaction.
+ */
+declare interface UnsignedTx {
+    /**
+     * The type of the object, used for identification (the "UnsignedTx" string).
+     */
+    objectType: string;
+
+    /**
+     * Adds a simple transaction input to the transaction.
+     * @param txId The transaction ID of the input UTxO.
+     * @param txIx The index of the input within the UTxO.
+     * @returns The `UnsignedTx` object with the added input.
+     */
+    addTxInput(txId: string, txIx: number): UnsignedTx;
+
+    /**
+     * Adds a simple transaction output to the transaction.
+     * @param destAddr The destination address.
+     * @param lovelaceAmount The amount in lovelaces to output.
+     * @returns The `UnsignedTx` object with the added output.
+     */
+    addSimpleTxOut(destAddr: string, lovelaceAmount: bigint): UnsignedTx;
+
+    /**
+     * Sets the fee for the transaction.
+     * @param lovelaceAmount The fee amount in lovelaces.
+     * @returns The `UnsignedTx` object with the set fee.
+     */
+    setFee(lovelaceAmount: bigint): UnsignedTx;
+
+    /**
+     * Estimates the minimum fee for the transaction.
+     * @param protocolParams The protocol parameters.
+     * @param numKeyWitnesses The number of key witnesses.
+     * @param numByronKeyWitnesses The number of Byron key witnesses.
+     * @param totalRefScriptSize The total size of reference scripts in bytes.
+     * @returns A promise that resolves to the estimated minimum fee in lovelaces.
+     */
+    estimateMinFee(protocolParams: any, numKeyWitnesses: number, numByronKeyWitnesses: number, totalRefScriptSize: number): Promise<bigint>;
+
+    /**
+     * Signs the transaction with a payment key.
+     * @param signingKey The signing key to witness the transaction.
+     * @returns A promise that resolves to a `SignedTx` object.
+     */
+    signWithPaymentKey(signingKey: string): Promise<SignedTx>;
+}

--- a/cardano-wasm/lib-wrapper/unsigned-tx.d.ts
+++ b/cardano-wasm/lib-wrapper/unsigned-tx.d.ts
@@ -1,5 +1,7 @@
 // unsigned-tx.d.ts
 
+import SignedTx from './signed-tx';
+
 /**
  * Represents an unsigned transaction.
  */
@@ -49,3 +51,5 @@ declare interface UnsignedTx {
      */
     signWithPaymentKey(signingKey: string): Promise<SignedTx>;
 }
+
+export default UnsignedTx;

--- a/cardano-wasm/lib-wrapper/wallet.d.ts
+++ b/cardano-wasm/lib-wrapper/wallet.d.ts
@@ -33,3 +33,5 @@ declare interface Wallet {
      */
     getBase16ForVerificationKeyHash(): Promise<string>;
 }
+
+export default Wallet;

--- a/cardano-wasm/lib-wrapper/wallet.d.ts
+++ b/cardano-wasm/lib-wrapper/wallet.d.ts
@@ -1,0 +1,35 @@
+// wallet.d.ts
+
+/**
+ * Represents a wallet.
+ */
+declare interface Wallet {
+    /**
+     * The type of the object, used for identification (the "Wallet" string).
+     */
+    objectType: string;
+
+    /**
+     * Get the Bech32 representation of the address. (Can be shared for receiving funds.)
+     * @returns The Bech32 representation of the address.
+     */
+    getAddressBech32(): Promise<string>;
+
+    /**
+     * Get the Bech32 representation of the verification key of the wallet. (Can be shared for verification.)
+     * @returns The Bech32 representation of the verification key.
+     */
+    getBech32ForVerificationKey(): Promise<string>;
+
+    /**
+     * Get the Bech32 representation of the signing key of the wallet. (Must be kept secret.)
+     * @returns The Bech32 representation of the signing key.
+     */
+    getBech32ForSigningKey(): Promise<string>;
+
+    /**
+     * Get the base16 representation of the hash of the verification key of the wallet.
+     * @returns The base16 representation of the verification key hash.
+     */
+    getBase16ForVerificationKeyHash(): Promise<string>;
+}

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/Info.hs
@@ -106,6 +106,8 @@ instance Aeson.ToJSON MethodInfo where
 data VirtualObjectInfo = VirtualObjectInfo
   { virtualObjectName :: String
   -- ^ Name of the virtual object.
+  , dashCaseName :: String
+  -- ^ A dash-case version of the virtual object name, used for typescript declaration file name.
   , virtualObjectDoc :: String
   -- ^ Documentation for the virtual object.
   , virtualObjectMethods :: [MethodInfo]
@@ -115,9 +117,10 @@ data VirtualObjectInfo = VirtualObjectInfo
 
 instance Aeson.ToJSON VirtualObjectInfo where
   toJSON :: VirtualObjectInfo -> Aeson.Value
-  toJSON (VirtualObjectInfo name doc methods) =
+  toJSON (VirtualObjectInfo name tsFileName doc methods) =
     Aeson.object
       [ "objectName" Aeson..= name
+      , "fileName" Aeson..= tsFileName
       , "doc" Aeson..= doc
       , "methods" Aeson..= methods
       ]
@@ -157,6 +160,7 @@ apiInfo =
       walletObj =
         VirtualObjectInfo
           { virtualObjectName = walletObjectName
+          , dashCaseName = "wallet"
           , virtualObjectDoc = "Represents a wallet."
           , virtualObjectMethods =
               [ MethodInfo
@@ -195,6 +199,7 @@ apiInfo =
       unsignedTxObj =
         VirtualObjectInfo
           { virtualObjectName = unsignedTxObjectName
+          , dashCaseName = "unsigned-tx"
           , virtualObjectDoc = "Represents an unsigned transaction."
           , virtualObjectMethods =
               [ MethodInfo
@@ -252,6 +257,7 @@ apiInfo =
       signedTxObj =
         VirtualObjectInfo
           { virtualObjectName = signedTxObjectName
+          , dashCaseName = "signed-tx"
           , virtualObjectDoc = "Represents a signed transaction."
           , virtualObjectMethods =
               [ MethodInfo
@@ -275,6 +281,7 @@ apiInfo =
       grpcConnection =
         VirtualObjectInfo
           { virtualObjectName = grpcConnectionName
+          , dashCaseName = "grpc-connection"
           , virtualObjectDoc = "Represents a gRPC-web client connection to a Cardano node."
           , virtualObjectMethods =
               [ MethodInfo
@@ -324,6 +331,7 @@ apiInfo =
         { mainObject =
             VirtualObjectInfo
               { virtualObjectName = "CardanoApi"
+              , dashCaseName = "cardano-api"
               , virtualObjectDoc = "The main Cardano API object with static methods."
               , virtualObjectMethods =
                   [ MethodInfo

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/InfoToTypeScript.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/InfoToTypeScript.hs
@@ -4,15 +4,21 @@ import Cardano.Wasm.Internal.Api.Info (tsTypeAsString)
 import Cardano.Wasm.Internal.Api.Info qualified as Info
 import Cardano.Wasm.Internal.Api.TypeScriptDefs qualified as TypeScript
 
+import Data.List (nub)
+import Data.Map (Map)
+import Data.Map qualified as Map
+
 -- | Converts the Cardano API information to a TypeScript declaration file AST.
 apiInfoToTypeScriptFile :: Info.ApiInfo -> [TypeScript.TypeScriptFile]
 apiInfoToTypeScriptFile apiInfo =
   ( TypeScript.TypeScriptFile
       { TypeScript.typeScriptFileName = Info.dashCaseName (Info.mainObject apiInfo) <> ".d.ts"
       , TypeScript.typeScriptFileContent =
-          map importDeclaration virtualObjectInterfaces
-            ++ [ TypeScript.Declaration [] (TypeScript.ExportDec True "initialise")
-               , TypeScript.Declaration
+          virtualObjectInfoToInterfaceDecs
+            False
+            voMap
+            (Info.mainObject apiInfo)
+            ++ [ TypeScript.Declaration
                    [ Info.initialiseFunctionDoc apiInfo
                    , "@returns " <> Info.initialiseFunctionReturnDoc apiInfo
                    ]
@@ -24,47 +30,65 @@ apiInfoToTypeScriptFile apiInfo =
                              "Promise<" <> Info.virtualObjectName (Info.mainObject apiInfo) <> ">"
                          }
                    )
-               ]
-            ++ [ virtualObjectInfoToInterfaceDec $ Info.mainObject apiInfo
+               , TypeScript.Declaration [] (TypeScript.ExportDec True "initialise")
                ]
       }
   )
     : virtualObjectInterfaces
  where
   virtualObjectInterfaces =
-    map virtualObjectInfoToTypeScriptFile (Info.virtualObjects apiInfo)
+    map (virtualObjectInfoToTypeScriptFile voMap) (Info.virtualObjects apiInfo)
 
-importDeclaration :: TypeScript.TypeScriptFile -> TypeScript.Declaration
-importDeclaration file =
+  voMap = Map.fromList [(Info.virtualObjectName vo, vo) | vo <- Info.virtualObjects apiInfo]
+
+importDeclaration :: Info.VirtualObjectInfo -> TypeScript.Declaration
+importDeclaration vo =
   TypeScript.Declaration
     { TypeScript.declarationComment = []
-    , TypeScript.declarationContent = TypeScript.ImportDec $ "./" <> TypeScript.typeScriptFileName file
+    , TypeScript.declarationContent =
+        TypeScript.ImportDec (Info.virtualObjectName vo) $ Info.dashCaseName vo
     }
 
-virtualObjectInfoToTypeScriptFile :: Info.VirtualObjectInfo -> TypeScript.TypeScriptFile
-virtualObjectInfoToTypeScriptFile vo =
+importDeclarations
+  :: Map String Info.VirtualObjectInfo -> Info.VirtualObjectInfo -> [TypeScript.Declaration]
+importDeclarations voMap (Info.VirtualObjectInfo{Info.virtualObjectMethods = methods}) =
+  map
+    importDeclaration
+    $ nub
+      [ vo
+      | Info.MethodInfo{Info.methodReturnType = Info.NewObject returnType} <- methods
+      , Just vo <- [Map.lookup returnType voMap]
+      ]
+
+virtualObjectInfoToTypeScriptFile
+  :: Map String Info.VirtualObjectInfo -> Info.VirtualObjectInfo -> TypeScript.TypeScriptFile
+virtualObjectInfoToTypeScriptFile voMap vo =
   TypeScript.TypeScriptFile
     { TypeScript.typeScriptFileName = Info.dashCaseName vo <> ".d.ts"
-    , TypeScript.typeScriptFileContent =
-        [virtualObjectInfoToInterfaceDec vo]
+    , TypeScript.typeScriptFileContent = virtualObjectInfoToInterfaceDecs True voMap vo
     }
 
-virtualObjectInfoToInterfaceDec :: Info.VirtualObjectInfo -> TypeScript.Declaration
-virtualObjectInfoToInterfaceDec vo =
-  TypeScript.Declaration
-    [Info.virtualObjectDoc vo]
-    ( TypeScript.InterfaceDec
-        (Info.virtualObjectName vo)
-        ( [ TypeScript.InterfaceContent
-              [ "The type of the object, used for identification (the \""
-                  <> Info.virtualObjectName vo
-                  <> "\" string)."
-              ]
-              (TypeScript.InterfaceProperty "objectType" "string")
-          ]
-            <> map (methodInfoToInterfaceContent (Info.virtualObjectName vo)) (Info.virtualObjectMethods vo)
-        )
-    )
+virtualObjectInfoToInterfaceDecs
+  :: Bool -> Map String Info.VirtualObjectInfo -> Info.VirtualObjectInfo -> [TypeScript.Declaration]
+virtualObjectInfoToInterfaceDecs isDefaultExport voMap vo =
+  importDeclarations voMap vo
+    ++ [ TypeScript.Declaration
+           [Info.virtualObjectDoc vo]
+           ( TypeScript.InterfaceDec
+               (Info.virtualObjectName vo)
+               ( [ TypeScript.InterfaceContent
+                     [ "The type of the object, used for identification (the \""
+                         <> Info.virtualObjectName vo
+                         <> "\" string)."
+                     ]
+                     (TypeScript.InterfaceProperty "objectType" "string")
+                 ]
+                   <> map (methodInfoToInterfaceContent (Info.virtualObjectName vo)) (Info.virtualObjectMethods vo)
+               )
+           )
+       ]
+    ++ [ TypeScript.Declaration [] (TypeScript.ExportDec True $ Info.virtualObjectName vo) | isDefaultExport
+       ]
 
 methodInfoToInterfaceContent :: String -> Info.MethodInfo -> TypeScript.InterfaceContent
 methodInfoToInterfaceContent selfTypeName method =

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/TypeScriptDefs.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/TypeScriptDefs.hs
@@ -94,6 +94,8 @@ data DeclarationType
   | -- | Reference to import another TypeScript declaration file.
     ImportDec
       String
+      -- ^ Name of the symbol to import.
+      String
       -- ^ Path to the TypeScript declaration file to import.
 
 -- | Creates a builder for a TypeScript declaration type and content.
@@ -111,10 +113,8 @@ buildDeclarationType (InterfaceDec name properties) =
     <> " {"
     <> mconcat (map (\prop -> "\n" <> buildInterfaceContent prop <> "\n") properties)
     <> "}"
-buildDeclarationType (ImportDec path) =
-  "/// <reference path=\""
-    <> TLB.fromString path
-    <> "\" />"
+buildDeclarationType (ImportDec symbolName path) =
+  "import " <> TLB.fromString symbolName <> " from './" <> TLB.fromString path <> "';"
 
 -- | Represents a function parameter in TypeScript.
 data FunctionParam = FunctionParam

--- a/cardano-wasm/src/Cardano/Wasm/Internal/Api/TypeScriptDefs.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/Api/TypeScriptDefs.hs
@@ -91,6 +91,10 @@ data DeclarationType
       -- ^ Name of the interface.
       [InterfaceContent]
       -- ^ Definitions of the interface.
+  | -- | Reference to import another TypeScript declaration file.
+    ImportDec
+      String
+      -- ^ Path to the TypeScript declaration file to import.
 
 -- | Creates a builder for a TypeScript declaration type and content.
 buildDeclarationType :: DeclarationType -> TLB.Builder
@@ -107,6 +111,10 @@ buildDeclarationType (InterfaceDec name properties) =
     <> " {"
     <> mconcat (map (\prop -> "\n" <> buildInterfaceContent prop <> "\n") properties)
     <> "}"
+buildDeclarationType (ImportDec path) =
+  "/// <reference path=\""
+    <> TLB.fromString path
+    <> "\" />"
 
 -- | Represents a function parameter in TypeScript.
 data FunctionParam = FunctionParam

--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,7 @@
               config,
               ...
             }: let
-              generatedExampleFiles = ["cardano-wasm/lib-wrapper/cardano-api.d.ts"];
+              generatedExampleFiles = map (f: "cardano-wasm/lib-wrapper/${f}") (builtins.filter (f: lib.strings.hasSuffix ".d.ts" f) (builtins.attrNames (builtins.readDir ./cardano-wasm/lib-wrapper)));
               exportWasmPath = "export CARDANO_WASM=${config.hsPkgs.cardano-wasm.components.exes.cardano-wasm}/bin/cardano-wasm${pkgs.stdenv.hostPlatform.extensions.executable}";
             in {
               packages.cardano-wasm.components.tests.cardano-wasm-golden.preCheck = let


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Split TypeScript declaration files.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

See this issue: https://github.com/IntersectMBO/cardano-api/issues/922
Also this is the PR that prepared the terrain: https://github.com/IntersectMBO/cardano-api/pull/948

# How to trust this PR

The golden files didn't change except for the new import declarations, I checked that. Also tested that VSCode still shows inline help using the new files. Other than that, the changes to the code are relatively small.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
