### PR TITLE
gRPC: Add TxOut CBOR representation to `readUtxos` method, fix address serialisation in TxOutput.

### DIFF
--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -68,6 +68,7 @@ library
     base,
     bytestring,
     cardano-api >=10.17,
+    cardano-binary,
     cardano-ledger-api,
     cardano-ledger-conway,
     cardano-ledger-core,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    gRPC: Add TxOut CBOR representation to `readUtxos` method, fix address serialisation in TxOutput.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  # - cardano-api
  # - cardano-api-gen
   - cardano-rpc
  # - cardano-wasm
```

# Context

Fixes address serialisation (wrong type was used before). Adds missing CBOR representation of TxOut to `readUtxos` RPC method.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
