### PR TITLE
Revert "refactor(api): migrate ToJSON instances to use experimental Era type"

### DIFF
--- a/cardano-api/src/Cardano/Api/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/UTxO.hs
@@ -81,12 +81,12 @@ module Cardano.Api.UTxO
   )
 where
 
+import Cardano.Api.Era.Internal.Core (IsCardanoEra)
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
   ( IsShelleyBasedEra
   , ShelleyBasedEra
   , ShelleyLedgerEra
   )
-import Cardano.Api.Experimental.Era qualified as Exp
 import Cardano.Api.Tx.Internal.Output
   ( CtxUTxO
   , TxOut (..)
@@ -133,7 +133,7 @@ instance GHC.IsList (UTxO era) where
   fromList = UTxO . GHC.fromList
   toList = GHC.toList . unUTxO
 
-instance Exp.IsEra era => ToJSON (UTxO era) where
+instance IsCardanoEra era => ToJSON (UTxO era) where
   toJSON (UTxO m) = toJSON m
   toEncoding (UTxO m) = toEncoding m
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -21,9 +21,6 @@ import Hedgehog.Gen qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-testEra :: ShelleyBasedEra ConwayEra
-testEra = ShelleyBasedEraConway
-
 prop_json_roundtrip_alonzo_genesis :: Property
 prop_json_roundtrip_alonzo_genesis = H.property $ do
   genesis <- forAll genAlonzoGenesis
@@ -31,27 +28,27 @@ prop_json_roundtrip_alonzo_genesis = H.property $ do
 
 prop_json_roundtrip_utxo :: Property
 prop_json_roundtrip_utxo = H.property $ do
-  utxo <- forAll $ genUTxO testEra
+  utxo <- forAll $ genUTxO ShelleyBasedEraBabbage
   tripping utxo encode eitherDecode
 
 prop_json_roundtrip_reference_scripts :: Property
 prop_json_roundtrip_reference_scripts = H.property $ do
-  rScript <- forAll $ genReferenceScript testEra
+  rScript <- forAll $ genReferenceScript ShelleyBasedEraBabbage
   tripping rScript encode eitherDecode
 
 prop_json_roundtrip_txoutvalue :: Property
 prop_json_roundtrip_txoutvalue = H.property $ do
-  oVal <- forAll $ genTxOutValue testEra
+  oVal <- forAll $ genTxOutValue ShelleyBasedEraBabbage
   tripping oVal encode eitherDecode
 
 prop_json_roundtrip_txout_tx_context :: Property
 prop_json_roundtrip_txout_tx_context = H.property $ do
-  txOut <- forAll $ genTxOutTxContext testEra
+  txOut <- forAll $ genTxOutTxContext ShelleyBasedEraBabbage
   tripping txOut encode eitherDecode
 
 prop_json_roundtrip_txout_utxo_context :: Property
 prop_json_roundtrip_txout_utxo_context = H.property $ do
-  txOut <- forAll $ genTxOutUTxOContext testEra
+  txOut <- forAll $ genTxOutUTxOContext ShelleyBasedEraBabbage
   tripping txOut encode eitherDecode
 
 prop_json_roundtrip_scriptdata_detailed_json :: Property


### PR DESCRIPTION


This reverts commit 21408c8fc897d13e64aedda4a622bd5962d4fe15.

# Changelog

```yaml
- description: |
    The reverted PR breaks the query utxo command in cardano-cli which is supposed to be compatible for all shelley based eras.
  type:
  - bugfix         
  projects:
  - cardano-api
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
