### PR TITLE
Deprecate eon-parameterized lenses in favour of direct ledger lenses

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -248,6 +248,7 @@ import Cardano.Api.Era.Internal.Eon.Convert
 import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
 import Cardano.Api.Era.Internal.Eon.MaryEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
+import Cardano.Api.Era.Internal.Eon.ShelleyEraOnly
 import Cardano.Api.Era.Internal.Eon.ShelleyToBabbageEra
 import Cardano.Api.Era.Internal.Feature
 import Cardano.Api.Error
@@ -1271,7 +1272,7 @@ createTransactionBody
   -> Either TxBodyError (TxBody era)
 createTransactionBody sbe bc =
   shelleyBasedEraConstraints sbe $ do
-    (sData, mScriptIntegrityHash, scripts) <-
+    (sData, (mScriptIntegrityHash :: StrictMaybe L.ScriptIntegrityHash), scripts) <-
       caseShelleyToMaryOrAlonzoEraOnwards
         ( \eon -> do
             let scripts =
@@ -1280,7 +1281,7 @@ createTransactionBody sbe bc =
                     | (_, AnyScriptWitness scriptwitness) <-
                         collectTxBodyScriptWitnesses (convert eon) bc
                     ]
-            return (TxBodyNoScriptData, SNothing, scripts)
+            return (TxBodyNoScriptData, SNothing @L.ScriptIntegrityHash, scripts)
         )
         ( \aeon -> do
             TxScriptWitnessRequirements languages scripts dats redeemers <-
@@ -1319,53 +1320,77 @@ createTransactionBody sbe bc =
         currentTreasuryValue = Ledger.maybeToStrictMaybe $ unFeatured =<< txCurrentTreasuryValue bc
         treasuryDonation = maybe 0 unFeatured $ txTreasuryDonation bc
 
-    setUpdateProposal <- monoidForEraInEonA era $ \w ->
-      Endo . (A.updateTxBodyL w .~) <$> convTxUpdateProposal sbe (txUpdateProposal bc)
+    setUpdateProposal <- monoidForEraInEonA era $ \w -> do
+      update' <- convTxUpdateProposal sbe (txUpdateProposal bc)
+      pure $ Endo $ \body -> shelleyToBabbageEraConstraints w $ body & (A.txBodyL . L.updateTxBodyL) .~ update'
 
     setInvalidBefore <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.invalidBeforeTxBodyL w .~ convValidityLowerBound (txValidityLowerBound bc)
+      pure $ Endo $ \body ->
+        allegraEraOnwardsConstraints w $
+          body
+            & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+              .~ convValidityLowerBound (txValidityLowerBound bc)
 
     setMint <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.mintTxBodyL w .~ convMintValue apiMintValue
+      pure $ Endo $ \body -> maryEraOnwardsConstraints w $ body & (A.txBodyL . L.mintTxBodyL) .~ convMintValue apiMintValue
 
     setScriptIntegrityHash <- monoidForEraInEonA era $ \w ->
-      pure $
-        Endo $
-          A.scriptIntegrityHashTxBodyL w .~ mScriptIntegrityHash
+      pure $ Endo $ \body ->
+        alonzoEraOnwardsConstraints w $
+          body & (A.txBodyL . L.scriptIntegrityHashTxBodyL) .~ mScriptIntegrityHash
 
     setCollateralInputs <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.collateralInputsTxBodyL w .~ collTxIns
+      pure $ Endo $ \body -> alonzoEraOnwardsConstraints w $ body & (A.txBodyL . L.collateralInputsTxBodyL) .~ collTxIns
 
     setReqSignerHashes <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.reqSignerHashesTxBodyL w .~ convExtraKeyWitnesses apiExtraKeyWitnesses
+      pure $ Endo $ \body ->
+        alonzoEraOnwardsConstraints w $
+          body & (A.txBodyL . L.reqSignerHashesTxBodyL) .~ convExtraKeyWitnesses apiExtraKeyWitnesses
 
     setReferenceInputs <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.referenceInputsTxBodyL w .~ refTxIns
+      pure $ Endo $ \body -> babbageEraOnwardsConstraints w $ body & (A.txBodyL . L.referenceInputsTxBodyL) .~ refTxIns
 
     setCollateralReturn <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.collateralReturnTxBodyL w .~ returnCollateral
+      pure $ Endo $ \body ->
+        babbageEraOnwardsConstraints w $ body & (A.txBodyL . L.collateralReturnTxBodyL) .~ returnCollateral
 
     setTotalCollateral <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.totalCollateralTxBodyL w .~ totalCollateral
+      pure $ Endo $ \body ->
+        babbageEraOnwardsConstraints w $ body & (A.txBodyL . L.totalCollateralTxBodyL) .~ totalCollateral
 
     setProposalProcedures <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.proposalProceduresTxBodyL w .~ proposalProcedures
+      pure $ Endo $ \body ->
+        conwayEraOnwardsConstraints w $
+          body & (A.txBodyL . L.proposalProceduresTxBodyL) .~ proposalProcedures
 
     setVotingProcedures <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.votingProceduresTxBodyL w .~ votingProcedures
+      pure $ Endo $ \body ->
+        conwayEraOnwardsConstraints w $ body & (A.txBodyL . L.votingProceduresTxBodyL) .~ votingProcedures
 
     setCurrentTreasuryValue <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.currentTreasuryValueTxBodyL w .~ currentTreasuryValue
+      pure $ Endo $ \body ->
+        conwayEraOnwardsConstraints w $
+          body & (A.txBodyL . L.currentTreasuryValueTxBodyL) .~ currentTreasuryValue
 
     setTreasuryDonation <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.treasuryDonationTxBodyL w .~ treasuryDonation
+      pure $ Endo $ \body ->
+        conwayEraOnwardsConstraints w $ body & (A.txBodyL . L.treasuryDonationTxBodyL) .~ treasuryDonation
 
-    let ledgerTxBody =
+    let upperBound = convValidityUpperBound sbe (txValidityUpperBound bc)
+        ledgerTxBody =
           mkCommonTxBody sbe (txIns bc) (txOuts bc) (txFee bc) (txWithdrawals bc) txAuxData
-            & A.certsTxBodyL sbe
+            & (A.txBodyL . L.certsTxBodyL)
               .~ certs
-            & A.invalidHereAfterTxBodyL sbe
-              .~ convValidityUpperBound sbe (txValidityUpperBound bc)
+            & caseShelleyEraOnlyOrAllegraEraOnwards
+              ( \w ->
+                  shelleyEraOnlyConstraints w $
+                    (A.txBodyL . L.ttlTxBodyL) .~ fromMaybe maxBound upperBound
+              )
+              ( \w ->
+                  allegraEraOnwardsConstraints w $
+                    (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL) .~ upperBound
+              )
+              sbe
             & appEndo
               ( mconcat
                   [ setUpdateProposal
@@ -1699,10 +1724,11 @@ fromLedgerTxValidityLowerBound sbe body =
   caseShelleyEraOnlyOrAllegraEraOnwards
     (const TxValidityNoLowerBound)
     ( \w ->
-        let mInvalidBefore = body ^. A.invalidBeforeTxBodyL w
-         in case mInvalidBefore of
-              Nothing -> TxValidityNoLowerBound
-              Just s -> TxValidityLowerBound w s
+        allegraEraOnwardsConstraints w $
+          let mInvalidBefore = body ^. A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL
+           in case mInvalidBefore of
+                Nothing -> TxValidityNoLowerBound
+                Just s -> TxValidityLowerBound w s
     )
     sbe
 
@@ -1711,7 +1737,18 @@ fromLedgerTxValidityUpperBound
   -> A.LedgerTxBody era
   -> TxValidityUpperBound era
 fromLedgerTxValidityUpperBound sbe body =
-  TxValidityUpperBound sbe $ body ^. A.invalidHereAfterTxBodyL sbe
+  TxValidityUpperBound sbe $
+    caseShelleyEraOnlyOrAllegraEraOnwards
+      ( \w ->
+          shelleyEraOnlyConstraints w $
+            let ttl = body ^. A.txBodyL . L.ttlTxBodyL
+             in if ttl == maxBound then Nothing else Just ttl
+      )
+      ( \w ->
+          allegraEraOnwardsConstraints w $
+            body ^. A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL
+      )
+      sbe
 
 fromLedgerAuxiliaryData
   :: ShelleyBasedEra era
@@ -2123,15 +2160,16 @@ makeShelleyTransactionBody
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.updateTxBodyL s2b
-                .~ update
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-          )
-            ^. A.txBodyL
+          shelleyToBabbageEraConstraints s2b $
+            ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                & (A.txBodyL . L.certsTxBodyL)
+                  .~ convCertificates sbe txCertificates
+                & (A.txBodyL . L.updateTxBodyL)
+                  .~ update
+                & (A.txBodyL . L.ttlTxBodyL)
+                  .~ fromMaybe maxBound (convValidityUpperBound sbe txValidityUpperBound)
+            )
+              ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe
@@ -2170,17 +2208,19 @@ makeShelleyTransactionBody
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.invalidBeforeTxBodyL aOn
-                .~ convValidityLowerBound txValidityLowerBound
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-              & A.updateTxBodyL s2b
-                .~ update
-          )
-            ^. A.txBodyL
+          allegraEraOnwardsConstraints aOn $
+            shelleyToBabbageEraConstraints s2b $
+              ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                  & (A.txBodyL . L.certsTxBodyL)
+                    .~ convCertificates sbe txCertificates
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+                    .~ convValidityLowerBound txValidityLowerBound
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL)
+                    .~ convValidityUpperBound sbe txValidityUpperBound
+                  & (A.txBodyL . L.updateTxBodyL)
+                    .~ update
+              )
+                ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe
@@ -2215,25 +2255,27 @@ makeShelleyTransactionBody
     , txUpdateProposal
     , txMintValue
     } = do
-    let aOn = AllegraEraOnwardsMary
+    let _aOn = AllegraEraOnwardsMary
     let s2b = ShelleyToBabbageEraMary
     let mOn = MaryEraOnwardsMary
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.invalidBeforeTxBodyL aOn
-                .~ convValidityLowerBound txValidityLowerBound
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-              & A.updateTxBodyL s2b
-                .~ update
-              & A.mintTxBodyL mOn
-                .~ convMintValue txMintValue
-          )
-            ^. A.txBodyL
+          maryEraOnwardsConstraints mOn $
+            shelleyToBabbageEraConstraints s2b $
+              ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                  & (A.txBodyL . L.certsTxBodyL)
+                    .~ convCertificates sbe txCertificates
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+                    .~ convValidityLowerBound txValidityLowerBound
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL)
+                    .~ convValidityUpperBound sbe txValidityUpperBound
+                  & (A.txBodyL . L.updateTxBodyL)
+                    .~ update
+                  & (A.txBodyL . L.mintTxBodyL)
+                    .~ convMintValue txMintValue
+              )
+                ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe
@@ -2273,35 +2315,37 @@ makeShelleyTransactionBody
     , txMintValue
     , txScriptValidity
     } = do
-    let aOn = AllegraEraOnwardsAlonzo
+    let _aOn = AllegraEraOnwardsAlonzo
     let s2b = ShelleyToBabbageEraAlonzo
-    let mOn = MaryEraOnwardsAlonzo
+    let _mOn = MaryEraOnwardsAlonzo
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
     let scriptIntegrityHash =
           convPParamsToScriptIntegrityHash AlonzoEraOnwardsAlonzo txProtocolParams redeemers datums languages
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.collateralInputsTxBodyL azOn
-                .~ convCollateralTxIns txInsCollateral
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.invalidBeforeTxBodyL aOn
-                .~ convValidityLowerBound txValidityLowerBound
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-              & A.updateTxBodyL s2b
-                .~ update
-              & A.reqSignerHashesTxBodyL azOn
-                .~ convExtraKeyWitnesses txExtraKeyWits
-              & A.mintTxBodyL mOn
-                .~ convMintValue txMintValue
-              & A.scriptIntegrityHashTxBodyL azOn
-                .~ scriptIntegrityHash
-                -- TODO Alonzo: support optional network id in TxBodyContent
-                -- & L.networkIdTxBodyL .~ SNothing
-          )
-            ^. A.txBodyL
+          alonzoEraOnwardsConstraints azOn $
+            shelleyToBabbageEraConstraints s2b $
+              ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                  & (A.txBodyL . L.collateralInputsTxBodyL)
+                    .~ convCollateralTxIns txInsCollateral
+                  & (A.txBodyL . L.certsTxBodyL)
+                    .~ convCertificates sbe txCertificates
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+                    .~ convValidityLowerBound txValidityLowerBound
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL)
+                    .~ convValidityUpperBound sbe txValidityUpperBound
+                  & (A.txBodyL . L.updateTxBodyL)
+                    .~ update
+                  & (A.txBodyL . L.reqSignerHashesTxBodyL)
+                    .~ convExtraKeyWitnesses txExtraKeyWits
+                  & (A.txBodyL . L.mintTxBodyL)
+                    .~ convMintValue txMintValue
+                  & (A.txBodyL . L.scriptIntegrityHashTxBodyL)
+                    .~ scriptIntegrityHash
+                    -- TODO Alonzo: support optional network id in TxBodyContent
+                    -- & L.networkIdTxBodyL .~ SNothing
+              )
+                ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe
@@ -2394,42 +2438,44 @@ makeShelleyTransactionBody
     , txMintValue
     , txScriptValidity
     } = do
-    let aOn = AllegraEraOnwardsBabbage
-    let mOn = MaryEraOnwardsBabbage
-    let bOn = BabbageEraOnwardsBabbage
+    let _aOn = AllegraEraOnwardsBabbage
+    let _mOn = MaryEraOnwardsBabbage
+    let _bOn = BabbageEraOnwardsBabbage
     let s2b = ShelleyToBabbageEraBabbage
     validateTxBodyContent sbe txbodycontent
     update <- convTxUpdateProposal sbe txUpdateProposal
     let scriptIntegrityHash =
           convPParamsToScriptIntegrityHash AlonzoEraOnwardsBabbage txProtocolParams redeemers datums languages
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.collateralInputsTxBodyL azOn
-                .~ convCollateralTxIns txInsCollateral
-              & A.referenceInputsTxBodyL bOn
-                .~ convReferenceInputs txInsReference
-              & A.collateralReturnTxBodyL bOn
-                .~ convReturnCollateral sbe txReturnCollateral
-              & A.totalCollateralTxBodyL bOn
-                .~ convTotalCollateral txTotalCollateral
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.invalidBeforeTxBodyL aOn
-                .~ convValidityLowerBound txValidityLowerBound
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-              & A.updateTxBodyL s2b
-                .~ update
-              & A.reqSignerHashesTxBodyL azOn
-                .~ convExtraKeyWitnesses txExtraKeyWits
-              & A.mintTxBodyL mOn
-                .~ convMintValue txMintValue
-              & A.scriptIntegrityHashTxBodyL azOn
-                .~ scriptIntegrityHash
-                -- TODO Babbage: support optional network id in TxBodyContent
-                -- & L.networkIdTxBodyL .~ SNothing
-          )
-            ^. A.txBodyL
+          babbageEraOnwardsConstraints BabbageEraOnwardsBabbage $
+            shelleyToBabbageEraConstraints s2b $
+              ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                  & (A.txBodyL . L.collateralInputsTxBodyL)
+                    .~ convCollateralTxIns txInsCollateral
+                  & (A.txBodyL . L.referenceInputsTxBodyL)
+                    .~ convReferenceInputs txInsReference
+                  & (A.txBodyL . L.collateralReturnTxBodyL)
+                    .~ convReturnCollateral sbe txReturnCollateral
+                  & (A.txBodyL . L.totalCollateralTxBodyL)
+                    .~ convTotalCollateral txTotalCollateral
+                  & (A.txBodyL . L.certsTxBodyL)
+                    .~ convCertificates sbe txCertificates
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+                    .~ convValidityLowerBound txValidityLowerBound
+                  & (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL)
+                    .~ convValidityUpperBound sbe txValidityUpperBound
+                  & (A.txBodyL . L.updateTxBodyL)
+                    .~ update
+                  & (A.txBodyL . L.reqSignerHashesTxBodyL)
+                    .~ convExtraKeyWitnesses txExtraKeyWits
+                  & (A.txBodyL . L.mintTxBodyL)
+                    .~ convMintValue txMintValue
+                  & (A.txBodyL . L.scriptIntegrityHashTxBodyL)
+                    .~ scriptIntegrityHash
+                    -- TODO Babbage: support optional network id in TxBodyContent
+                    -- & L.networkIdTxBodyL .~ SNothing
+              )
+                ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe
@@ -2537,49 +2583,50 @@ makeShelleyTransactionBody
     , txCurrentTreasuryValue
     , txTreasuryDonation
     } = do
-    let aOn = AllegraEraOnwardsConway
+    let _aOn = AllegraEraOnwardsConway
     let cOn = ConwayEraOnwardsConway
-    let mOn = MaryEraOnwardsConway
-    let bOn = BabbageEraOnwardsConway
+    let _mOn = MaryEraOnwardsConway
+    let _bOn = BabbageEraOnwardsConway
     validateTxBodyContent sbe txbodycontent
     let scriptIntegrityHash =
           convPParamsToScriptIntegrityHash AlonzoEraOnwardsConway txProtocolParams redeemers datums languages
     let txbody =
-          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
-              & A.collateralInputsTxBodyL azOn
-                .~ case txInsCollateral of
-                  TxInsCollateralNone -> Set.empty
-                  TxInsCollateral _ txins -> fromList (map toShelleyTxIn txins)
-              & A.referenceInputsTxBodyL bOn
-                .~ convReferenceInputs txInsReference
-              & A.collateralReturnTxBodyL bOn
-                .~ convReturnCollateral sbe txReturnCollateral
-              & A.totalCollateralTxBodyL bOn
-                .~ convTotalCollateral txTotalCollateral
-              & A.certsTxBodyL sbe
-                .~ convCertificates sbe txCertificates
-              & A.invalidBeforeTxBodyL aOn
-                .~ convValidityLowerBound txValidityLowerBound
-              & A.invalidHereAfterTxBodyL sbe
-                .~ convValidityUpperBound sbe txValidityUpperBound
-              & A.reqSignerHashesTxBodyL azOn
-                .~ convExtraKeyWitnesses txExtraKeyWits
-              & A.mintTxBodyL mOn
-                .~ convMintValue txMintValue
-              & A.scriptIntegrityHashTxBodyL azOn
-                .~ scriptIntegrityHash
-              & A.votingProceduresTxBodyL cOn
-                .~ convVotingProcedures (maybe TxVotingProceduresNone unFeatured txVotingProcedures)
-              & A.proposalProceduresTxBodyL cOn
-                .~ convProposalProcedures (maybe TxProposalProceduresNone unFeatured txProposalProcedures)
-              & A.currentTreasuryValueTxBodyL cOn
-                .~ Ledger.maybeToStrictMaybe (unFeatured =<< txCurrentTreasuryValue)
-              & A.treasuryDonationTxBodyL cOn
-                .~ maybe (L.Coin 0) unFeatured txTreasuryDonation
-                -- TODO Conway: support optional network id in TxBodyContent
-                -- & L.networkIdTxBodyL .~ SNothing
-          )
-            ^. A.txBodyL
+          conwayEraOnwardsConstraints cOn $
+            ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+                & (A.txBodyL . L.collateralInputsTxBodyL)
+                  .~ case txInsCollateral of
+                    TxInsCollateralNone -> Set.empty
+                    TxInsCollateral _ txins -> fromList (map toShelleyTxIn txins)
+                & (A.txBodyL . L.referenceInputsTxBodyL)
+                  .~ convReferenceInputs txInsReference
+                & (A.txBodyL . L.collateralReturnTxBodyL)
+                  .~ convReturnCollateral sbe txReturnCollateral
+                & (A.txBodyL . L.totalCollateralTxBodyL)
+                  .~ convTotalCollateral txTotalCollateral
+                & (A.txBodyL . L.certsTxBodyL)
+                  .~ convCertificates sbe txCertificates
+                & (A.txBodyL . L.vldtTxBodyL . L.invalidBeforeL . A.strictMaybeL)
+                  .~ convValidityLowerBound txValidityLowerBound
+                & (A.txBodyL . L.vldtTxBodyL . L.invalidHereAfterL . A.strictMaybeL)
+                  .~ convValidityUpperBound sbe txValidityUpperBound
+                & (A.txBodyL . L.reqSignerHashesTxBodyL)
+                  .~ convExtraKeyWitnesses txExtraKeyWits
+                & (A.txBodyL . L.mintTxBodyL)
+                  .~ convMintValue txMintValue
+                & (A.txBodyL . L.scriptIntegrityHashTxBodyL)
+                  .~ scriptIntegrityHash
+                & (A.txBodyL . L.votingProceduresTxBodyL)
+                  .~ convVotingProcedures (maybe TxVotingProceduresNone unFeatured txVotingProcedures)
+                & (A.txBodyL . L.proposalProceduresTxBodyL)
+                  .~ convProposalProcedures (maybe TxProposalProceduresNone unFeatured txProposalProcedures)
+                & (A.txBodyL . L.currentTreasuryValueTxBodyL)
+                  .~ Ledger.maybeToStrictMaybe (unFeatured =<< txCurrentTreasuryValue)
+                & (A.txBodyL . L.treasuryDonationTxBodyL)
+                  .~ maybe (L.Coin 0) unFeatured txTreasuryDonation
+                  -- TODO Conway: support optional network id in TxBodyContent
+                  -- & L.networkIdTxBodyL .~ SNothing
+            )
+              ^. A.txBodyL
     return $
       ShelleyTxBody
         sbe

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -4,8 +4,6 @@
 
 {- HLINT ignore "Eta reduce" -}
 
--- TODO: Deprecate all the lenses that use eons. Explore parameterizing them on `Era era` instead.
-
 module Cardano.Api.Tx.Internal.Body.Lens
   ( -- * Types
     LedgerTxBody (..)
@@ -69,6 +67,86 @@ import Data.OSet.Strict qualified as L
 import Data.Sequence.Strict qualified as L
 import Data.Set (Set)
 import Lens.Micro
+
+{-# DEPRECATED
+  invalidBeforeTxBodyL
+  "Use 'txBodyL . L.vldtTxBodyL . L.invalidBeforeL' with appropriate era constraints instead"
+  #-}
+
+{-# DEPRECATED
+  invalidHereAfterTxBodyL
+  "Use 'txBodyL . L.vldtTxBodyL . L.invalidHereAfterL' with appropriate era constraints instead. For Shelley era, use 'L.ttlTxBodyL' directly."
+  #-}
+
+{-# DEPRECATED ttlAsInvalidHereAfterTxBodyL "Use 'txBodyL . L.ttlTxBodyL' with ShelleyEraOnly constraints instead" #-}
+
+{-# DEPRECATED updateTxBodyL "Use 'txBodyL . L.updateTxBodyL' with ShelleyToBabbageEra constraints instead" #-}
+
+{-# DEPRECATED mintTxBodyL "Use 'txBodyL . L.mintTxBodyL' with MaryEraOnwards constraints instead" #-}
+
+{-# DEPRECATED
+  scriptIntegrityHashTxBodyL
+  "Use 'txBodyL . L.scriptIntegrityHashTxBodyL' with AlonzoEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  collateralInputsTxBodyL
+  "Use 'txBodyL . L.collateralInputsTxBodyL' with AlonzoEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  reqSignerHashesTxBodyL
+  "Use 'txBodyL . L.reqSignerHashesTxBodyL' with AlonzoEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  referenceInputsTxBodyL
+  "Use 'txBodyL . L.referenceInputsTxBodyL' with BabbageEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  collateralReturnTxBodyL
+  "Use 'txBodyL . L.collateralReturnTxBodyL' with BabbageEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  totalCollateralTxBodyL
+  "Use 'txBodyL . L.totalCollateralTxBodyL' with BabbageEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED certsTxBodyL "Use 'txBodyL . L.certsTxBodyL' with ShelleyBasedEra constraints instead" #-}
+
+{-# DEPRECATED
+  votingProceduresTxBodyL
+  "Use 'txBodyL . L.votingProceduresTxBodyL' with ConwayEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  proposalProceduresTxBodyL
+  "Use 'txBodyL . L.proposalProceduresTxBodyL' with ConwayEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  currentTreasuryValueTxBodyL
+  "Use 'txBodyL . L.currentTreasuryValueTxBodyL' with ConwayEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED
+  treasuryDonationTxBodyL
+  "Use 'txBodyL . L.treasuryDonationTxBodyL' with ConwayEraOnwards constraints instead"
+  #-}
+
+{-# DEPRECATED adaAssetL "For MaryEraOnwards (Conway, Dijkstra), use a direct lens over MaryValue instead" #-}
+
+{-# DEPRECATED adaAssetShelleyToAllegraEraL "No longer needed. Pre-Mary eras are not supported by the new API." #-}
+
+{-# DEPRECATED adaAssetMaryEraOnwardsL "Use a direct lens over MaryValue instead" #-}
+
+{-# DEPRECATED multiAssetL "Use a direct lens over MaryValue instead" #-}
+
+{-# DEPRECATED valueTxOutL "Use 'L.valueTxOutL' with ShelleyBasedEra constraints instead" #-}
+
+{-# DEPRECATED valueTxOutAdaAssetL "Use 'L.valueTxOutL' composed with a direct MaryValue lens instead" #-}
 
 newtype LedgerTxBody era = LedgerTxBody
   { unTxBody :: L.TxBody L.TopTx (ShelleyLedgerEra era)

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -285,7 +285,7 @@ estimateBalancedTxBody
 
     let partialChange = toLedgerValue w $ calculatePartialChangeValue sbe availableUTxOValue txbodycontent1
         maxLovelaceChange = L.Coin (2 ^ (64 :: Integer)) - 1
-        changeWithMaxLovelace = partialChange & A.adaAssetL sbe .~ maxLovelaceChange
+        changeWithMaxLovelace = setAdaCoin w partialChange maxLovelaceChange
         changeTxOut =
           forShelleyBasedEraInEon
             sbe
@@ -1308,7 +1308,7 @@ calcReturnAndTotalCollateral w fee pp' TxInsCollateral{} txReturnCollateral txTo
       -- We must first figure out how much lovelace we have committed
       -- as collateral and we must determine if we have enough lovelace at our
       -- collateral tx inputs to cover the tx
-      totalCollateralLovelace = totalAvailableCollateral ^. A.adaAssetL sbe
+      totalCollateralLovelace = let L.MaryValue c _ = totalAvailableCollateral in c
       requiredCollateral@(L.Coin reqAmt) = fromIntegral colPerc * fee
       totalCollateral =
         TxTotalCollateral w . L.rationalToCoinViaCeiling $
@@ -1627,3 +1627,13 @@ calculateMinimumUTxO sbe pp txout =
   shelleyBasedEraConstraints sbe $
     let txOutWithMinCoin = L.setMinCoinTxOut pp (toShelleyTxOutAny sbe txout)
      in txOutWithMinCoin ^. L.coinTxOutL
+
+-- | Set the ada (coin) component of a ledger value for Mary-era-onwards eras.
+-- All Mary+ eras use MaryValue, so this is a simple pattern match.
+setAdaCoin
+  :: MaryEraOnwards era -> L.Value (ShelleyLedgerEra era) -> L.Coin -> L.Value (ShelleyLedgerEra era)
+setAdaCoin MaryEraOnwardsMary (L.MaryValue _ ma) c = L.MaryValue c ma
+setAdaCoin MaryEraOnwardsAlonzo (L.MaryValue _ ma) c = L.MaryValue c ma
+setAdaCoin MaryEraOnwardsBabbage (L.MaryValue _ ma) c = L.MaryValue c ma
+setAdaCoin MaryEraOnwardsConway (L.MaryValue _ ma) c = L.MaryValue c ma
+setAdaCoin MaryEraOnwardsDijkstra (L.MaryValue _ ma) c = L.MaryValue c ma

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -64,7 +64,9 @@ import Cardano.Api.Era.Internal.Eon.AlonzoEraOnwards
 import Cardano.Api.Era.Internal.Eon.BabbageEraOnwards
 import Cardano.Api.Era.Internal.Eon.Convert
 import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
+import Cardano.Api.Era.Internal.Eon.MaryEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
+import Cardano.Api.Era.Internal.Eon.ShelleyToAllegraEra
 import Cardano.Api.Error (Error (..), displayError)
 import Cardano.Api.HasTypeProxy qualified as HTP
 import Cardano.Api.Ledger.Internal.Reexport qualified as Ledger
@@ -87,6 +89,7 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin qualified as L
 import Cardano.Ledger.Core qualified as Core
 import Cardano.Ledger.Core qualified as Ledger
+import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus.Data qualified as Plutus
 
 import Data.Aeson (object, withObject, (.:), (.:?), (.=))
@@ -858,7 +861,7 @@ fromShelleyTxOut
   -> Core.TxOut (ShelleyLedgerEra era)
   -> TxOut ctx era
 fromShelleyTxOut sbe ledgerTxOut = shelleyBasedEraConstraints sbe $ do
-  let txOutValue = TxOutValueShelleyBased sbe $ ledgerTxOut ^. A.valueTxOutL sbe
+  let txOutValue = TxOutValueShelleyBased sbe $ ledgerTxOut ^. L.valueTxOutL
   let addressInEra = fromShelleyAddr sbe $ ledgerTxOut ^. L.addrTxOutL
 
   case sbe of
@@ -1004,7 +1007,11 @@ txOutValueToLovelace :: TxOutValue era -> L.Coin
 txOutValueToLovelace tv =
   case tv of
     TxOutValueByron l -> l
-    TxOutValueShelleyBased sbe v -> v ^. A.adaAssetL sbe
+    TxOutValueShelleyBased sbe v ->
+      caseShelleyToAllegraOrMaryEraOnwards
+        (\w -> shelleyToAllegraEraConstraints w v)
+        (\w -> maryEraOnwardsConstraints w $ let MaryValue c _ = v in c)
+        sbe
 
 txOutValueToValue :: TxOutValue era -> Value
 txOutValueToValue tv =

--- a/cardano-api/src/Cardano/Api/Value/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Value/Internal.hs
@@ -73,13 +73,13 @@ where
 import Cardano.Api.Era.Internal.Case
 import Cardano.Api.Era.Internal.Eon.MaryEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
+import Cardano.Api.Era.Internal.Eon.ShelleyToAllegraEra
 import Cardano.Api.HasTypeProxy
 import Cardano.Api.Parser.Text (($>), (<?>), (<|>))
 import Cardano.Api.Parser.Text qualified as P
 import Cardano.Api.Plutus.Internal.Script
 import Cardano.Api.Serialise.Raw
 import Cardano.Api.Serialise.SerialiseUsing
-import Cardano.Api.Tx.Internal.Body.Lens qualified as A
 
 import Cardano.Chain.Common qualified as Byron
 import Cardano.Ledger.Allegra.Core qualified as L
@@ -109,7 +109,7 @@ import Data.MonoTraversable
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Exts (IsList (..))
-import Lens.Micro ((%~))
+import Lens.Micro (Lens', lens, (%~))
 
 toByronLovelace :: Lovelace -> Maybe Byron.Lovelace
 toByronLovelace (L.Coin x) =
@@ -297,9 +297,12 @@ negateLedgerValue
   :: ShelleyBasedEra era -> L.Value (ShelleyLedgerEra era) -> L.Value (ShelleyLedgerEra era)
 negateLedgerValue sbe v =
   caseShelleyToAllegraOrMaryEraOnwards
-    (\_ -> v & A.adaAssetL sbe %~ L.Coin . negate . L.unCoin)
-    (\w -> v & A.multiAssetL w %~ invert)
+    (\w -> shelleyToAllegraEraConstraints w $ L.Coin . negate . L.unCoin $ v)
+    (\w -> maryEraOnwardsConstraints w $ v & maryMultiAssetL %~ invert)
     sbe
+ where
+  maryMultiAssetL :: Lens' MaryValue L.MultiAsset
+  maryMultiAssetL = lens (\(MaryValue _ ma) -> ma) (\(MaryValue c _) ma -> MaryValue c ma)
 
 filterValue :: (AssetId -> Bool) -> Value -> Value
 filterValue p (Value m) = Value (Map.filterWithKey (\k _v -> p k) m)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -482,7 +482,7 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
       era = convert beo
   feeCoin@(L.Coin fee) <- forAll genLovelace
   totalCollateral <- forAll $ genLedgerValueForTxOut sbe
-  let totalCollateralAda = totalCollateral ^. Api.adaAssetL sbe
+  let totalCollateralAda = let L.MaryValue c _ = totalCollateral in c
   pparams <-
     H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
   requiredCollateralPct <- H.noteShow . fromIntegral $ pparams ^. L.ppCollateralPercentageL


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace eon-parameterized lenses with direct ledger lenses and era constraints
  type:
   - refactoring
  projects:
   - cardano-api
```

# Context

Resolves https://github.com/IntersectMBO/cardano-api/issues/938

`Cardano.Api.Tx.Internal.Body.Lens` contains lenses that take an eon witness parameter (e.g. `reqSignerHashesTxBodyL :: AlonzoEraOnwards era -> Lens' ...`). This PR replaces those with direct use of ledger lenses (`L.vldtTxBodyL`, `L.mintTxBodyL`, `L.collateralInputsTxBodyL`, etc.) composed with the appropriate era constraints at each call site.

Key changes:
- Use `L.ttlTxBodyL` / `L.vldtTxBodyL` directly instead of `invalidHereAfterTxBodyL` / `invalidBeforeTxBodyL`
- Use `L.mintTxBodyL`, `L.collateralInputsTxBodyL`, `L.reqSignerHashesTxBodyL`, etc. directly
- Replace `adaAssetL` / `multiAssetL` with inline lens in `negateLedgerValue`
- Update `L.Witness` -> `L.Guard` (ledger API rename)
- Remove duplicate Dijkstra era branches in `Output.hs`

# How to trust this PR

WIP — not yet formatted or build-verified. Review the diff for correctness of lens replacements and era constraint placement.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] Self-reviewed the diff
- [ ] Fourmolu formatted
- [ ] Build verified