### PR TITLE
Remove dcoutts, newhoggy, smelc, and kevinhammond from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,9 @@
 # Release manager added for notification on dependency updates
-cabal.project                                                 @Jimbo4350 @newhoggy @disassembler
+cabal.project                                                 @Jimbo4350 @disassembler
 
 # General reviewers per PR
-#                        Duncan   Jordan     Erik   John      Mateusz     Clément Pablo  Kevin          Carlos             Sam
-*                        @dcoutts @Jimbo4350 @erikd @newhoggy @carbolymer @smelc  @palas @kevinhammond @CarlosLopezDeLara @disassembler
+#                        Jordan     Erik   Mateusz  Pablo  Carlos             Sam
+*                        @Jimbo4350 @erikd @carbolymer @palas @CarlosLopezDeLara @disassembler
 
 # Specific reviewers for code pieces
 # NB - The last matching pattern takes precedence
@@ -12,6 +12,6 @@ cabal.project                                                 @Jimbo4350 @newhog
 flake.lock                                                    @intersectmbo/core-tech-release-1
 
 # Technical writers
-README.*                                                      @Jimbo4350 @newhoggy @olgahryniuk @disassembler @CarlosLopezDeLara
+README.*                                                      @Jimbo4350 @olgahryniuk @disassembler @CarlosLopezDeLara
 
-.github                                                       @Jimbo4350 @newhoggy @carbolymer @smelc @palas @intersectmbo/core-tech-release-1
+.github                                                       @Jimbo4350 @carbolymer @palas @intersectmbo/core-tech-release-1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ See the [Contributing guide](CONTRIBUTING.md) for how to contribute to this proj
 ## Core maintainers
 
 * [Jordan Millar](https://github.com/Jimbo4350)
-* [John Ky](https://github.com/newhoggy)
 * [Mateusz Gałażyn](https://github.com/carbolymer)
 * [Pablo Lamela](https://github.com/palas)
 


### PR DESCRIPTION
## Summary
- Remove @dcoutts, @newhoggy, @smelc, and @kevinhammond from automatic PR review requests
- They are no longer active reviewers on cardano-api

## Test plan
- [ ] Verify new PRs no longer request reviews from removed users

# Changelog

```yaml
- description: |
    Remove dcoutts, newhoggy, smelc, and kevinhammond from CODEOWNERS
  type:
   - maintenance
  projects:
   - cardano-api
```

# Context

Duncan Coutts, John Ky, Clément Hurlin, and Kevin Hammond are no longer active reviewers on cardano-api. Removing them from CODEOWNERS to stop automatic review requests.

# How to trust this PR

Inspect the CODEOWNERS diff — only reviewer names were removed.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff