### PR TITLE
Remove configuration reload action in cardano-rpc server startup

### DIFF
--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -66,19 +66,15 @@ methodsUtxoRpcSubmit =
 
 runRpcServer
   :: Tracer IO TraceRpc
-  -> IO (RpcConfig, NetworkMagic)
-  -- ^ action which reloads RPC configuration
+  -> (RpcConfig, NetworkMagic)
   -> IO ()
-runRpcServer tracer loadRpcConfig = handleFatalExceptions $ do
-  ( rpcConfig@RpcConfig
-      { isEnabled = Identity isEnabled
-      , rpcSocketPath = Identity (File rpcSocketPathFp)
-      , nodeSocketPath = Identity nodeSocketPath
-      }
-    , networkMagic
-    ) <-
-    loadRpcConfig
-  let config =
+runRpcServer tracer (rpcConfig, networkMagic) = handleFatalExceptions $ do
+  let RpcConfig
+        { isEnabled = Identity isEnabled
+        , rpcSocketPath = Identity (File rpcSocketPathFp)
+        , nodeSocketPath = Identity nodeSocketPath
+        } = rpcConfig
+      config =
         ServerConfig
           { serverInsecure = Just $ InsecureUnix rpcSocketPathFp
           , serverSecure = Nothing
@@ -89,10 +85,6 @@ runRpcServer tracer loadRpcConfig = handleFatalExceptions $ do
           , tracer = natTracer liftIO tracer
           , rpcLocalNodeConnectInfo = mkLocalNodeConnectInfo nodeSocketPath networkMagic
           }
-
-  -- TODO this is logged by node configuration already, so it would make sense to log it again when
-  -- configuration gets reloaded
-  -- traceWith tracer $ "RPC configuration: " <> show rpcConfig
 
   when isEnabled $
     runRIO rpcEnv $


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove configuration reload action in cardano-rpc server startup
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  # - cardano-api
  # - cardano-api-gen
   - cardano-rpc
  # - cardano-wasm
```

# Context

This is not needed anymore, as configuration reload is implemented as whole server restart:
- https://github.com/IntersectMBO/cardano-node/pull/6468

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
