### PR TITLE
Add change log entries from patch releases

### DIFF
--- a/cardano-api/CHANGELOG.md
+++ b/cardano-api/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for cardano-api
 
+## 10.20.1.0
+
+- Remove duplicated `Arbitrary` orphans and re-import `testlib`s
+  (bugfix)
+  [PR 1070](https://github.com/IntersectMBO/cardano-api/pull/1070)
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1060](https://github.com/IntersectMBO/cardano-api/pull/1060)
+
 ## 10.20.0.0
 
 - Deprecate "old" certificate api helper functions and introduce equivalent functions exposed by:
@@ -15,6 +25,16 @@
 - Replace `Certificate` in `TxCertificates` with new api's `Certificate` type.
   (breaking)
   [PR 962](https://github.com/IntersectMBO/cardano-api/pull/962)
+
+## 10.19.2.0
+
+- Remove duplicated `Arbitrary` orphans and re-import `testlib`s
+  (bugfix)
+  [PR 1069](https://github.com/IntersectMBO/cardano-api/pull/1069)
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1059](https://github.com/IntersectMBO/cardano-api/pull/1059)
 
 ## 10.19.1.0
 
@@ -35,6 +55,16 @@
 - Add `Cardano.Api.Address.shelleyPayAddrToPaymentKeyHash`.
   (feature, compatible)
   [PR 976](https://github.com/IntersectMBO/cardano-api/pull/976)
+
+## 10.18.1.0
+
+- Remove duplicated `Arbitrary` orphans and re-import `testlib`s
+  (bugfix)
+  [PR 1068](https://github.com/IntersectMBO/cardano-api/pull/1068)
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1058](https://github.com/IntersectMBO/cardano-api/pull/1058)
 
 ## 10.18.0.0
 
@@ -69,6 +99,11 @@
 - Re-export `fromShelleyGenesis` in `Cardano.Api.Genesis`.
   (compatible)
   [PR 886](https://github.com/IntersectMBO/cardano-api/pull/886)
+
+## 10.17.3.0
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
 
 ## 10.17.2.0
 
@@ -259,6 +294,12 @@
   (compatible)
   [PR 841](https://github.com/IntersectMBO/cardano-api/pull/841)
 
+## 10.16.4.0
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1056](https://github.com/IntersectMBO/cardano-api/pull/1056)
+
 ## 10.16.3.0
 
 - Add `IsShelleyBasedEra` constraint to `EraCommonConstraints`
@@ -322,6 +363,12 @@
   (feature)
   [PR 778](https://github.com/IntersectMBO/cardano-api/pull/778)
 
+## 10.15.1.0
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1055](https://github.com/IntersectMBO/cardano-api/pull/1055)
+
 ## 10.15.0.0
 
 - Removed Babbage era from `Experimental` API together with `babbageEraOnwardsToEra` function.
@@ -344,6 +391,12 @@
 - Fixed CBOR codecs for Proposal
   (compatible, maintenance)
   [PR 823](https://github.com/IntersectMBO/cardano-api/pull/823)
+
+## 10.14.2.0
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1054](https://github.com/IntersectMBO/cardano-api/pull/1054)
 
 ## 10.14.1.0
 
@@ -378,6 +431,12 @@
   * IsShelleyBasedEra era
   (feature)
   [PR 806](https://github.com/IntersectMBO/cardano-api/pull/806)
+
+## 10.13.2.0
+
+- The current canonicalisation functionality does not canonicalise CBOR maps in CBOR lists
+  (bugfix)
+  [PR 1052](https://github.com/IntersectMBO/cardano-api/pull/1052)
 
 ## 10.13.1.0
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add change log entries from patch release
  type:
    - maintenance    # not directly related to the code
  projects:
    - cardano-api
```

# Context

We have back-ported these two bug-fixes:
- https://github.com/IntersectMBO/cardano-api/pull/1047
- https://github.com/IntersectMBO/cardano-api/pull/1051 

Because versions patched have diverged from `master` and also have the same changes in different parts of the commit history, it doesn't make sense to merge the patch release PRs to `master`. But because we don't do that, the change log entries for those releases are also not in the `CHANGELOG.md` file in `master`.

This PR fixes that, by adding the change log entries from the patch releases to the `master` branch.

# How to trust this PR

The contents are just copied from the release PRs for patches. These are the relevant PRs:
- https://github.com/IntersectMBO/cardano-api/pull/1053
- https://github.com/IntersectMBO/cardano-api/pull/1061
- https://github.com/IntersectMBO/cardano-api/pull/1062
- https://github.com/IntersectMBO/cardano-api/pull/1063
- https://github.com/IntersectMBO/cardano-api/pull/1064
- https://github.com/IntersectMBO/cardano-api/pull/1065
- https://github.com/IntersectMBO/cardano-api/pull/1066
- https://github.com/IntersectMBO/cardano-api/pull/1067

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
