### PR TITLE
cardano-wasm: use envoy-bin in wasm nix devshell (Supersedes #1043) 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,7 +252,7 @@
                   wasm.secp256k1
                   wasm.blst
                 ]
-                ++ lib.optional (system == "x86_64-linux" || system == "aarch64-linux") wasm-pkgs.envoy;
+                ++ lib.optional (system == "x86_64-linux" || system == "aarch64-linux") wasm-pkgs.envoy-bin;
             };
           };
         playwrightShell = let


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make wasm nix devshell use envoy-bin instead of
    envoy from nixpkgs
  type:
  - maintenance
  projects:
  - cardano-wasm
```

See #1043