### PR TITLE
Release cardano-api-10.18.0.0

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog for cardano-api
 
+## 10.18.0.0
+
+- Add some instance for `data Certificate era`
+  (compatible)
+  [PR 956](https://github.com/IntersectMBO/cardano-api/pull/956)
+
+- Implement experimental `estimateBalancedTxBody`
+  (feature, compatible)
+  [PR 887](https://github.com/IntersectMBO/cardano-api/pull/887)
+
+- Remove test library dependencies as it is bad practice to depend on them. This is a breaking change because there may be users that depend on both `cardano-api`'s test/gen libraries as well as ledger's test libraries. We think this is highly unlikely however.
+  (breaking)
+  [PR 942](https://github.com/IntersectMBO/cardano-api/pull/942)
+
+- Use raw bytes representation instead of CBOR for CIP-129 identifier serialisation
+  (breaking, bugfix)
+  [PR 937](https://github.com/IntersectMBO/cardano-api/pull/937)
+
+- Re-export `asTxMetadata`
+  (feature)
+  [PR 943](https://github.com/IntersectMBO/cardano-api/pull/943)
+
+- Expose additional ledger functionality:  `pattern AlonzoGenesis`, `costModelsValid`, `getCostModelParams`
+  (compatible)
+  [PR 939](https://github.com/IntersectMBO/cardano-api/pull/939)
+
+- Fix incorrect index in `GovActionId` serialisation
+  (bugfix)
+  [PR 936](https://github.com/IntersectMBO/cardano-api/pull/936)
+
+- Re-export `fromShelleyGenesis` in `Cardano.Api.Genesis`.
+  (compatible)
+  [PR 886](https://github.com/IntersectMBO/cardano-api/pull/886)
+
 ## 10.17.2.0
 
 - Add JavaScript wrapper and HTML browser example of usage for the `cardano-wasm` API

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-api
-version: 10.17.2.0
+version: 10.18.0.0
 synopsis: The cardano API
 description: The cardano API.
 category:

--- a/cardano-rpc/CHANGELOG.md
+++ b/cardano-rpc/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## 10.0.0.0 (unreleased)
 
+- cardano-rpc | Add getProtocolParamsJson gRPC endpoint
+  (feature, compatible)
+  [PR 919](https://github.com/IntersectMBO/cardano-api/pull/919)
+
+- cardano-rpc | Add UTxO RPC: submitTx method
+  (feature)
+  [PR 905](https://github.com/IntersectMBO/cardano-api/pull/905)
+
+- Update `proto-js-bundle` nix output to create bundles for all the `.proto` files
+  (feature)
+  [PR 913](https://github.com/IntersectMBO/cardano-api/pull/913)
+
+- Add nix output that produces a bundle with a web-grpc client for `cardano-rpc`
+  (feature)
+  [PR 911](https://github.com/IntersectMBO/cardano-api/pull/911)
+
+- cardano-rpc | Add `readUtxos` UTxO RPC query
+  (feature)
+  [PR 889](https://github.com/IntersectMBO/cardano-api/pull/889)
+
+- cardano-rpc: add UTxO RPC protocol parameters query
+  (feature)
+  [PR 888](https://github.com/IntersectMBO/cardano-api/pull/888)
+
 - cardano-rpc: Add cardano-rpc package with a dummy gRPC service
   (feature)
   [PR 885](https://github.com/IntersectMBO/cardano-api/pull/885)

--- a/cardano-wasm/CHANGELOG.md
+++ b/cardano-wasm/CHANGELOG.md
@@ -2,13 +2,59 @@
 
 ## 10.0.0.0 (unreleased)
 
-- Added support for compiling `cardano-api` to `wasm`
+- Added `newTx` and `newExperimentalEraTx` functions to `cardano-wasm` API
   (feature)
-  [PR 852](https://github.com/IntersectMBO/cardano-api/pull/852)
+  [PR 953](https://github.com/IntersectMBO/cardano-api/pull/953)
+
+- Added simple wallet example using `cardano-wasm`
+  (feature)
+  [PR 940](https://github.com/IntersectMBO/cardano-api/pull/940)
+
+- Fix coin serialisation to use `bigint` instead of `Number`
+  (bugfix)
+  [PR 931](https://github.com/IntersectMBO/cardano-api/pull/931)
+
+- cardano-wasm | Add `getUtxos` using GRPC-web to JS API
+  (feature, compatible)
+  [PR 927](https://github.com/IntersectMBO/cardano-api/pull/927)
+
+- cardano-wasm | Add getProtocolParams query to cardano-wasm
+  (feature)
+  [PR 924](https://github.com/IntersectMBO/cardano-api/pull/924)
+
+- Fix capitalisation error in typescript declaration (it used BigInt instead of bigint, which is a different thing)
+  (bugfix)
+  [PR 925](https://github.com/IntersectMBO/cardano-api/pull/925)
+
+- Added support for submitting transactions through gRPC-web to the `cardano-wasm` API
+  (feature)
+  [PR 920](https://github.com/IntersectMBO/cardano-api/pull/920)
+
+- Added support for handling payment addresses and keys to `cardano-wasm` API
+  (feature)
+  [PR 917](https://github.com/IntersectMBO/cardano-api/pull/917)
+
+- Updated `proto-js-bundle` nix output to create a single `.js` bundle file with qualified names for each `.proto`
+  (feature)
+  [PR 914](https://github.com/IntersectMBO/cardano-api/pull/914)
+
+- Added wasm API support for querying era from cardano-node (through GRPC-web)
+  (feature)
+  [PR 912](https://github.com/IntersectMBO/cardano-api/pull/912)
+
+- Added typescript declaration for `cardano-wasm` API
+  (feature, documentation)
+  [PR 901](https://github.com/IntersectMBO/cardano-api/pull/901)
+
+- Add `estimateMinFee` function to `UnsignedTx` in `cardano-wasm` API
+  (feature)
+  [PR 900](https://github.com/IntersectMBO/cardano-api/pull/900)
 
 - Add `SerialiseAsRawBytes` instance to `UnsignedTx ConwayEra`
   (feature)
   [PR 880](https://github.com/IntersectMBO/cardano-api/pull/880)
 
-
+- Added support for compiling `cardano-api` to `wasm`
+  (feature)
+  [PR 852](https://github.com/IntersectMBO/cardano-api/pull/852)
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release cardano-api-10.18.0.0
  type:
  - release
  projects:
  - cardano-api
```

Corresponding CHaP PR: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1135