### PR TITLE
Update WASM cache

### DIFF
--- a/.github/workflows/haskell-wasm.yml
+++ b/.github/workflows/haskell-wasm.yml
@@ -114,9 +114,9 @@ jobs:
 
     - name: Restore cached deps
       run: |
-        wget "https://agrius.feralhosting.com/palas/wasm-cache/37532912ac94e8ac8888d6e85e7369935732e1065218c37ab340130b65c63060.tar.xz"
-        tar -xf 37532912ac94e8ac8888d6e85e7369935732e1065218c37ab340130b65c63060.tar.xz
-        rm 37532912ac94e8ac8888d6e85e7369935732e1065218c37ab340130b65c63060.tar.xz
+        wget "https://agrius.feralhosting.com/palas/wasm-cache/89a621d4f3f4b1ac05cff66e3bcf62dece3a515f73c92095d34c914b71f03538.tar.xz"
+        tar -xf 89a621d4f3f4b1ac05cff66e3bcf62dece3a515f73c92095d34c914b71f03538.tar.xz
+        rm 89a621d4f3f4b1ac05cff66e3bcf62dece3a515f73c92095d34c914b71f03538.tar.xz
         rm -fr ~/.ghc-wasm/.cabal/store/
         mv store ~/.ghc-wasm/.cabal/
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update WASM cache
  type:
    - maintenance
  projects:
    - cardano-wasm
```

# Context

This is a maintenance task to update which version of the cached build for wasm to use in CI. This reduces greatly the amount of time it takes to run.

# How to trust this PR

You can see from the time it takes to run the WASM build in CI and also in that it passes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
