### PR TITLE
Enable PR number validation against changelog fragment in GHA

### DIFF
--- a/.changes/20260413_093442_cardano-api_mateusz.galazyn_make_herald_validation_mandatory.yml
+++ b/.changes/20260413_093442_cardano-api_mateusz.galazyn_make_herald_validation_mandatory.yml
@@ -1,0 +1,5 @@
+description: Enable PR number validation in changelog fragments
+kind:
+- maintenance
+pr: 1183
+project: cardano-api

--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -28,6 +28,3 @@ jobs:
             accept-flake-config = true
 
       - uses: input-output-hk/cardano-dev/herald/.github/actions/validate@main
-        with:
-          # TODO: re-enable after backfill PR #1164 merges
-          pr: false


### PR DESCRIPTION
Enable PR number validation against changelog fragment in GHA

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
