### PR TITLE
Build pure WASI1 wasm binary in CI

### DIFF
--- a/.github/workflows/haskell-wasm.yml
+++ b/.github/workflows/haskell-wasm.yml
@@ -141,6 +141,8 @@ jobs:
     - name: Build all
       run: |
         wasm32-wasi-cabal build cardano-wasm --no-semaphore -j1 --ghc-options="-j1"
+        wasm32-wasi-cabal build cardano-wasi --no-semaphore -j1 --ghc-options="-j1"
+        cp $(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasi | tail -n1) cardano-wasm/cardano-wasi.wasm
 
     - name: Prepare example
       run: |
@@ -225,6 +227,13 @@ jobs:
       with:
         name: cardano-wasm
         path: cardano-wasm/lib-wrapper/*
+        compression-level: 9
+
+    - name: Upload pure WASI wasm binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: cardano-wasi
+        path: cardano-wasm/cardano-wasi.wasm
         compression-level: 9
 
     - name: Upload built NPM package


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Build pure WASI1 wasm binary in CI
  type:
  - feature
  projects:
  - cardano-wasm
```

# Context

https://github.com/IntersectMBO/cardano-api/pull/995 create a new project that compiles to WASM that exposes a version of `cardano-wasm` that doesn't depend on any JS but only on WASI1-preview. This PR builds it and uploads the build as part of the Haskel WASM GHA.

# How to trust this PR

It is very few lines of code, very similar to existing ones, and if the CI passes, then there is no much room for error.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
