### PR TITLE
Bump ouroboros-consensus to ^>=2.0 for cardano-node 10.7.2

### DIFF
--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -167,7 +167,7 @@ library
     network-mux,
     nothunks,
     ordered-containers,
-    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=1.0,
+    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=2.0,
     ouroboros-network:{api, framework, ouroboros-network, protocols} ^>=1.1,
     parsec,
     plutus-core ^>=1.59,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bump ouroboros-consensus dependency to ^>=2.0 for cardano-node 10.7.2 release
  type:
   - release
  projects:
   - cardano-api
```

# Context

Bumps `ouroboros-consensus` dependency bound from `^>=1.0` to `^>=2.0` on the `cardano-api-10.25.0.0` release branch, required for `cardano-node 10.7.2`.

# How to trust this PR

Single line change in `cardano-api.cabal` — dependency bound bump only, no code changes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
