### PR TITLE
makeUnsignedTx: error when Plutus scripts present without protocol params

### DIFF
--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -12,6 +12,7 @@ module Cardano.Api.Experimental
     -- ** Transaction-related
     UnsignedTx (..)
   , SignedTx (..)
+  , MakeUnsignedTxError (..)
   , makeUnsignedTx
   , makeKeyWitness
   , signTx

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -117,6 +117,7 @@ module Cardano.Api.Experimental.Tx
     -- * Contents
     UnsignedTx (..)
   , SignedTx (..)
+  , MakeUnsignedTxError (..)
   , makeUnsignedTx
   , makeKeyWitness
   , signTx

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -78,7 +78,9 @@ module Cardano.Api.Experimental.Tx
     -- 'TxBodyContent' that we defined earlier:
     --
     -- @
-    -- let (Right unsignedTx) = Exp.makeUnsignedTx era txBodyContent
+    -- case Exp.makeUnsignedTx era txBodyContent of
+    --   Left err -> error (show err)
+    --   Right unsignedTx -> ...
     -- @
     --
     -- Next, use the key witness to sign the unsigned transaction with the 'makeKeyWitness' function:

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
@@ -107,6 +107,7 @@ import Cardano.Api.Governance.Internal.Action.VotingProcedure
 import Cardano.Api.Key.Internal
 import Cardano.Api.Ledger.Internal.Reexport (StrictMaybe (..))
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
+import Cardano.Api.Monad.Error (liftMaybe)
 import Cardano.Api.Plutus.Internal.Script
   ( PlutusScript (..)
   , PlutusScriptVersion (..)
@@ -313,7 +314,7 @@ convPParamsToScriptIntegrityHash mTxProtocolParams redeemers datums languages = 
             && null languages
   if shouldCalculateHash
     then do
-      pp <- maybe (Left MakeUnsignedTxMissingProtocolParams) Right mTxProtocolParams
+      pp <- liftMaybe MakeUnsignedTxMissingProtocolParams mTxProtocolParams
       pure $
         SJust $
           L.hashScriptIntegrity $

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
@@ -24,6 +24,7 @@ module Cardano.Api.Experimental.Tx.Internal.BodyContent.New
   , TxWithdrawals (..)
   , TxBodyContent (..)
   , Datum (..)
+  , MakeUnsignedTxError (..)
   , defaultTxBodyContent
   , extractDatumsAndHashes
   , getDatums
@@ -170,11 +171,27 @@ import Data.Typeable (cast)
 import GHC.Exts (IsList (..))
 import Lens.Micro
 
+-- | Error that can occur when constructing an unsigned transaction.
+data MakeUnsignedTxError
+  = -- | Plutus scripts are present in the transaction but no protocol
+    -- parameters were provided. Protocol parameters are required to
+    -- compute the script integrity hash (script_data_hash).
+    MakeUnsignedTxMissingProtocolParams
+  deriving (Eq, Show)
+
+instance Error MakeUnsignedTxError where
+  prettyError MakeUnsignedTxMissingProtocolParams =
+    mconcat
+      [ "Transaction uses Plutus scripts but no protocol parameters were provided. "
+      , "Protocol parameters are required to compute the script integrity hash "
+      , "(script_data_hash) from the cost models."
+      ]
+
 makeUnsignedTx
   :: forall era
    . Era era
   -> TxBodyContent (LedgerEra era)
-  -> UnsignedTx (LedgerEra era)
+  -> Either MakeUnsignedTxError (UnsignedTx (LedgerEra era))
 makeUnsignedTx DijkstraEra _ = error "makeUnsignedTx: Dijkstra era not supported yet"
 makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
   let TxScriptWitnessRequirements languages scripts datums redeemers = collectTxBodyScriptWitnessRequirements bc
@@ -197,12 +214,13 @@ makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
       totCollateral = unTxTotalCollateral <$> txTotalCollateral bc
       txAuxData = toAuxiliaryData (txMetadata bc) (txAuxScripts bc)
       scriptValidity = scriptValidityToIsValid $ txScriptValidity bc
-      scriptIntegrityHash =
-        convPParamsToScriptIntegrityHash
-          protocolParameters
-          redeemers
-          datums
-          languages
+
+  scriptIntegrityHash <-
+    convPParamsToScriptIntegrityHash
+      protocolParameters
+      redeemers
+      datums
+      languages
 
   let setMint = convMintValue apiMintValue
       setReqSignerHashes = convExtraKeyWitnesses apiExtraKeyWitnesses
@@ -235,11 +253,12 @@ makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
           & L.rdmrsTxWitsL .~ redeemers
 
   let eraSpecificTxBody = eraSpecificLedgerTxBody era ledgerTxBody bc
-  UnsignedTx $
-    L.mkBasicTx eraSpecificTxBody
-      & L.witsTxL .~ scriptWitnesses
-      & L.auxDataTxL .~ L.maybeToStrictMaybe (toAuxiliaryData (txMetadata bc) (txAuxScripts bc))
-      & L.isValidTxL .~ scriptValidity
+  Right $
+    UnsignedTx $
+      L.mkBasicTx eraSpecificTxBody
+        & L.witsTxL .~ scriptWitnesses
+        & L.auxDataTxL .~ L.maybeToStrictMaybe (toAuxiliaryData (txMetadata bc) (txAuxScripts bc))
+        & L.isValidTxL .~ scriptValidity
 
 convTxIns :: [(TxIn, AnyWitness era)] -> Set L.TxIn
 convTxIns inputs =
@@ -283,9 +302,8 @@ convPParamsToScriptIntegrityHash
   -> L.Redeemers (LedgerEra era)
   -> L.TxDats (LedgerEra era)
   -> Set Plutus.Language
-  -> StrictMaybe L.ScriptIntegrityHash
+  -> Either MakeUnsignedTxError (StrictMaybe L.ScriptIntegrityHash)
 convPParamsToScriptIntegrityHash mTxProtocolParams redeemers datums languages = obtainCommonConstraints (useEra @era) $ do
-  pp <- L.maybeToStrictMaybe mTxProtocolParams
   -- This logic is copied from ledger, because their code is not reusable
   -- c.f. https://github.com/IntersectMBO/cardano-ledger/commit/5a975d9af507c9ee835a86d3bb77f3e2670ad228#diff-8236dfec9688f22550b91fc9a87af9915523ab9c5bd817218ecceec8ca7a789bR282
   let shouldCalculateHash =
@@ -293,9 +311,14 @@ convPParamsToScriptIntegrityHash mTxProtocolParams redeemers datums languages = 
           null (redeemers ^. L.unRedeemersL)
             && null (datums ^. L.unTxDatsL)
             && null languages
-  guard shouldCalculateHash
-  let scriptIntegrity = L.ScriptIntegrity redeemers datums (Set.map (L.getLanguageView pp) languages)
-  pure $ L.hashScriptIntegrity scriptIntegrity
+  if shouldCalculateHash
+    then do
+      pp <- maybe (Left MakeUnsignedTxMissingProtocolParams) Right mTxProtocolParams
+      pure $
+        SJust $
+          L.hashScriptIntegrity $
+            L.ScriptIntegrity redeemers datums (Set.map (L.getLanguageView pp) languages)
+    else pure SNothing
 
 convProposalProcedures
   :: forall era

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -138,6 +138,7 @@ data TxBodyErrorAutoBalance era
       -- ^ Total deposits
       L.MaryValue
       -- ^ Balance
+  | TxBodyErrorMakeUnsignedTx MakeUnsignedTxError
 
 deriving instance Show (TxBodyErrorAutoBalance era)
 
@@ -203,6 +204,8 @@ instance Error (TxBodyErrorAutoBalance era) where
         , "\nBalance (UTxO value - deposits): "
         , pshow balance
         ]
+    TxBodyErrorMakeUnsignedTx err ->
+      prettyError err
 
 -- | Use when you do not have access to the UTxOs you intend to spend
 estimateBalancedTxBody
@@ -254,12 +257,14 @@ estimateBalancedTxBody
 data TxFeeEstimationError era
   = TxFeeEstimationScriptExecutionError (TxBodyErrorAutoBalance (LedgerEra era))
   | TxFeeEstimationBalanceError (TxBodyErrorAutoBalance (LedgerEra era))
+  | TxFeeEstimationMakeUnsignedTxError MakeUnsignedTxError
   deriving Show
 
 instance Error (TxFeeEstimationError era) where
   prettyError = \case
     TxFeeEstimationScriptExecutionError e -> prettyError e
     TxFeeEstimationBalanceError e -> prettyError e
+    TxFeeEstimationMakeUnsignedTxError e -> prettyError e
 
 -- | Use when you do not have access to the UTxOs you intend to spend
 estimateBalancedTxBody'
@@ -365,17 +370,18 @@ estimateBalancedTxBody'
     -- Step 3. Create a tx body with out max lovelace fee. This is strictly for
     -- calculating our fee with evaluateTransactionFee.
     let maxLovelaceFee = L.Coin (2 ^ (32 :: Integer) - 1)
-    let txbody1ForFeeEstimateOnly =
-          makeUnsignedTx
-            useEra
-            txbodycontent1
-              { txFee = maxLovelaceFee
-              , txOuts =
-                  obtainCommonConstraints (useEra @era) (TxOut changeTxOut)
-                    : txOuts txbodycontent
-              , txReturnCollateral = mDummyReturnCollateral
-              , txTotalCollateral = mDummyTotalCollateral
-              }
+    txbody1ForFeeEstimateOnly <-
+      first TxFeeEstimationMakeUnsignedTxError $
+        makeUnsignedTx
+          useEra
+          txbodycontent1
+            { txFee = maxLovelaceFee
+            , txOuts =
+                obtainCommonConstraints (useEra @era) (TxOut changeTxOut)
+                  : txOuts txbodycontent
+            , txReturnCollateral = mDummyReturnCollateral
+            , txTotalCollateral = mDummyTotalCollateral
+            }
     let fee =
           evaluateTransactionFee
             pparams
@@ -400,8 +406,8 @@ estimateBalancedTxBody'
     --  1. The original outputs
     --  2. Tx fee
     --  3. Return and total collateral
-    let
-      txbody2 =
+    txbody2 <-
+      first TxFeeEstimationMakeUnsignedTxError $
         makeUnsignedTx
           useEra
           txbodycontent1
@@ -1420,10 +1426,11 @@ makeTransactionBodyAutoBalance
     -- 3. update tx with fees
     -- 4. balance the transaction and update tx change output
 
-    let txbodyForChange =
-          makeUnsignedTx
-            useEra
-            txbodycontent
+    txbodyForChange <-
+      first TxBodyErrorMakeUnsignedTx $
+        makeUnsignedTx
+          useEra
+          txbodycontent
 
     let initialChangeTxOutValue :: Ledger.Value (LedgerEra era) =
           evaluateTransactionBalance pp poolids stakeDelegDeposits drepDelegDeposits utxo txbodyForChange
@@ -1441,13 +1448,14 @@ makeTransactionBodyAutoBalance
     -- scripts execution costs.
     -- TODO: The txbody is made (leder tx) so this
     -- is where the execution units map is made
-    let UnsignedTx txbody =
-          makeUnsignedTx
-            useEra
-            ( txbodycontent
-                & modTxOuts
-                  (<> [initialChangeTxOut])
-            )
+    UnsignedTx txbody <-
+      first TxBodyErrorMakeUnsignedTx $
+        makeUnsignedTx
+          useEra
+          ( txbodycontent
+              & modTxOuts
+                (<> [initialChangeTxOut])
+          )
     let exUnitsMapWithLogs =
           evaluateTransactionExecutionUnits
             systemstart
@@ -1479,17 +1487,18 @@ makeTransactionBodyAutoBalance
     let maxLovelaceFee = L.Coin (2 ^ (32 :: Integer) - 1)
     -- Make a txbody that we will use for calculating the fees.
     let (maybeDummyReturnTxCollateral, maybeDummyTotalTxCollateral) = maybeDummyTotalCollAndCollReturnOutput txbodycontent changeaddr
-    let txbody1 =
-          makeUnsignedTx
-            useEra
-            txbodycontent1
-              { txFee = maxLovelaceFee
-              , txReturnCollateral = maybeDummyReturnTxCollateral
-              , txTotalCollateral = maybeDummyTotalTxCollateral
-              , txOuts =
-                  txOuts txbodycontent
-                    <> [initialChangeTxOut]
-              }
+    txbody1 <-
+      first TxBodyErrorMakeUnsignedTx $
+        makeUnsignedTx
+          useEra
+          txbodycontent1
+            { txFee = maxLovelaceFee
+            , txReturnCollateral = maybeDummyReturnTxCollateral
+            , txTotalCollateral = maybeDummyTotalTxCollateral
+            , txOuts =
+                txOuts txbodycontent
+                  <> [initialChangeTxOut]
+            }
 
     -- NB: This has the potential to over estimate the fees because estimateTransactionKeyWitnessCount
     -- makes the conservative assumption that all inputs are from distinct
@@ -1521,14 +1530,15 @@ makeTransactionBodyAutoBalance
     -- does not matter, instead it's just the values of the fee and outputs.
     -- Here we do not want to start with any change output, since that's what
     -- we need to calculate.
-    let txbody2 =
-          makeUnsignedTx
-            useEra
-            txbodycontent1
-              { txFee = fee
-              , txReturnCollateral = maybeReturnTxCollateral
-              , txTotalCollateral = maybeTotalTxCollateral
-              }
+    txbody2 <-
+      first TxBodyErrorMakeUnsignedTx $
+        makeUnsignedTx
+          useEra
+          txbodycontent1
+            { txFee = fee
+            , txReturnCollateral = maybeReturnTxCollateral
+            , txTotalCollateral = maybeTotalTxCollateral
+            }
 
     case useEra @era of
       DijkstraEra -> error "makeTransactionBodyAutoBalance: DijkstraEra not supported"
@@ -1566,10 +1576,11 @@ makeTransactionBodyAutoBalance
                 , txReturnCollateral = maybeReturnTxCollateral
                 , txTotalCollateral = maybeTotalTxCollateral
                 }
-        let txbody3 =
-              makeUnsignedTx
-                useEra
-                finalTxBodyContent
+        txbody3 <-
+          first TxBodyErrorMakeUnsignedTx $
+            makeUnsignedTx
+              useEra
+              finalTxBodyContent
         return
           (txbody3, finalTxBodyContent)
 

--- a/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Tx.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/Cardano/Api/Tx.hs
@@ -99,10 +99,11 @@ tx_canonical = H.propertyOnce $ do
             & Exp.setTxTotalCollateral txTotalColl
             & Exp.setTxFee (L.Coin 0)
 
-    let unsignedTx = Exp.makeUnsignedTx era txBodyContent'
-        tx = Exp.signTx era [] [] unsignedTx
-        Exp.SignedTx ledgerTx = tx
-        oldStyleTx = OldApi.ShelleyTx sbe ledgerTx
+    unsignedTx <- H.evalEither $ Exp.makeUnsignedTx era txBodyContent'
+    let
+      tx = Exp.signTx era [] [] unsignedTx
+      Exp.SignedTx ledgerTx = tx
+      oldStyleTx = OldApi.ShelleyTx sbe ledgerTx
 
     void . H.evalIO $ OldApi.writeTxFileTextEnvelope sbe (OldApi.File outFileNonCanonical) oldStyleTx
     void . H.evalIO $

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -154,8 +154,8 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
     txBodyContent <- exampleTxBodyContentExperimental era
     signingKey <- exampleSigningKey
 
-    let unsignedTx = Exp.makeUnsignedTx era txBodyContent
-        witness = Exp.makeKeyWitness era unsignedTx (Api.WitnessPaymentKey signingKey)
+    unsignedTx <- H.evalEither $ Exp.makeUnsignedTx era txBodyContent
+    let witness = Exp.makeKeyWitness era unsignedTx (Api.WitnessPaymentKey signingKey)
 
     let bootstrapWitnesses = []
         keyWitnesses = [witness]
@@ -176,9 +176,9 @@ prop_balance_transaction_two_ways = H.propertyOnce $ do
   -- Simple fee estimate (no change output in tx body)
   -- Old API
   let oldFees = Api.evaluateTransactionFee sbe exampleProtocolParams txBody 0 1 0
-      -- NEW API
-      unSignTx = Exp.makeUnsignedTx era newTxBodyContent
-      newFees = Exp.evaluateTransactionFee exampleProtocolParams unSignTx 0 1 0
+  -- NEW API
+  unSignTx <- H.evalEither $ Exp.makeUnsignedTx era newTxBodyContent
+  let newFees = Exp.evaluateTransactionFee exampleProtocolParams unSignTx 0 1 0
 
   oldFees H.=== L.Coin 236
   newFees H.=== L.Coin 236
@@ -349,7 +349,8 @@ prop_balance_transaction_two_ways = H.propertyOnce $ do
 
   -- Check old and new api serialises a tx the same way
 
-  let newTx = Api.serialiseToRawBytes $ Exp.makeUnsignedTx era newTxBodyContent
+  newUnsignedTx <- H.evalEither $ Exp.makeUnsignedTx era newTxBodyContent
+  let newTx = Api.serialiseToRawBytes newUnsignedTx
       oldTx = Api.serialiseToCBOR $ Api.makeSignedTransaction [] txBody
   newTx H.=== oldTx
   H.success
@@ -631,7 +632,9 @@ genFundedSimpleTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Like 'genFundedSimpleTx' but the UTxO and output both carry native tokens.
 -- The output sends all tokens; the surplus ADA goes to the change output.
@@ -668,7 +671,9 @@ genFundedMultiAssetTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a simple lovelace-only transaction where the single output
 -- (5-10 ADA) greatly exceeds the UTxO funding (0.5-2 ADA).
@@ -701,7 +706,9 @@ genUnderfundedTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | A well-funded transaction (UTxO >> output + fee) always produces a
 -- successful, fully balanced result with a positive fee.
@@ -810,7 +817,9 @@ genNonAdaUnbalancedTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a two-output transaction where the second output carries native
 -- tokens with only 1000 lovelace — well below the minimum UTxO for a
@@ -854,7 +863,9 @@ genMinUTxOViolatingTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut1, sendTxOut2]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a transaction with inputs but no outputs. Once the fee
 -- converges (Case 3), the positive surplus triggers Case 2, and
@@ -882,7 +893,9 @@ genNoOutputsTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [] -- No outputs!
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | When the output demands tokens not present in the ADA-only UTxO,
 -- the function returns 'Left (NonAdaAssetsUnbalanced _)'.

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
@@ -15,12 +15,14 @@ import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.Era (convert)
 import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Monad.Error (failEither)
 
 import Cardano.Ledger.Api qualified as UnexportedLedger
 import Cardano.Ledger.Core qualified as L
 import Cardano.Ledger.Mary.Value qualified as Mary
 import Cardano.Ledger.Tools qualified as L (calcMinFeeTx)
 
+import Data.Bifunctor (first)
 import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Sequence.Strict qualified as Seq
@@ -387,9 +389,8 @@ genTinySurplusTx era = Exp.obtainCommonConstraints era $ do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  unsignedTx <- case Exp.makeUnsignedTx era txBodyContent of
-    Left err -> fail $ "makeUnsignedTx: " <> show err
-    Right tx -> return tx
+  unsignedTx <-
+    failEither . first (("makeUnsignedTx: " <>) . show) $ Exp.makeUnsignedTx era txBodyContent
   let
     -- Compute F1 via case match on UnsignedTx (needed to bring EraTx into scope)
     L.Coin f1 = case unsignedTx of

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
@@ -145,7 +145,9 @@ genFundedSimpleTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Like 'genFundedSimpleTx' but the UTxO and output both carry native tokens.
 -- The output sends all tokens; the surplus ADA goes to the change output.
@@ -182,7 +184,9 @@ genFundedMultiAssetTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a simple lovelace-only transaction where the single output
 -- (5-10 ADA) greatly exceeds the UTxO funding (0.5-2 ADA).
@@ -215,7 +219,9 @@ genUnderfundedTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a transaction whose output demands a native token that does
 -- not exist in the UTxO (which is ADA-only). This guarantees a negative
@@ -255,7 +261,9 @@ genNonAdaUnbalancedTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a two-output transaction where the second output carries native
 -- tokens with only 1000 lovelace — well below the minimum UTxO for a
@@ -299,7 +307,9 @@ genMinUTxOViolatingTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut1, sendTxOut2]
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a transaction with inputs but no outputs. Once the fee
 -- converges (Case 3), the positive surplus triggers Case 2, and
@@ -327,7 +337,9 @@ genNoOutputsTx era = do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [] -- No outputs!
           & Exp.setTxFee 0
-  return (Exp.makeUnsignedTx era txBodyContent, utxo, changeAddr)
+  case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return (tx, utxo, changeAddr)
 
 -- | Generates a transaction designed to trigger 'NotEnoughAdaForChangeOutput'.
 --
@@ -375,11 +387,14 @@ genTinySurplusTx era = Exp.obtainCommonConstraints era $ do
           & Exp.setTxIns [(txIn, Exp.AnyKeyWitnessPlaceholder)]
           & Exp.setTxOuts [sendTxOut]
           & Exp.setTxFee 0
-      unsignedTx = Exp.makeUnsignedTx era txBodyContent
-      -- Compute F1 via case match on UnsignedTx (needed to bring EraTx into scope)
-      L.Coin f1 = case unsignedTx of
-        Exp.UnsignedTx prelimLedgerTx ->
-          L.calcMinFeeTx prelimUtxo (exampleProtocolParamsEra era) prelimLedgerTx 0
+  unsignedTx <- case Exp.makeUnsignedTx era txBodyContent of
+    Left err -> fail $ "makeUnsignedTx: " <> show err
+    Right tx -> return tx
+  let
+    -- Compute F1 via case match on UnsignedTx (needed to bring EraTx into scope)
+    L.Coin f1 = case unsignedTx of
+      Exp.UnsignedTx prelimLedgerTx ->
+        L.calcMinFeeTx prelimUtxo (exampleProtocolParamsEra era) prelimLedgerTx 0
   -- Surplus just above F1 but well below F2 (≈ F1 + 23). This is enough
   -- to pass fee convergence but not survive adding a change output.
   surplus <- L.Coin <$> Gen.integral (Range.linear (f1 + 4) (f1 + 10))


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    makeUnsignedTx now returns Either MakeUnsignedTxError and errors when
    Plutus scripts are present but protocol parameters are missing, instead
    of silently omitting the script integrity hash (script_data_hash).
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  # - cardano-wasm
```

# Context

Addresses [IntersectMBO/cardano-cli#1363](https://github.com/IntersectMBO/cardano-cli/issues/1363).

`convPParamsToScriptIntegrityHash` silently returned `SNothing` when protocol parameters were `Nothing` but Plutus scripts required computing the script integrity hash (`script_data_hash`, field 11 in the Conway CDDL). The `StrictMaybe` monad short-circuited on `maybeToStrictMaybe Nothing`, masking the real error.

This caused `build-raw` in cardano-cli to produce invalid transaction bodies when using reference scripts without `--protocol-params-file`.

## Changes

- `makeUnsignedTx` now returns `Either MakeUnsignedTxError (UnsignedTx (LedgerEra era))` (breaking change)
- `convPParamsToScriptIntegrityHash` checks whether the hash needs to be computed first, then fails explicitly if protocol params are missing
- `TxBodyErrorAutoBalance` and `TxFeeEstimationError` gain constructors to propagate the new error
- Test call sites updated

# How to trust this PR

- The happy path (protocol params always present) is unchanged — `convPParamsToScriptIntegrityHash` returns `Right (SJust hash)` as before
- The `estimateBalancedTxBody` / `makeTransactionBodyAutoBalance` callers always set protocol params on `TxBodyContent`, so the `Left` branch is unreachable there
- The fix targets the silent `SNothing` path that only fires when callers omit protocol params with Plutus scripts present

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff