### PR TITLE
cardano-wasm: use envoy-bin in wasm nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,7 +252,7 @@
                   wasm.secp256k1
                   wasm.blst
                 ]
-                ++ lib.optional (system == "x86_64-linux" || system == "aarch64-linux") wasm-pkgs.envoy;
+                ++ lib.optional (system == "x86_64-linux" || system == "aarch64-linux") wasm-pkgs.envoy-bin;
             };
           };
         playwrightShell = let


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    This patch makes the wasm nix devshell use envoy-bin instead of
    envoy from nixpkgs, given envoy build on nixos hydra has been
    broken for a long time:
    https://github.com/NixOS/nixpkgs/issues/438433. This is also
    blocking ghc-wasm-meta from upgrading to nixos-25.11 nixpkgs
    channel at the moment, since cardano-wasm build is included as a
    part of our integration tests.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  # - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  - cardano-wasm
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
