### PR TITLE
Increase stale issues period to 90 days and closing after 190 days

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity.  Remove stale label or comment or this will be closed in 120 days.'
+          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity.  Remove stale label or comment or this will be closed in 100 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity.'
-          close-issue-message: 'This issue was closed because it has been stalled for 120 days with no activity.  Remove stale label or comment or this will be closed in 60 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 190 days with no activity.'
           close-pr-message: 'This issue was closed because it has been stalled for 60 days with no activity.'
-          days-before-stale: 30
-          days-before-close: 120
+          days-before-stale: 90
+          days-before-close: 190
           days-before-pr-stale: 45
           days-before-pr-close: 60


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Increase stale issues period to 90 days and closing after 190 days
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  # - cardano-wasm
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
