### PR TITLE
Add grpc-deps reusable GHA

### DIFF
--- a/.github/actions/grpc-deps/action.yml
+++ b/.github/actions/grpc-deps/action.yml
@@ -1,0 +1,33 @@
+name: 'Install gRPC system dependencies'
+description: 'Install dependencies required to build a project with proto-lens'
+
+runs:
+  using: composite
+  steps:
+    - name: "[Linux] Install grpc dependencies"
+      shell: 'bash'
+      if: runner.os == 'Linux'
+      run: sudo apt install libsnappy-dev protobuf-compiler
+
+    - name: "[Windows] Install grpc dependencies"
+      shell: 'C:/msys64/usr/bin/bash.exe -e {0}'
+      if: runner.os == 'Windows'
+      run: |
+        /usr/bin/pacman --noconfirm -S mingw-w64-x86_64-snappy mingw-w64-x86_64-protobuf
+        cat <<EOF >> $GITHUB_ENV
+        LIBRARY_PATH=/mingw64/lib
+        CPATH=/mingw64/include
+        EOF
+
+    - name: "[macOS] Install grpc dependencies"
+      shell: 'bash'
+      if: runner.os == 'macOS'
+      run: |
+        brew install snappy protobuf
+        SNAPPY_PREFIX=$(brew --prefix snappy)
+        # TODO generalise and move these paths fixups to https://github.com/input-output-hk/actions/blob/latest/base/action.yml
+        cat <<EOF >> $GITHUB_ENV
+        LIBRARY_PATH=$SNAPPY_PREFIX/lib
+        CPATH=$SNAPPY_PREFIX/include
+        EOF
+

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -84,31 +84,10 @@ jobs:
       with:
         use-sodium-vrf: true # default is true
 
-    - name: "[Linux] Install grpc dependencies"
-      if: runner.os == 'Linux'
-      run: sudo apt install libsnappy-dev protobuf-compiler
-
-    - name: "[Windows] Install grpc dependencies"
-      if: runner.os == 'Windows'
-      run: |
-        /usr/bin/pacman --noconfirm -S mingw-w64-x86_64-snappy mingw-w64-x86_64-protobuf
-        cat <<EOF >> $GITHUB_ENV
-        LIBRARY_PATH=/mingw64/lib
-        CPATH=/mingw64/include
-        EOF
-
-    - name: "[macOS] Install grpc dependencies"
-      if: runner.os == 'macOS'
-      run: |
-        brew install snappy protobuf
-        SNAPPY_PREFIX=$(brew --prefix snappy)
-        # TODO generalise and move these paths fixups to https://github.com/input-output-hk/actions/blob/latest/base/action.yml
-        cat <<EOF >> $GITHUB_ENV
-        LIBRARY_PATH=$SNAPPY_PREFIX/lib
-        CPATH=$SNAPPY_PREFIX/include
-        EOF
-
     - uses: actions/checkout@v4
+
+    - name: Install gRPC system dependencies
+      uses: ./.github/actions/grpc-deps
 
     - name: Cache and install Cabal dependencies
       uses: ./.github/actions/cabal-cache
@@ -116,17 +95,15 @@ jobs:
         cabal-store: ${{ steps.setup-haskell.outputs.cabal-store }}
         cache-version: ${{ env.CABAL_CACHE_VERSION }}
 
-
-    - name: '[Linux] [cardano-rpc] Install buf'
+    - name: '[Linux] [cardano-rpc] Install buf tool'
       if: runner.os == 'Linux'
       run: |
         curl -sSL "https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-x86_64" -o "/usr/local/bin/buf"
         chmod +x /usr/local/bin/buf
 
-    - name: '[Linux] [cardano-rpc] Install proto-lens-protoc'
+    - name: '[Linux] [cardano-rpc] Install proto-lens-protoc tool'
       if: runner.os == 'Linux'
-      run: |
-        cabal install proto-lens-protoc --installdir=$HOME/.local/bin
+      run: cabal install proto-lens-protoc --installdir=$HOME/.local/bin
 
     - name: '[Linux] [cardano-rpc] Generate protobuf code'
       if: runner.os == 'Linux'


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add grpc-deps reusable GHA
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  # - cardano-api
  # - cardano-api-gen
   - cardano-rpc
  # - cardano-wasm
```

# Context

This adds a reusable github action which installs gRPC Haskell dependencies.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
