### PR TITLE
Release 10.20.0.0

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog for cardano-api
 
+## 10.20.0.0
+
+- Deprecate "old" certificate api helper functions and introduce equivalent functions exposed by:
+    `Cardano.Api.Compatible.Certificate`
+    `Cardano.Api.Experimental.Certificate`
+  (feature, breaking, refactoring)
+  [PR 983](https://github.com/IntersectMBO/cardano-api/pull/983)
+
+- Added `HasTypeProxy` `FromCBOR`, `ToCBOR`, and `SerialiseAsCBOR ` instances to `TxOut`.
+  (feature)
+  [PR 960](https://github.com/IntersectMBO/cardano-api/pull/960)
+
+- Replace `Certificate` in `TxCertificates` with new api's `Certificate` type.
+  (breaking)
+  [PR 962](https://github.com/IntersectMBO/cardano-api/pull/962)
+
 ## 10.19.1.0
 
 - Update `cardano-ledger-api` to fix bug in `queryPoolState`, where current Pool parameters were returned instead of the future ones.

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.8
 name: cardano-api
-version: 10.19.1.0
+version: 10.20.0.0
 synopsis: The cardano API
 description: The cardano API.
 category:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 10.20.0.0
  type:
  - release       
  projects:
  - cardano-api
```

# Context

This PR prepares the 10.20.0.0 release of cardano-api by documenting all the changes that have been merged since the 10.19.1.0 release. This release includes significant improvements to the certificate API and enhancements to TxOut serialization capabilities.

The release contains:
- **Breaking changes**: Replacement of the Certificate type in TxCertificates with the new API's Certificate type
- **New features**: Additional type class instances for TxOut (HasTypeProxy, FromCBOR, ToCBOR, SerialiseAsCBOR)
- **Refactoring**: Deprecation of old certificate API helper functions in favor of new modules

# How to trust this PR

This is a straightforward release preparation PR that only updates documentation and version numbers:

1. **CHANGELOG.md**: Documents three major changes that were merged in recent PRs (#983, #960, #962)
2. **cardano-api.cabal**: Bumps version from 10.19.1.0 to 10.20.0.0

The changelog entries accurately describe the merged changes and link to their respective pull requests for full traceability.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff