### PR TITLE
Fix type and naming issues

### DIFF
--- a/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
+++ b/cardano-wasm/src/Cardano/Wasm/Internal/JavaScript/Bridge.hs
@@ -362,17 +362,17 @@ signWithPaymentKey jsUnsignedTx jsSigningKey =
 -- * SignedTxObject
 
 foreign export javascript "alsoSignWithPaymentKey"
-  alsoSignWithPaymentKey :: JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
+  alsoSignWithPaymentKey :: JSSignedTx -> JSSigningKey -> IO JSSignedTx
 
 foreign export javascript "txToCbor"
   txToCbor :: JSSignedTx -> IO JSString
 
 -- | Sign an unsigned transaction with a payment key.
-alsoSignWithPaymentKey :: HasCallStack => JSUnsignedTx -> JSSigningKey -> IO JSSignedTx
-alsoSignWithPaymentKey jsUnsignedTx jsSigningKey =
+alsoSignWithPaymentKey :: HasCallStack => JSSignedTx -> JSSigningKey -> IO JSSignedTx
+alsoSignWithPaymentKey jsSignedTx jsSigningKey =
   toJSVal
     =<< ( Wasm.alsoSignWithPaymentKeyImpl
-            <$> fromJSVal jsUnsignedTx
+            <$> fromJSVal jsSignedTx
             <*> fromJSVal jsSigningKey
         )
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix soft typing issue that doesn't affect the behaviour of the code but is misleading
  type:
  - bugfix
  projects:
  - cardano-wasm
```

# Context

This PR fixes a mistake that was using the wrong types and names for the wrong things, but because they were aliases, it didn't get caught by the compiler.

# How to trust this PR

Check that the changes make sense and don't have an effect in the behaviour of the code.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
