### PR TITLE
chore(deps): upgrade hedgehog-extras to 0.10.0.0 and optimize CI

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -16,7 +16,7 @@ jobs:
       # Modify this value to "invalidate" the cache.
       HLS_CACHE_VERSION: "2025-09-04"
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -17,7 +17,7 @@ jobs:
       HLS_CACHE_VERSION: "2025-09-04"
 
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
 

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-06-22T20:18:27Z
+  , hackage.haskell.org 2025-09-10T10:05:13Z
   , cardano-haskell-packages 2025-06-20T09:11:51Z
 
 packages:

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -441,7 +441,7 @@ test-suite cardano-api-golden
     errors,
     filepath,
     hedgehog >=1.1,
-    hedgehog-extras ^>=0.8,
+    hedgehog-extras ^>=0.10,
     microlens,
     plutus-core ^>=1.45,
     plutus-ledger-api,

--- a/cardano-wasm/cardano-wasm.cabal
+++ b/cardano-wasm/cardano-wasm.cabal
@@ -85,7 +85,7 @@ test-suite cardano-wasm-golden
     build-depends:
       filepath,
       hedgehog >=1.1,
-      hedgehog-extras ^>=0.8,
+      hedgehog-extras ^>=0.10,
       tasty,
       tasty-hedgehog,
 

--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1750624265,
-        "narHash": "sha256-6G+1a6WS1Y2CLWz+5MpUAvJs03pGMhpIZBaUAH3wQ1Y=",
+        "lastModified": 1758447740,
+        "narHash": "sha256-F1AxwYezN7YF20q2d8sQZeG+cryzNBeH1J7C18kj+go=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "275b94a4dffdd33b33fd734e01066715da4d7f9c",
+        "rev": "4a8df371282fabbbf1d5ce23623d834aa356e101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade hedgehog-extras dependency from 0.8 to 0.10.0.0 and optimize HLS CI workflow with 4-core runner
  type:
    - maintenance    # not directly related to the code
  projects:
    - cardano-api
    - cardano-wasm
```

# Context

This PR contains two related improvements to the project infrastructure:

1. **Dependency Upgrade**: Updates the `hedgehog-extras` testing library from version `^>=0.8` to `^>=0.10` across both `cardano-api` and `cardano-wasm` test suites, bringing in the latest property-based testing utilities and improvements.

2. **CI Optimization**: Migrates the HLS (Haskell Language Server) workflow from standard `ubuntu-latest` runners to `ubuntu-latest-4-cores` for improved build performance, with timeout extended to 90 minutes to accommodate the additional processing capacity.

The dependency upgrade also includes refreshing the Hackage index-state from `2025-06-22T20:18:27Z` to `2025-09-10T10:05:13Z` and updating the corresponding `flake.lock` with the new Hackage snapshot.

# How to trust this PR

Key changes to review:

1. **Dependency Changes**: Verify the version bump in cabal files:
   - `cardano-api/cardano-api.cabal`: `hedgehog-extras ^>=0.8` → `hedgehog-extras ^>=0.10`
   - `cardano-wasm/cardano-wasm.cabal`: `hedgehog-extras ^>=0.8` → `hedgehog-extras ^>=0.10`

2. **Build Configuration**: Check the updated Hackage index-state in `cabal.project` and corresponding `flake.lock` changes

3. **CI Configuration**: Review the runner change in `.github/workflows/hls.yml`:
   - `runs-on: ubuntu-latest` → `runs-on: ubuntu-latest-4-cores`
   - `timeout-minutes: 60` → `timeout-minutes: 90`

To verify compatibility, you can run the test suites locally:
```bash
cabal test cardano-api:cardano-api-golden
cabal test cardano-wasm:cardano-wasm-golden
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff