### PR TITLE
Bump `ouroboros-consensus` to 3.0.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-03-22T23:17:32Z
-  , cardano-haskell-packages 2026-04-01T09:04:56Z
+  , cardano-haskell-packages 2026-04-07T20:21:55Z
 
 active-repositories:
   , :rest

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -176,7 +176,7 @@ library
     network-mux,
     nothunks,
     ordered-containers,
-    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=2.0,
+    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=3.0,
     ouroboros-network:{api, framework, ouroboros-network, protocols} ^>=1.1,
     parsec,
     plutus-core ^>=1.59,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1775035666,
-        "narHash": "sha256-IyVfMOLL4iiJomE2UDncq0PkSAwiMplauB49RZjnMP0=",
+        "lastModified": 1775608993,
+        "narHash": "sha256-AHi1GtyIWNox83Hzwdt9lyaTCI2OK7DuztJtBVIzRsQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "c0270a024f09aa2dd84ce48d4a5828e5c0d88a0d",
+        "rev": "32b5f2ab66b36dd3acf57641ef14a192d1bb6f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
  - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  # - cardano-wasm
```

# Context

This PR updates `ouroboros-consensus` to the new release that includes the mempool transaction differences optimisations work.

It also brings in the minor Ledger release, `cardano-ledger-conway-1.21.1.0`.

# How to trust this PR

The cabal plan diff indicates the desired packages bumps:

```diff
-cardano-ledger-conway-1.21.0.0 lib
+cardano-ledger-conway-1.21.1.0 lib
-cardano-ledger-conway-1.21.0.0 lib:cddl
+cardano-ledger-conway-1.21.1.0 lib:cddl
-cardano-ledger-conway-1.21.0.0 lib:testlib
+cardano-ledger-conway-1.21.1.0 lib:testlib
-cardano-ledger-conway-1.21.0.0 exe:gen-golden
+cardano-ledger-conway-1.21.1.0 exe:gen-golden
-cardano-ledger-conway-1.21.0.0 exe:generate-cddl
+cardano-ledger-conway-1.21.1.0 exe:generate-cddl
-cardano-prelude-0.2.1.0 lib
+cardano-prelude-0.2.2.0 lib
-ouroboros-consensus-2.0.0.0 lib
+ouroboros-consensus-3.0.0.0 lib
-ouroboros-consensus-2.0.0.0 lib:cardano
+ouroboros-consensus-3.0.0.0 lib:cardano
-ouroboros-consensus-2.0.0.0 lib:diffusion
+ouroboros-consensus-3.0.0.0 lib:diffusion
-ouroboros-consensus-2.0.0.0 lib:lmdb
+ouroboros-consensus-3.0.0.0 lib:lmdb
-ouroboros-consensus-2.0.0.0 lib:lsm
+ouroboros-consensus-3.0.0.0 lib:lsm
-ouroboros-consensus-2.0.0.0 lib:protocol
+ouroboros-consensus-3.0.0.0 lib:protocol
-ouroboros-consensus-2.0.0.0 lib:unstable-byron-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-byron-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-byronspec
+ouroboros-consensus-3.0.0.0 lib:unstable-byronspec
-ouroboros-consensus-2.0.0.0 lib:unstable-cardano-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-cardano-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-cardano-tools
+ouroboros-consensus-3.0.0.0 lib:unstable-cardano-tools
-ouroboros-consensus-2.0.0.0 lib:unstable-consensus-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-consensus-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-diffusion-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-diffusion-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-mempool-test-utils
+ouroboros-consensus-3.0.0.0 lib:unstable-mempool-test-utils
-ouroboros-consensus-2.0.0.0 lib:unstable-mock-block
+ouroboros-consensus-3.0.0.0 lib:unstable-mock-block
-ouroboros-consensus-2.0.0.0 lib:unstable-mock-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-mock-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-protocol-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-protocol-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-shelley-testlib
+ouroboros-consensus-3.0.0.0 lib:unstable-shelley-testlib
-ouroboros-consensus-2.0.0.0 lib:unstable-snapshot-conversion
+ouroboros-consensus-3.0.0.0 lib:unstable-snapshot-conversion
-ouroboros-consensus-2.0.0.0 lib:unstable-tutorials
+ouroboros-consensus-3.0.0.0 lib:unstable-tutorials
-ouroboros-consensus-2.0.0.0 exe:db-analyser
+ouroboros-consensus-3.0.0.0 exe:db-analyser
-ouroboros-consensus-2.0.0.0 exe:db-immutaliser
+ouroboros-consensus-3.0.0.0 exe:db-immutaliser
-ouroboros-consensus-2.0.0.0 exe:db-synthesizer
+ouroboros-consensus-3.0.0.0 exe:db-synthesizer
-ouroboros-consensus-2.0.0.0 exe:db-truncater
+ouroboros-consensus-3.0.0.0 exe:db-truncater
-ouroboros-consensus-2.0.0.0 exe:gen-header
+ouroboros-consensus-3.0.0.0 exe:gen-header
-ouroboros-consensus-2.0.0.0 exe:immdb-server
+ouroboros-consensus-3.0.0.0 exe:immdb-server
-ouroboros-consensus-2.0.0.0 exe:snapshot-converter
+ouroboros-consensus-3.0.0.0 exe:snapshot-converter
-trace-dispatcher-2.12.0 lib
+trace-dispatcher-2.12.1 lib
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
