### PR TITLE
Update CI for newer cabal, use only GHC 9.12 on windows consistently

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,19 +20,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6", "9.10"]
-        cabal: ["3.14"]
+        ghc: [&ghc-stable "9.6", "9.10", &ghc-latest "9.12"]
+        cabal: [&cabal-version "3.16"]
         sys:
-          - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
           - { os: ubuntu-latest, shell: bash }
         include:
           # Using include, to make sure there will only be one macOS job, even if the matrix gets expanded later on.
           # We want a single job, because macOS runners are scarce.
-          - cabal: "3.12"
-            ghc: "9.6"
+          - ghc: *ghc-stable
+            cabal: *cabal-version
             sys:
               os: macos-latest
               shell: bash
+          - ghc: *ghc-latest
+            cabal: *cabal-version
+            sys:
+              os: windows-latest
+              shell: 'C:/msys64/usr/bin/bash.exe -e {0}'
 
     defaults:
         run:
@@ -81,11 +85,11 @@ jobs:
         use-sodium-vrf: true # default is true
 
     - name: "[Linux] Install grpc dependencies"
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.12'
       run: sudo apt install libsnappy-dev protobuf-compiler
 
     - name: "[Windows] Install grpc dependencies"
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.ghc != '9.12'
       run: |
         /usr/bin/pacman --noconfirm -S mingw-w64-x86_64-snappy mingw-w64-x86_64-protobuf
         cat <<EOF >> $GITHUB_ENV
@@ -94,7 +98,7 @@ jobs:
         EOF
 
     - name: "[macOS] Install grpc dependencies"
-      if: runner.os == 'macOS'
+      if: runner.os == 'macOS' && matrix.ghc != '9.12'
       run: |
         brew install snappy protobuf
         SNAPPY_PREFIX=$(brew --prefix snappy)
@@ -114,23 +118,23 @@ jobs:
 
 
     - name: '[Linux] [cardano-rpc] Install buf'
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.12'
       run: |
         curl -sSL "https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-x86_64" -o "/usr/local/bin/buf"
         chmod +x /usr/local/bin/buf
 
     - name: '[Linux] [cardano-rpc] Install proto-lens-protoc'
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.12'
       run: |
         cabal install proto-lens-protoc --installdir=$HOME/.local/bin
 
     - name: '[Linux] [cardano-rpc] Generate protobuf code'
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.12'
       working-directory: cardano-rpc
       run: buf generate proto
 
     - name: '[Linux] [cardano-rpc] Check that generated files from proto definitions are up to date'
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && matrix.ghc != '9.12'
       run: |
         git add cardano-rpc/gen
         if ! git diff --staged --quiet -- cardano-rpc/gen; then

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Test HLS works
         if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         run: |
+          # TODO remove after reenabling cardano-rpc
+          rm -r cardano-rpc/
           # workaround for https://github.com/haskell/haskell-language-server/issues/3735
           cat <<EOF > hie.yaml
           cradle:

--- a/cabal.project
+++ b/cabal.project
@@ -13,14 +13,14 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-12-02T22:23:29Z
-  , cardano-haskell-packages 2026-02-09T12:34:49Z
+  , hackage.haskell.org 2026-02-06T20:27:32Z
+  , cardano-haskell-packages 2026-02-12T12:47:38Z
 
 packages:
     cardano-api
     cardano-api-gen
     cardano-wasm
-    cardano-rpc
+    -- cardano-rpc
 
 extra-packages: Cabal
 
@@ -52,9 +52,9 @@ jobs: $ncpus
 semaphore: True
 
 if impl (ghc >= 9.12)
-  allow-newer:
-    -- https://github.com/kapralVV/Unique/issues/11
-    , Unique:hashable
+  constraints:
+    -- haskell.nix patch does not work for 1.6.8
+    , any.crypton-x509-system < 1.6.8
 
 -- WASM compilation specific
 

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -38,7 +38,7 @@ common project-config
     -Wunused-packages
 
 common maybe-unix
-  if !(os(windows)|| arch(wasm32))
+  if !(os(windows) || arch(wasm32))
     build-depends: unix
 
 common maybe-Win32
@@ -46,7 +46,7 @@ common maybe-Win32
     build-depends: Win32
 
 common text
-  if os(osx)&& arch(aarch64)
+  if os(osx) && arch(aarch64)
     build-depends: text >=1.2.5.0
   else
     build-depends: text >=2.0

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -38,7 +38,7 @@ common project-config
     -Wredundant-constraints
     -Wunused-packages
 
-  if impl(ghc >= 9.12)
+  if impl(ghc >=9.12)
     buildable: False
 
 library

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1770641570,
-        "narHash": "sha256-wsqV7xDxdDtrH5Yvo5slVOaKPMrysulaDH7d/nU50u8=",
+        "lastModified": 1770910700,
+        "narHash": "sha256-oOQrIwKKJ0uOqkIuf9G3L6MZ0PaKlxOIwRKz6Dv6b1k=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8fc4f331682bb230a35dd6c59d7aea1dbfc3bd63",
+        "rev": "2d8d9a4b0e911fa31340b3c7e669c898956acadf",
         "type": "github"
       },
       "original": {
@@ -248,11 +248,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766017489,
-        "narHash": "sha256-5f1Bkw2ESZz1eYAPc2jis2ewSrxnmX00pF6rEtC3Gwc=",
+        "lastModified": 1770942948,
+        "narHash": "sha256-dQKpqfHHQUbirXLY5yXp0jktRI2yXiUBG4ZAGQcEBKk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "1048c223690ef006bd23089d32863198fa2fa637",
+        "rev": "2efa5ca9e3e621f1919540ed0d22ede856a98c9f",
         "type": "github"
       },
       "original": {
@@ -281,11 +281,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1764721618,
-        "narHash": "sha256-qayd4uIJ1PU3TWnm4ExC8WmLBUo8/4LL9QEWngiaz24=",
+        "lastModified": 1771016120,
+        "narHash": "sha256-/Iu+9bkCdyTHQswWk64XSy/EkRzqq/hTtEeRtwM2egw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "1b943b3cd91ffdaa62da6fe5870b7c7cfca30729",
+        "rev": "aaea35facc6ec26cf70ee66a0b7589d5e35630da",
         "type": "github"
       },
       "original": {
@@ -312,6 +312,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -336,11 +337,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1766019120,
-        "narHash": "sha256-jMXvU/vr1CcGcPdr4/KVHi55+JwPJpr6salCitN/M6E=",
+        "lastModified": 1770944382,
+        "narHash": "sha256-lb1LiiIxAscVhgNdHUGBWiBtdhpf8gYEpJ2dsQxjSYw=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "aa046831ccdbb412bef2d367f06a3b4d0eec2947",
+        "rev": "92c02e3955c2db61fe23d0ce6c09ada5b7bb867a",
         "type": "github"
       },
       "original": {
@@ -429,6 +430,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -627,11 +645,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1770174258,
+        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
         "type": "github"
       },
       "original": {
@@ -881,6 +899,7 @@
         "iohkNix": "iohkNix",
         "nixpkgs": "nixpkgs_3",
         "pre-commit-hooks": "pre-commit-hooks",
+        "unstable": "unstable",
         "wasm-nixpkgs": [
           "ghc-wasm-meta",
           "nixpkgs"
@@ -924,11 +943,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765930395,
-        "narHash": "sha256-R1LpWCQdhHJwNDbioitMK/a3zXiNRS2vBbKfNXE7ZHM=",
+        "lastModified": 1770769351,
+        "narHash": "sha256-f8WSq0lEB+R1h78Rr+J1U4El6m33rR7zskrHREZqPgk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "a78ff1a9a591f04d48aa49922e6b951fe6b45b79",
+        "rev": "f656c6e52f1efe33648c6433f30011a4d5e0abd0",
         "type": "github"
       },
       "original": {
@@ -965,6 +984,21 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "unstable": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     # blst fails to build for x86_64-darwin
     # nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     nixpkgs.url = "github:NixOS/nixpkgs/11cb3517b3af6af300dd6c055aeda73c9bf52c48";
+    unstable.url = "nixpkgs/nixos-unstable";
     iohkNix.url = "github:input-output-hk/iohk-nix";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
     pre-commit-hooks.url = "github:cachix/git-hooks.nix";
@@ -43,10 +44,12 @@
     ];
 
     # see flake `variants` below for alternative compilers
-    defaultCompiler = "ghc9102";
-    # Used for cross compilation, and so referenced in .github/workflows/release-upload.yml. Adapt the
-    # latter if you change this value.
-    crossCompilerVersion = "ghc9122";
+    # this is used to build cardano-node on linux, so we test against it
+    stableCompiler = "ghc967";
+    # this is our main compiler for development
+    defaultCompiler = "ghc9122";
+    # Used for cross compilation for windows.
+    crossCompilerVersion = defaultCompiler;
   in
     inputs.flake-utils.lib.eachSystem supportedSystems (
       system: let
@@ -59,9 +62,16 @@
                 buildInputs = previousAttrs.buildInputs ++ [prev.pkgs.windows.mingw_w64_pthreads];
               });
             };
+          unstableOverlay = final: prev: {
+            unstable = import inputs.unstable {
+              inherit system;
+              inherit (inputs.haskellNix) config;
+            };
+          };
         in
           import inputs.nixpkgs {
             overlays = [
+              unstableOverlay
               # iohkNix.overlays.crypto provide libsodium-vrf, libblst and libsecp256k1.
               inputs.iohkNix.overlays.crypto
               # haskellNix.overlay can be configured by later overlays, so need to come before them.
@@ -142,18 +152,18 @@
           # tools we want in our shell, from hackage
           shell.tools =
             {
-              cabal = "3.14.1.1";
+              cabal = "3.16.1.0";
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
               ghcid = "0.8.9";
-              cabal-gild = "1.3.1.2";
+              cabal-gild = "1.7.0.1";
               fourmolu = "0.18.0.0";
               haskell-language-server = "2.11.0.0";
               hlint = "3.10";
             };
           # and from nixpkgs or other inputs
-          shell.nativeBuildInputs = with nixpkgs; [gh git jq yq-go actionlint shellcheck snappy protobuf buf blst];
+          shell.nativeBuildInputs = with nixpkgs; [gh git jq yq-go unstable.actionlint shellcheck snappy protobuf buf blst];
           # disable Hoogle until someone request it
           shell.withHoogle = false;
           # Skip cross compilers for the shell
@@ -221,9 +231,16 @@
         flake = cabalProject.flake (
           lib.optionalAttrs (system == "x86_64-linux") {
             # on linux, build/test other supported compilers
-            variants = lib.genAttrs [crossCompilerVersion] (compiler-nix-name: {
-              inherit compiler-nix-name;
-            });
+            variants = let
+              # on windows we're using defaultCompiler only - stableCompiler makes ghc-iserv flaky
+              osDependentStableCompiler =
+                if nixpkgs.stdenv.hostPlatform.isWindows
+                then defaultCompiler
+                else stableCompiler;
+            in
+              lib.genAttrs [osDependentStableCompiler crossCompilerVersion] (compiler-nix-name: {
+                inherit compiler-nix-name;
+              });
           }
         );
         # wasm shell


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update CI for newer cabal, use only GHC 9.12 on windows consistently
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-api
  # - cardano-api-gen
   - cardano-rpc
  # - cardano-wasm
```

# Context

Since we switched to GHC 9.12 for windows builds, we may switch to GHC 9.12 everywhere.
This PR also adds GHC 9.6.7 (linux only) to nix, to check that we're still building fine and we're able to integrate in cardano-node.
Unused GHC versions are removed from windows build GHA. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
