### PR TITLE
Fix location of `AddressArray` in read utxos requests

### DIFF
--- a/cardano-wasm/src-wasm/Cardano/Wasm/Internal/JavaScript/GRPC.hs
+++ b/cardano-wasm/src-wasm/Cardano/Wasm/Internal/JavaScript/GRPC.hs
@@ -49,7 +49,7 @@ foreign import javascript safe
 -- | Get UTXOs for a given address using a GRPC-web client.
 foreign import javascript safe
   "{ let req = new cardano_node.query.ReadUtxosRequest(); \
-     let addresses = new proto.AddressArray(); \
+     let addresses = new proto.utxorpc.v1alpha.cardano.AddressArray(); \
      addresses.addItems(btoa($2)); \
      req.setCardanoAddresses(addresses); \
      let pres = await ($1).query.readUtxos(req, {}); \


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed location of AddressArray in read utxos request
  type:
  - bugfix
  projects:
  - cardano-wasm
```

# Context

The `js_readUtxosForAddress` function was failing because `AddressArray` constructor moved. This PR fixes the location, so that everything works.

# How to trust this PR

The only way is to test it, really, unless you know that the constructor indeed moved to this location.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
