### PR TITLE
Add HasCallStack constraints to functions containing error calls

### DIFF
--- a/.changes/20260414_cardano_api_has_callstack.yml
+++ b/.changes/20260414_cardano_api_has_callstack.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1175
+kind:
+  - compatible
+description: |
+  Add `HasCallStack` constraints to standalone functions that call error directly or indirectly, improving stack traces. Dijkstra-era placeholder error messages are also improved.

--- a/cardano-api/src/Cardano/Api/Certificate/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Certificate/Internal.hs
@@ -826,7 +826,7 @@ getAnchorDataFromCertificate c =
           Ledger.RetirePoolTxCert _ _ -> return Nothing
           Ledger.GenesisDelegTxCert{} -> return Nothing
           Ledger.MirTxCert _ -> return Nothing
-          _ -> error "dijkstra"
+          _ -> error "getAnchorDataFromCertificate: Dijkstra era not supported"
     ConwayCertificate ceo ccert ->
       conwayEraOnwardsConstraints ceo $
         case ccert of
@@ -843,7 +843,7 @@ getAnchorDataFromCertificate c =
           Ledger.UpdateDRepTxCert _ mAnchor -> return $ Ledger.strictMaybeToMaybe mAnchor
           Ledger.AuthCommitteeHotKeyTxCert _ _ -> return Nothing
           Ledger.ResignCommitteeColdTxCert _ mAnchor -> return $ Ledger.strictMaybeToMaybe mAnchor
-          _ -> error "dijkstra"
+          _ -> error "getAnchorDataFromCertificate: Dijkstra era not supported"
  where
   anchorDataFromPoolMetadata
     :: MonadError AnchorDataFromCertificateError m

--- a/cardano-api/src/Cardano/Api/Certificate/Internal/OperationalCertificate.hs
+++ b/cardano-api/src/Cardano/Api/Certificate/Internal/OperationalCertificate.hs
@@ -37,6 +37,7 @@ import Cardano.Protocol.Crypto (StandardCrypto)
 import Cardano.Protocol.TPraos.OCert qualified as Shelley
 
 import Data.Word
+import GHC.Stack (HasCallStack)
 
 -- ----------------------------------------------------------------------------
 -- Operational certificates
@@ -107,7 +108,8 @@ instance Error OperationalCertIssueError where
 -- TODO: include key ids
 
 issueOperationalCertificate
-  :: VerificationKey KesKey
+  :: HasCallStack
+  => VerificationKey KesKey
   -> Either
        AnyStakePoolSigningKey
        (SigningKey GenesisDelegateExtendedKey)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -264,7 +264,8 @@ hashTxBody
 hashTxBody = L.extractHash . L.hashAnnotated
 
 makeKeyWitness
-  :: Era era
+  :: HasCallStack
+  => Era era
   -> UnsignedTx (LedgerEra era)
   -> ShelleyWitnessSigningKey
   -> L.WitVKey L.Witness

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
@@ -125,7 +125,7 @@ getPlutusDatum
 getPlutusDatum L.SPlutusV1 (SpendingScriptDatum d) = Just d
 getPlutusDatum L.SPlutusV2 (SpendingScriptDatum d) = Just d
 getPlutusDatum L.SPlutusV3 (SpendingScriptDatum d) = d
-getPlutusDatum L.SPlutusV4 (SpendingScriptDatum _d) = error "dijkstra"
+getPlutusDatum L.SPlutusV4 (SpendingScriptDatum _d) = error "getPlutusDatum: Dijkstra era not supported"
 getPlutusDatum _ InlineDatum = Nothing
 getPlutusDatum _ NoScriptDatum = Nothing
 

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
@@ -170,6 +170,7 @@ import Data.Set qualified as Set
 import Data.Text.Encoding qualified as Text
 import Data.Typeable (cast)
 import GHC.Exts (IsList (..))
+import GHC.Stack (HasCallStack)
 import Lens.Micro
 
 -- | Error that can occur when constructing an unsigned transaction.
@@ -538,7 +539,8 @@ legacyDatumToDatum OldApi.TxOutDatumNone = Nothing
 
 fromLegacyTxOut
   :: forall era
-   . IsEra era
+   . HasCallStack
+  => IsEra era
   => OldApi.TxOut CtxTx era
   -> Either DatumDecodingError (TxOut (LedgerEra era), Map L.DataHash (L.Data (LedgerEra era)))
 fromLegacyTxOut tOut@(OldApi.TxOut _ _ d _) = do

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
@@ -71,7 +71,7 @@ makeStakeAddressDelegationCertificate sCred delegatee =
     e@ShelleyBasedEraMary -> cert e delegatee
     e@ShelleyBasedEraAllegra -> cert e delegatee
     e@ShelleyBasedEraShelley -> cert e delegatee
-    ShelleyBasedEraDijkstra -> error "TODO: makeStakeAddressDelegationCertificate DijkstraEra"
+    ShelleyBasedEraDijkstra -> error "makeStakeAddressDelegationCertificate: Dijkstra era not supported"
  where
   cert
     :: Delegatee era ~ Api.Hash Api.StakePoolKey

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -751,7 +751,8 @@ instance Error FeeCalculationError where
 -- In practice convergence occurs within 2–3 iterations.
 calcMinFeeRecursive
   :: forall era
-   . IsEra era
+   . HasCallStack
+  => IsEra era
   => L.Addr
   -- ^ Change address. Any surplus value (ADA and/or native tokens) is
   -- sent to a new output at this address, appended at the end of the

--- a/cardano-api/src/Cardano/Api/Genesis/Internal/Parameters.hs
+++ b/cardano-api/src/Cardano/Api/Genesis/Internal/Parameters.hs
@@ -25,6 +25,7 @@ import Cardano.Slotting.Slot (EpochSize (..))
 
 import Data.Time (NominalDiffTime, UTCTime)
 import Data.Word (Word64)
+import GHC.Stack (HasCallStack)
 
 -- ----------------------------------------------------------------------------
 -- Genesis parameters
@@ -74,7 +75,7 @@ data GenesisParameters era
 -- Conversion functions
 --
 
-fromShelleyGenesis :: Shelley.ShelleyGenesis -> GenesisParameters ShelleyEra
+fromShelleyGenesis :: HasCallStack => Shelley.ShelleyGenesis -> GenesisParameters ShelleyEra
 fromShelleyGenesis
   sg@Shelley.ShelleyGenesis
     { Shelley.sgSystemStart

--- a/cardano-api/src/Cardano/Api/Key/Internal/Class.hs
+++ b/cardano-api/src/Cardano/Api/Key/Internal/Class.hs
@@ -22,6 +22,7 @@ import Cardano.Crypto.Seed qualified as Crypto
 
 import Control.Monad.IO.Class
 import Data.Kind (Type)
+import GHC.Stack (HasCallStack)
 import System.Random (StdGen)
 import System.Random qualified as Random
 
@@ -77,7 +78,8 @@ generateSigningKey keytype = do
   seedSize = deterministicSigningKeySeedSize keytype
 
 generateInsecureSigningKey
-  :: MonadIO m
+  :: HasCallStack
+  => MonadIO m
   => Key keyrole
   => SerialiseAsRawBytes (SigningKey keyrole)
   => StdGen

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -270,6 +270,7 @@ import Data.Word
 import Data.Yaml qualified as Yaml
 import Formatting.Buildable (build)
 import GHC.Exts (IsList (..))
+import GHC.Stack (HasCallStack)
 import Lens.Micro
 import Network.Mux qualified as Mux
 import Network.TypedProtocol.Core (Nat (..))
@@ -458,7 +459,7 @@ data FoldStatus
 -- the node's tip where @k@ is the security parameter.
 foldBlocks
   :: forall a t m
-   . ()
+   . HasCallStack
   => Show a
   => MonadIOTransError FoldBlocksError t m
   => NodeConfigFile 'In
@@ -715,7 +716,8 @@ foldBlocks nodeConfigFilePath socketPath validationMode state0 accumulate = hand
 -- | Wrap a 'ChainSyncClient' with logic that tracks the ledger state.
 chainSyncClientWithLedgerState
   :: forall m a
-   . Monad m
+   . HasCallStack
+  => Monad m
   => Env
   -> LedgerState
   -- ^ Initial ledger state
@@ -859,7 +861,8 @@ chainSyncClientWithLedgerState env ledgerState0 validationMode (CS.ChainSyncClie
 -- | See 'chainSyncClientWithLedgerState'.
 chainSyncClientPipelinedWithLedgerState
   :: forall m a
-   . Monad m
+   . HasCallStack
+  => Monad m
   => Env
   -> LedgerState
   -> ValidationMode
@@ -2308,7 +2311,8 @@ getLedgerTablesUTxOValues sbe tbs =
 -- provide a termination epoch otherwise blocks would be applied indefinitely.
 foldEpochState
   :: forall t m s
-   . MonadIOTransError FoldBlocksError t m
+   . HasCallStack
+  => MonadIOTransError FoldBlocksError t m
   => NodeConfigFile 'In
   -- ^ Path to the cardano-node config file (e.g. <path to cardano-node project>/configuration/cardano/mainnet-config.json)
   -> SocketPath

--- a/cardano-api/src/Cardano/Api/Network/Internal/NetworkId.hs
+++ b/cardano-api/src/Cardano/Api/Network/Internal/NetworkId.hs
@@ -25,6 +25,8 @@ import Cardano.Crypto.ProtocolMagic qualified as Byron
 import Cardano.Ledger.BaseTypes qualified as Shelley (Network (..))
 import Ouroboros.Network.Magic (NetworkMagic (..))
 
+import GHC.Stack (HasCallStack)
+
 -- ----------------------------------------------------------------------------
 -- NetworkId type
 --
@@ -74,7 +76,7 @@ toShelleyNetwork :: NetworkId -> Shelley.Network
 toShelleyNetwork Mainnet = Shelley.Mainnet
 toShelleyNetwork (Testnet _) = Shelley.Testnet
 
-fromShelleyNetwork :: Shelley.Network -> NetworkMagic -> NetworkId
+fromShelleyNetwork :: HasCallStack => Shelley.Network -> NetworkMagic -> NetworkId
 fromShelleyNetwork Shelley.Testnet nm = Testnet nm
 fromShelleyNetwork Shelley.Mainnet nm
   | nm == mainnetNetworkMagic = Mainnet

--- a/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
+++ b/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
@@ -1416,7 +1416,8 @@ toShelleyMultiSig = go
   go _ = Left MultiSigErrorTimelockNotsupported
 
 -- | Conversion for the 'Shelley.MultiSig' language used by the Shelley era.
-fromShelleyMultiSig :: Shelley.MultiSig (ShelleyLedgerEra ShelleyEra) -> SimpleScript
+fromShelleyMultiSig
+  :: Shelley.MultiSig (ShelleyLedgerEra ShelleyEra) -> SimpleScript
 fromShelleyMultiSig = go
  where
   go (Shelley.RequireSignature kh) =
@@ -1425,7 +1426,7 @@ fromShelleyMultiSig = go
   go (Shelley.RequireAllOf s) = RequireAllOf (map go $ toList s)
   go (Shelley.RequireAnyOf s) = RequireAnyOf (map go $ toList s)
   go (Shelley.RequireMOf m s) = RequireMOf m (map go $ toList s)
-  go _ = error ""
+  go _ = error "fromShelleyMultiSig: Dijkstra era not supported"
 
 -- | Conversion for the 'Timelock.Timelock' language that is shared between the
 -- Allegra and Mary eras.
@@ -1459,7 +1460,7 @@ fromAllegraTimelock = go
   go (Shelley.RequireAllOf s) = RequireAllOf (map go (toList s))
   go (Shelley.RequireAnyOf s) = RequireAnyOf (map go (toList s))
   go (Shelley.RequireMOf i s) = RequireMOf i (map go (toList s))
-  go _ = error "dijkstra"
+  go _ = error "fromAllegraTimelock: Dijkstra era not supported"
 
 type family ToLedgerPlutusLanguage lang where
   ToLedgerPlutusLanguage PlutusScriptV1 = Plutus.PlutusV1

--- a/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
@@ -572,7 +572,7 @@ toConsensusQuery QueryLedgerConfig = Some Consensus.DebugLedgerConfig
 
 toConsensusQueryShelleyBased
   :: forall era protocol block result
-   . ()
+   . HasCallStack
   => ConsensusBlockForEra era ~ Consensus.ShelleyBlock protocol (ShelleyLedgerEra era)
   => Consensus.CardanoBlock StandardCrypto ~ block
   => L.EraGov (ShelleyLedgerEra era)

--- a/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
@@ -545,6 +545,7 @@ fromShelleyRewardAccounts =
 toConsensusQuery
   :: forall block result
    . ()
+  => HasCallStack
   => Consensus.CardanoBlock StandardCrypto ~ block
   => QueryInMode result
   -> Some (Consensus.Query block)

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1185,7 +1185,7 @@ setTxTreasuryDonation
   :: Maybe (Featured ConwayEraOnwards era L.Coin) -> TxBodyContent build era -> TxBodyContent build era
 setTxTreasuryDonation v txBodyContent = txBodyContent{txTreasuryDonation = v}
 
-getTxIdByron :: Byron.ATxAux ByteString -> TxId
+getTxIdByron :: HasCallStack => Byron.ATxAux ByteString -> TxId
 getTxIdByron (Byron.ATxAux{Byron.aTaTx = txbody}) =
   TxId
     . fromMaybe impossible
@@ -2660,7 +2660,7 @@ makeShelleyTransactionBody
 
     txAuxData :: Maybe (L.TxAuxData E.ConwayEra)
     txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
-makeShelleyTransactionBody ShelleyBasedEraDijkstra _ = error "makeShelleyTransactionBody: Dijkstra is not  supported"
+makeShelleyTransactionBody ShelleyBasedEraDijkstra _ = error "makeShelleyTransactionBody: Dijkstra era not supported"
 
 -- ----------------------------------------------------------------------------
 -- Script witnesses within the tx body

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1518,6 +1518,7 @@ maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 {-# DEPRECATED createAndValidateTransactionBody "Use createTransactionBody instead" #-}
 createAndValidateTransactionBody
   :: ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)
@@ -2104,6 +2105,7 @@ mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData =
 makeShelleyTransactionBody
   :: forall era
    . ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> Either TxBodyError (TxBody era)

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Convenience.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Convenience.hs
@@ -34,6 +34,7 @@ import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Text qualified as Text
 import GHC.Exts (IsList (..))
+import GHC.Stack (HasCallStack)
 
 -- | Construct a balanced transaction.
 -- See Cardano.Api.Query.Internal.Convenience.queryStateForBalancedTx for a
@@ -41,6 +42,7 @@ import GHC.Exts (IsList (..))
 -- for constructBalancedTx.
 constructBalancedTx
   :: ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxBodyContent BuildTx era
   -> AddressInEra era

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -124,7 +124,8 @@ instance Error (AutoBalanceError era) where
     AutoBalanceCalculationError e -> prettyError e
 
 estimateOrCalculateBalancedTxBody
-  :: ShelleyBasedEra era
+  :: HasCallStack
+  => ShelleyBasedEra era
   -> FeeEstimationMode era
   -> L.PParams (ShelleyLedgerEra era)
   -> TxBodyContent BuildTx era

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
@@ -1088,6 +1088,7 @@ data WitnessNetworkIdOrByronAddress
 makeShelleyBootstrapWitness
   :: forall era
    . ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> WitnessNetworkIdOrByronAddress
   -> TxBody era
@@ -1100,6 +1101,7 @@ makeShelleyBootstrapWitness sbe nwOrAddr txBody sk =
 makeShelleyBasedBootstrapWitness
   :: forall era
    . ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> WitnessNetworkIdOrByronAddress
   -> Ledger.TxBody Ledger.TopTx (ShelleyLedgerEra era)
@@ -1183,6 +1185,7 @@ makeShelleyBasedBootstrapWitness sbe nwOrAddr txbody (ByronSigningKey sk) =
 makeShelleyKeyWitness
   :: forall era
    . ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> TxBody era
   -> ShelleyWitnessSigningKey
@@ -1193,6 +1196,7 @@ makeShelleyKeyWitness sbe (ShelleyTxBody _ txBody _ _ _ _) =
 makeShelleyKeyWitness'
   :: forall era
    . ()
+  => HasCallStack
   => ShelleyBasedEra era
   -> L.TxBody L.TopTx (ShelleyLedgerEra era)
   -> ShelleyWitnessSigningKey

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
@@ -115,6 +115,7 @@ import Data.Text qualified as Text
 import Data.Type.Equality (TestEquality (..), (:~:) (Refl))
 import Data.Validation qualified as Valid
 import GHC.Exts (IsList (..))
+import GHC.Stack (HasCallStack)
 import Lens.Micro
 
 -- ----------------------------------------------------------------------------
@@ -868,7 +869,8 @@ data ShelleySigningKey
     ShelleyExtendedSigningKey Crypto.HD.XPrv
 
 makeShelleySignature
-  :: Crypto.SignableRepresentation tosign
+  :: HasCallStack
+  => Crypto.SignableRepresentation tosign
   => tosign
   -> ShelleySigningKey
   -> (Crypto.SignedDSIGN Shelley.DSIGN) tosign

--- a/cardano-api/src/Cardano/Api/UTxO.hs
+++ b/cardano-api/src/Cardano/Api/UTxO.hs
@@ -122,6 +122,7 @@ import Data.Set (Set)
 import Data.Text (Text)
 import Data.Tuple (uncurry)
 import GHC.Exts qualified as GHC
+import GHC.Stack (HasCallStack)
 import Text.Show
 
 newtype UTxO era = UTxO {unUTxO :: Map TxIn (TxOut CtxUTxO era)}
@@ -354,7 +355,8 @@ fromMap = UTxO
 --------------------------------------------------------------------}
 
 -- | Convert from a `cardano-api` `UTxO` to a `cardano-ledger` UTxO.
-toShelleyUTxO :: ShelleyBasedEra era -> UTxO era -> Ledger.UTxO (ShelleyLedgerEra era)
+toShelleyUTxO
+  :: HasCallStack => ShelleyBasedEra era -> UTxO era -> Ledger.UTxO (ShelleyLedgerEra era)
 toShelleyUTxO sbe =
   Ledger.UTxO . Map.foldMapWithKey f . unUTxO
  where


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add HasCallStack constraints to standalone functions that call error
    directly or indirectly, and propagate to their callers. Dijkstra-era
    placeholder error messages are also improved.
  type:
   - compatible
  projects:
   - cardano-api
```

# Context

Closes #809

## Phase 1: HasCallStack at error sites

Each placement is justified by a real `error` call in the function body. We add `HasCallStack` rather than replacing `error` with proper error handling for the reasons noted:

| Function | File | Error source | Why `HasCallStack` rather than replacing `error` |
|----------|------|-------------|--------------------------------------------------|
| `generateInsecureSigningKey` | Key/Internal/Class.hs | Direct `error` on deserialization failure | Genuinely impossible — random bytes that don't deserialize as a valid signing key indicate a broken crypto implementation, not a recoverable condition |
| `foldBlocks` | LedgerState.hs | `error "Impossible! Missing Ledger state"` in nested chain sync client | Return type is constrained by the ouroboros-network protocol client callback interface — can't change to `Either` without rearchitecting the protocol client |
| `chainSyncClientWithLedgerState` | LedgerState.hs | 2× `error "Impossible! History should always be non-empty"` | Same — deep inside a protocol handler whose type is dictated by ouroboros-network |
| `chainSyncClientPipelinedWithLedgerState` | LedgerState.hs | 2× same as above | Pipelined variant, same constraint |
| `foldEpochState` | LedgerState.hs | `error "Impossible! Missing Ledger state"` in nested function | Same — protocol callback interface |
| `fromShelleyNetwork` | Network/Internal/NetworkId.hs | `error` on wrong mainnet network magic | Could return `Either`, but it's called from `fromShelleyGenesis` and other pure conversion functions — changing the return type would ripple through the genesis/network conversion chain |
| `toConsensusQueryShelleyBased` | Query/Internal/Type/QueryInMode.hs | 4× direct `error` for wrong-era queries | Could return `Either`, but feeds into the consensus query pipeline which expects a pure value — would require reworking the query infrastructure |
| `getTxIdByron` | Tx/Internal/Body.hs | `fromMaybe impossible` (hash size mismatch) | Genuinely impossible — hash size is fixed by the crypto algorithm |
| `makeShelleySignature` | Tx/Internal/Sign.hs | `fromMaybe impossible` (signature size mismatch) | Genuinely impossible — signature size is fixed by the crypto algorithm |

## Phase 2: Propagation to callers

After adding `HasCallStack` to the error sites, it was propagated up the call chain so stack traces show the full path rather than stopping at the immediate error site. Each line below is a call chain — read `→` as "calls". The rightmost function is where the `error` lives; each function to its left gets `HasCallStack` so its frame appears in the stack trace.

### Propagation from Phase 1 error sites

Tx signing (all paths end at `makeShelleySignature`):
```
makeShelleyKeyWitness       → makeShelleyKeyWitness'            → makeShelleySignature
makeShelleyBootstrapWitness → makeShelleyBasedBootstrapWitness  → makeShelleySignature
makeKeyWitness              → makeShelleySignature
issueOperationalCertificate → makeShelleySignature
```

Query:
```
toConsensusQuery → toConsensusQueryShelleyBased
```

Genesis:
```
fromShelleyGenesis → fromShelleyNetwork
```

The remaining Phase 1 error sites (`generateInsecureSigningKey`, `foldBlocks`, `chainSyncClientWithLedgerState`, `chainSyncClientPipelinedWithLedgerState`, `foldEpochState`, `getTxIdByron`) are top-level entry points with no internal callers in this repo to propagate to.

### Propagation from pre-existing master constraints

These functions call downstream functions that already carried `HasCallStack` on master but were themselves missing the constraint:

Tx body construction & output (callees pre-existing on master: `mkCommonTxBody`, `toShelleyTxOut`, `toShelleyTxOutAny`, `createTransactionBody`):
```
createAndValidateTransactionBody → makeShelleyTransactionBody → (pre-existing constrained callees)
fromLegacyTxOut                                               → (pre-existing constrained callees)
toShelleyUTxO                                                 → (pre-existing constrained callees)
```

Fee calculation (callees pre-existing on master: `balanceTxOuts`, `makeTransactionBodyAutoBalance`, `estimateBalancedTxBody`, `calculateMinimumUTxO`):
```
calcMinFeeRecursive               → (pre-existing constrained callees)
estimateOrCalculateBalancedTxBody → (pre-existing constrained callees)
constructBalancedTx               → (pre-existing constrained callees)
```

## Error message improvements (no HasCallStack)

Dijkstra-era placeholder `error` calls had unhelpful messages (`error "dijkstra"`, `error ""`). These are replaced with descriptive messages naming the function and the reason, e.g. `error "getPlutusDatum: Dijkstra era not supported"`.

## What was excluded and why

**Dijkstra-era placeholders (~20 calls across Era/Internal/Case.hs, Eon/*.hs, etc.):** All temporary `error` calls that will be replaced with real implementations when Dijkstra support lands. Adding `HasCallStack` would create churn across many signatures that will be rewritten anyway.

**Class method instances (`castVerificationKey`, `deterministicSigningKey`):** The failing cases guard impossible code paths (e.g. ed25519-bip32 extended key byte length can never mismatch ed25519). `HasCallStack` on instance methods via `InstanceSigs` doesn't propagate the caller's stack through class dispatch, and putting it on the class method would force the constraint on all instances including those that can never fail.

**Certificate validation functions (`toShelleyPoolParams`, `toShelleyDnsName`, `toShelleyUrl`, `fromShelleyPoolMetadata`):** These have real `error` calls for validation failures, but they carry `TODO: proper validation` comments — they should be converted to proper error handling rather than patched with `HasCallStack`.

# How to trust this PR

- Every `HasCallStack` placement is justified by a real `error` call in the function body — see table above
- Propagation chains are visualized above so the "caller → callee" relationship is auditable
- Only standalone functions are constrained; class methods are left alone
- Dijkstra placeholder messages are improved but not constrained
- Builds clean with `-Wredundant-constraints` — every constraint is actually used

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff