### PR TITLE
refactor(api): migrate ToJSON instances to use experimental Era type

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -65,6 +65,7 @@ import Cardano.Api.Era.Internal.Eon.Convert
 import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
 import Cardano.Api.Error (Error (..), displayError)
+import Cardano.Api.Experimental.Era qualified as Exp
 import Cardano.Api.HasTypeProxy qualified as HTP
 import Cardano.Api.Ledger.Internal.Reexport qualified as Ledger
 import Cardano.Api.Monad.Error
@@ -338,24 +339,13 @@ fromBabbageTxOut w txdatums txout =
           (fromAlonzoData d)
     | otherwise = TxOutDatumHash (convert w) (ScriptDataHash dh)
 
-instance IsCardanoEra era => ToJSON (TxOut ctx era) where
-  toJSON = txOutToJsonValue cardanoEra
+instance Exp.IsEra era => ToJSON (TxOut ctx era) where
+  toJSON = txOutToJsonValue Exp.useEra
 
-txOutToJsonValue :: CardanoEra era -> TxOut ctx era -> Aeson.Value
+txOutToJsonValue :: Exp.Era era -> TxOut ctx era -> Aeson.Value
 txOutToJsonValue era (TxOut addr val dat refScript) =
   case era of
-    ByronEra -> object ["address" .= addr, "value" .= val]
-    ShelleyEra -> object ["address" .= addr, "value" .= val]
-    AllegraEra -> object ["address" .= addr, "value" .= val]
-    MaryEra -> object ["address" .= addr, "value" .= val]
-    AlonzoEra ->
-      object
-        [ "address" .= addr
-        , "value" .= val
-        , datHashJsonVal dat
-        , "datum" .= datJsonVal dat
-        ]
-    BabbageEra ->
+    Exp.ConwayEra ->
       object
         [ "address" .= addr
         , "value" .= val
@@ -365,17 +355,7 @@ txOutToJsonValue era (TxOut addr val dat refScript) =
         , "inlineDatumRaw" .= inlineDatumRawJsonCbor dat
         , "referenceScript" .= refScriptJsonVal refScript
         ]
-    ConwayEra ->
-      object
-        [ "address" .= addr
-        , "value" .= val
-        , datHashJsonVal dat
-        , "datum" .= datJsonVal dat
-        , "inlineDatum" .= inlineDatumJsonVal dat
-        , "inlineDatumRaw" .= inlineDatumRawJsonCbor dat
-        , "referenceScript" .= refScriptJsonVal refScript
-        ]
-    DijkstraEra ->
+    Exp.DijkstraEra ->
       object
         [ "address" .= addr
         , "value" .= val

--- a/cardano-api/src/Cardano/Api/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/UTxO.hs
@@ -81,12 +81,12 @@ module Cardano.Api.UTxO
   )
 where
 
-import Cardano.Api.Era.Internal.Core (IsCardanoEra)
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
   ( IsShelleyBasedEra
   , ShelleyBasedEra
   , ShelleyLedgerEra
   )
+import Cardano.Api.Experimental.Era qualified as Exp
 import Cardano.Api.Tx.Internal.Output
   ( CtxUTxO
   , TxOut (..)
@@ -133,7 +133,7 @@ instance GHC.IsList (UTxO era) where
   fromList = UTxO . GHC.fromList
   toList = GHC.toList . unUTxO
 
-instance IsCardanoEra era => ToJSON (UTxO era) where
+instance Exp.IsEra era => ToJSON (UTxO era) where
   toJSON (UTxO m) = toJSON m
   toEncoding (UTxO m) = toEncoding m
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -21,6 +21,9 @@ import Hedgehog.Gen qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
+testEra :: ShelleyBasedEra ConwayEra
+testEra = ShelleyBasedEraConway
+
 prop_json_roundtrip_alonzo_genesis :: Property
 prop_json_roundtrip_alonzo_genesis = H.property $ do
   genesis <- forAll genAlonzoGenesis
@@ -28,27 +31,27 @@ prop_json_roundtrip_alonzo_genesis = H.property $ do
 
 prop_json_roundtrip_utxo :: Property
 prop_json_roundtrip_utxo = H.property $ do
-  utxo <- forAll $ genUTxO ShelleyBasedEraBabbage
+  utxo <- forAll $ genUTxO testEra
   tripping utxo encode eitherDecode
 
 prop_json_roundtrip_reference_scripts :: Property
 prop_json_roundtrip_reference_scripts = H.property $ do
-  rScript <- forAll $ genReferenceScript ShelleyBasedEraBabbage
+  rScript <- forAll $ genReferenceScript testEra
   tripping rScript encode eitherDecode
 
 prop_json_roundtrip_txoutvalue :: Property
 prop_json_roundtrip_txoutvalue = H.property $ do
-  oVal <- forAll $ genTxOutValue ShelleyBasedEraBabbage
+  oVal <- forAll $ genTxOutValue testEra
   tripping oVal encode eitherDecode
 
 prop_json_roundtrip_txout_tx_context :: Property
 prop_json_roundtrip_txout_tx_context = H.property $ do
-  txOut <- forAll $ genTxOutTxContext ShelleyBasedEraBabbage
+  txOut <- forAll $ genTxOutTxContext testEra
   tripping txOut encode eitherDecode
 
 prop_json_roundtrip_txout_utxo_context :: Property
 prop_json_roundtrip_txout_utxo_context = H.property $ do
-  txOut <- forAll $ genTxOutUTxOContext ShelleyBasedEraBabbage
+  txOut <- forAll $ genTxOutUTxOContext testEra
   tripping txOut encode eitherDecode
 
 prop_json_roundtrip_scriptdata_detailed_json :: Property


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Migrates ToJSON instances for TxOut and UTxO types to use the new experimental Era framework,
    simplifying era handling and reducing pattern matching complexity in JSON serialization.
  type:
  - refactoring    # QoL changes
  projects:
  - cardano-api
```

# Context

This PR refactors the JSON serialization logic for `TxOut` and `UTxO` types to adopt the experimental Era framework (`Cardano.Api.Experimental.Era`). The change replaces the `IsCardanoEra` constraint with `Exp.IsEra`, providing a cleaner and more maintainable approach to era-specific serialization.

The refactoring significantly reduces the complexity of `txOutToJsonValue` by eliminating redundant pattern matches for historical eras (Byron through Babbage) that share identical serialization logic, keeping only the distinct implementations for Conway and Dijkstra eras.

# How to trust this PR

The changes are purely refactoring with no functional changes to the JSON output format. Key areas to review:

- **Constraint changes**: `IsCardanoEra era => ToJSON` becomes `Exp.IsEra era => ToJSON` in both `TxOut` and `UTxO` modules
- **Pattern simplification**: The `txOutToJsonValue` function now only handles `Exp.ConwayEra` and `Exp.DijkstraEra`, removing 6 redundant case branches
- **Test updates**: Tests have been updated to use `ShelleyBasedEraConway` instead of `ShelleyBasedEraBabbage` for better coverage

To verify the changes preserve existing behavior:
```bash
# Run the JSON roundtrip tests
cabal test cardano-api-test --test-options "-p Json"

# Verify all tests pass
cabal test all
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff