### PR TITLE
[backport for 10.13] Fix canonical CBOR bug

### DIFF
--- a/cardano-api/src/Cardano/Api/Internal/Serialise/Cbor/Canonical.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Serialise/Cbor/Canonical.hs
@@ -67,7 +67,9 @@ canonicaliseTerm = \case
   (TTagged tag term) ->
     TTagged tag $ canonicaliseTerm term
   (TListI terms) ->
-    TList terms
+    TList $ map canonicaliseTerm terms
+  (TList terms) ->
+    TList $ map canonicaliseTerm terms
   term -> term
 
 -- | Implements sorting of CBOR terms for canonicalisation. CBOR terms are compared by lexical order of their


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
  type:
  - bugfix      
  projects:
  - cardano-api
```

# Context

Backport for https://github.com/IntersectMBO/cardano-api/pull/1047
