### PR TITLE
Bump `ouroboros-consensus-0.30.0.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-12-02T22:23:29Z
-  , cardano-haskell-packages 2026-01-24T11:25:12Z
+  , cardano-haskell-packages 2026-01-29T19:27:06Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -165,7 +165,7 @@ library
     network-mux,
     nothunks,
     ordered-containers,
-    ouroboros-consensus ^>=0.29,
+    ouroboros-consensus ^>=0.30,
     ouroboros-consensus-cardano ^>=0.26,
     ouroboros-consensus-diffusion ^>=0.25,
     ouroboros-consensus-protocol ^>=0.13,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1769539092,
-        "narHash": "sha256-bFd3tzV8FaYUQiZFA1V+2WjXPcnlxN1GbNs+HO6aUR4=",
+        "lastModified": 1769729764,
+        "narHash": "sha256-JhEnYd6Kpcg+beRhgdrL3bzKTkN2SrzO8NWCEluP/58=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a175d3efe0e99fe537b822e344c451166f6d0b97",
+        "rev": "5851ee1a8f253baff87dc0572e7048df8fbb3473",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bumped `ouroboros-consensus-0.30.0.0`
  type:
    - maintenance    # not directly related to the code
  projects:
    - cardano-api
```

# Context

This PR bumps the version of the dependency `ouroboros-consensus` to the version `0.30.0.0`

# How to trust this PR

Because it just updates a dependency, if it compiles and CI passes, is probably fine.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
