### PR TITLE
Remove redundant typeclass GetPlutusScriptPurpose

### DIFF
--- a/cardano-api/src/Cardano/Api/Experimental/Plutus.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Plutus.hs
@@ -28,7 +28,7 @@ module Cardano.Api.Experimental.Plutus
   , WitnessableItem (..)
 
     -- ** Create the index for a witnessable thing.
-  , GetPlutusScriptPurpose (..)
+  , toPlutusScriptPurpose
   , createIndexedPlutusScriptWitnesses
   , getAnyWitnessRedeemerPointerMap
   , obtainAlonzoScriptPurposeConstraints


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove redundant typeclass GetPlutusScriptPurpose
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  # - cardano-wasm
```

# Context
Instance `GetPlutusScriptPurpose era` served little purpose and can be easily replaced by just a regular function. 

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
