### PR TITLE
Add `cardano-wasm` typedocs to `gh-pages`

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -1,4 +1,4 @@
-name: "Haddock documentation"
+name: "Update github pages"
 
 on:
   push:
@@ -34,27 +34,34 @@ jobs:
         run: |
           cabal build all
 
-      - name: Build documentation
+      - name: Build haddock documentation
         run: |
-          cabal haddock-project --output=./haddocks --internal --foreign-libraries
+          mkdir website
+          cabal haddock-project --output=./website --internal --foreign-libraries
 
-      - name: Compress haddocks
+      - name: Build typedoc documentation
         run: |
-          tar -czf haddocks.tgz -C haddocks .
+          nix build .#wasm-typedoc
+          mkdir -p website/cardano-wasm/typedoc
+          cp -r result/. website/cardano-wasm/typedoc/
 
-      - name: Upload haddocks artifact
+      - name: Compress website
+        run: |
+          tar -czf website.tgz -C website .
+
+      - name: Upload website artifact
         uses: actions/upload-artifact@v4
         if: ${{ always() }}
         continue-on-error: true
         with:
-          name: haddocks
-          path: ./haddocks.tgz
+          name: website
+          path: ./website.tgz
 
       - name: Deploy documentation to gh-pages 🚀
         if: github.ref == 'refs/heads/master'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
-          publish_dir: haddocks
+          publish_dir: website
           cname: cardano-api.cardano.intersectmbo.org
           force_orphan: true

--- a/flake.nix
+++ b/flake.nix
@@ -265,9 +265,13 @@
             # also provide hydraJobs through legacyPackages to allow building without system prefix:
             inherit hydraJobs;
           };
-          packages = lib.optionalAttrs (system != "aarch64-darwin") {
-            proto-js-bundle = proto-js-bundle-drv;
-          };
+          packages =
+            lib.optionalAttrs (system != "aarch64-darwin") {
+              proto-js-bundle = proto-js-bundle-drv;
+            }
+            // {
+              wasm-typedoc = wasm-typedoc-drv;
+            };
           devShells = let
             # profiling shell
             profilingShell = p: {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `cardano-wasm` typedocs to `gh-pages`
  type:
  - maintenance
  - documentation
  projects:
  - cardano-wasm
```

# Context

In order to improve accessibility of the `cardano-wasm` API. This PR publishes the generated `typedoc` for `master` branch. In the same way that it is done already for haddocs of `cardano-api`.

We publish it under the URL https://cardano-api.cardano.intersectmbo.org/cardano-wasm/typedoc/ because the root is already taken by Haddock (and I am not sure moving it is a good idea). And even if we move the Haddock to a subfolder, we want to be able to write manual documentation, examples, and demos that is not generated by typedoc. So we can do that under https://cardano-api.cardano.intersectmbo.org/cardano-wasm/, and we can add a link to the `typedoc` generated doc in the future.

Also, as part of the PR, but unrelated: I've added the typedoc generation flake output `.#wasm-typedoc`, which I had forgotten to do.

# How to trust this PR

You can see the output in: https://github.com/IntersectMBO/cardano-api/actions/runs/18293470492

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
