### PR TITLE
Apply `wasm-opt` to wasm generated in CI

### DIFF
--- a/.github/workflows/haskell-wasm.yml
+++ b/.github/workflows/haskell-wasm.yml
@@ -143,11 +143,11 @@ jobs:
       run: |
         wasm32-wasi-cabal build cardano-wasm --no-semaphore -j1 --ghc-options="-j1"
         wasm32-wasi-cabal build cardano-wasi --no-semaphore -j1 --ghc-options="-j1"
-        cp $(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasi | tail -n1) cardano-wasm/cardano-wasi.wasm
+        wasm-opt -O4 $(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasi | tail -n1) -o cardano-wasm/cardano-wasi.wasm
 
     - name: Prepare example
       run: |
-        cp $(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasm | tail -n1) cardano-wasm/lib-wrapper/
+        wasm-opt -Oz $(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasm | tail -n1) -o cardano-wasm/lib-wrapper/cardano-wasm.wasm
         $(wasm32-wasi-ghc --print-libdir)/post-link.mjs -i "$(env -u CABAL_CONFIG wasm32-wasi-cabal list-bin exe:cardano-wasm | tail -n1)" -o cardano-wasm/lib-wrapper/cardano-wasm.js
         cp cardano-wasm/lib-wrapper/* cardano-wasm/examples/basic/
 

--- a/flake.nix
+++ b/flake.nix
@@ -247,6 +247,7 @@
                   wasm-pkgs.curl
                   wasm-pkgs.git
                   wasm-pkgs.patch-package
+                  wasm-pkgs.binaryen
                   inputs.ghc-wasm-meta.packages.${system}.all_9_10
                   wasm.libsodium
                   wasm.secp256k1


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Apply `wasm-opt` to wasm generated in CI
  type:
    - optimisation
  projects:
    - cardano-wasm
```

# Context

Especially for the web, it is important that the size of files that have to be distributed is small, because it translates on loading time for the user.

This PR modifies the CI process that generates `wasm` to use `wasm-opt` to reduce the size of the resulting binaries.

- For the JS dependent we use the `-Oz` flag, to optimise for size (this results on a reduction from 48MB to 17MB).
- For the JS independent (wasi) we use the `-O4` flag, to optimise for speed, since for offline usages, this is typically more important than size.

# How to trust this PR

The tests passing is a good sign, if things start failing mysteriously in the future we can roll this back. You can see the effect of the optimisation in the resulting binaries produced by the CI.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

