### PR TITLE
Unify Dijkstra-era placeholder messages under TODO Dijkstra

### DIFF
--- a/.changes/20260420_cardano_api_dijkstra_placeholder_unification.yml
+++ b/.changes/20260420_cardano_api_dijkstra_placeholder_unification.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 0
+kind:
+  - maintenance
+description: |
+  Unify Dijkstra-era placeholder `error` messages and `TODO` comments under a single greppable token `TODO Dijkstra:`, so `grep -r 'TODO Dijkstra'` finds every Dijkstra-era placeholder in one shot. No behaviour change.

--- a/.changes/20260420_cardano_api_dijkstra_placeholder_unification.yml
+++ b/.changes/20260420_cardano_api_dijkstra_placeholder_unification.yml
@@ -1,5 +1,5 @@
 project: cardano-api
-pr: 0
+pr: 1187
 kind:
   - maintenance
 description: |

--- a/cardano-api/src/Cardano/Api/Certificate/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Certificate/Internal.hs
@@ -826,7 +826,7 @@ getAnchorDataFromCertificate c =
           Ledger.RetirePoolTxCert _ _ -> return Nothing
           Ledger.GenesisDelegTxCert{} -> return Nothing
           Ledger.MirTxCert _ -> return Nothing
-          _ -> error "getAnchorDataFromCertificate: Dijkstra era not supported"
+          _ -> error "TODO Dijkstra: getAnchorDataFromCertificate: era not supported"
     ConwayCertificate ceo ccert ->
       conwayEraOnwardsConstraints ceo $
         case ccert of
@@ -843,7 +843,7 @@ getAnchorDataFromCertificate c =
           Ledger.UpdateDRepTxCert _ mAnchor -> return $ Ledger.strictMaybeToMaybe mAnchor
           Ledger.AuthCommitteeHotKeyTxCert _ _ -> return Nothing
           Ledger.ResignCommitteeColdTxCert _ mAnchor -> return $ Ledger.strictMaybeToMaybe mAnchor
-          _ -> error "getAnchorDataFromCertificate: Dijkstra era not supported"
+          _ -> error "TODO Dijkstra: getAnchorDataFromCertificate: era not supported"
  where
   anchorDataFromPoolMetadata
     :: MonadError AnchorDataFromCertificateError m

--- a/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
@@ -52,7 +52,7 @@ caseByronOrShelleyBasedEra l r = \case
   AlonzoEra -> r ShelleyBasedEraAlonzo
   BabbageEra -> r ShelleyBasedEraBabbage
   ConwayEra -> r ShelleyBasedEraConway
-  DijkstraEra -> error "caseByronOrShelleyBasedEra: DijkstraEra is not supported"
+  DijkstraEra -> error "TODO Dijkstra: caseByronOrShelleyBasedEra: era not supported"
 
 -- | @caseByronToAlonzoOrBabbageEraOnwards f g era@ applies @f@ to byron, shelley, allegra, mary, and alonzo;
 -- and @g@ to babbage and later eras.
@@ -70,7 +70,7 @@ caseByronToAlonzoOrBabbageEraOnwards l r = \case
   AlonzoEra -> l ByronToAlonzoEraAlonzo
   BabbageEra -> r BabbageEraOnwardsBabbage
   ConwayEra -> r BabbageEraOnwardsConway
-  DijkstraEra -> error "caseByronToAlonzoOrBabbageEraOnwards: DijkstraEra is not supported"
+  DijkstraEra -> error "TODO Dijkstra: caseByronToAlonzoOrBabbageEraOnwards: era not supported"
 
 -- | @caseShelleyEraOnlyOrAllegraEraOnwards f g era@ applies @f@ to shelley;
 -- and applies @g@ to allegra and later eras.
@@ -87,7 +87,7 @@ caseShelleyEraOnlyOrAllegraEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> r AllegraEraOnwardsAlonzo
   ShelleyBasedEraBabbage -> r AllegraEraOnwardsBabbage
   ShelleyBasedEraConway -> r AllegraEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "caseShelleyEraOnlyOrAllegraEraOnwards: DijkstraEra is not supported"
+  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyEraOnlyOrAllegraEraOnwards: era not supported"
 
 -- | @caseShelleyToAllegraOrMaryEraOnwards f g era@ applies @f@ to shelley and allegra;
 -- and applies @g@ to mary and later eras.
@@ -104,7 +104,7 @@ caseShelleyToAllegraOrMaryEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> r MaryEraOnwardsAlonzo
   ShelleyBasedEraBabbage -> r MaryEraOnwardsBabbage
   ShelleyBasedEraConway -> r MaryEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "caseShelleyToAllegraOrMaryEraOnwards: DijkstraEra is not supported"
+  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToAllegraOrMaryEraOnwards: era not supported"
 
 -- | @caseShelleyToMaryOrAlonzoEraOnwards f g era@ applies @f@ to shelley, allegra, and mary;
 -- and applies @g@ to alonzo and later eras.
@@ -121,7 +121,7 @@ caseShelleyToMaryOrAlonzoEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> r AlonzoEraOnwardsAlonzo
   ShelleyBasedEraBabbage -> r AlonzoEraOnwardsBabbage
   ShelleyBasedEraConway -> r AlonzoEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "caseShelleyToMaryOrAlonzoEraOnwards: DijkstraEra is not supported"
+  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToMaryOrAlonzoEraOnwards: era not supported"
 
 -- | @caseShelleyToAlonzoOrBabbageEraOnwards f g era@ applies @f@ to shelley, allegra, mary, and alonzo;
 -- and applies @g@ to babbage and later eras.
@@ -138,7 +138,7 @@ caseShelleyToAlonzoOrBabbageEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> l ShelleyToAlonzoEraAlonzo
   ShelleyBasedEraBabbage -> r BabbageEraOnwardsBabbage
   ShelleyBasedEraConway -> r BabbageEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "caseShelleyToAlonzoOrBabbageEraOnwards: DijkstraEra is not supported"
+  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToAlonzoOrBabbageEraOnwards: era not supported"
 
 -- | @caseShelleyToBabbageOrConwayEraOnwards f g era@ applies @f@ to eras before conway;
 -- and applies @g@ to conway and later eras.
@@ -155,7 +155,7 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> l ShelleyToBabbageEraAlonzo
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway -> r ConwayEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "caseShelleyToBabbageOrConwayEraOnwards: DijkstraEra is not supported"
+  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToBabbageOrConwayEraOnwards: era not supported"
 
 {-# DEPRECATED shelleyToAlonzoEraToShelleyToBabbageEra "Use convert instead" #-}
 shelleyToAlonzoEraToShelleyToBabbageEra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
@@ -120,7 +120,7 @@ allegraEraOnwardsConstraints = \case
   AllegraEraOnwardsAlonzo -> id
   AllegraEraOnwardsBabbage -> id
   AllegraEraOnwardsConway -> id
-  _ -> const $ error "allegraEraOnwardsConstraints: Dijkstra era not supported"
+  _ -> const $ error "TODO Dijkstra: allegraEraOnwardsConstraints: era not supported"
 
 {-# DEPRECATED allegraEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 allegraEraOnwardsToShelleyBasedEra :: AllegraEraOnwards era -> ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
@@ -137,7 +137,7 @@ babbageEraOnwardsConstraints
 babbageEraOnwardsConstraints = \case
   BabbageEraOnwardsBabbage -> id
   BabbageEraOnwardsConway -> id
-  BabbageEraOnwardsDijkstra -> const $ error "babbageEraOnwardsConstraints: DijkstraEra is currently not supported"
+  BabbageEraOnwardsDijkstra -> const $ error "TODO Dijkstra: babbageEraOnwardsConstraints: era not supported"
 
 {-# DEPRECATED babbageEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
@@ -145,7 +145,7 @@ conwayEraOnwardsConstraints
   -> a
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id
-  _ -> const $ error "conwayEraOnwardsConstraints: Dijkstra era is not yet supported"
+  _ -> const $ error "TODO Dijkstra: conwayEraOnwardsConstraints: era not supported"
 
 {-# DEPRECATED conwayEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 conwayEraOnwardsToShelleyBasedEra :: ConwayEraOnwards era -> ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
@@ -121,7 +121,7 @@ maryEraOnwardsConstraints = \case
   MaryEraOnwardsAlonzo -> id
   MaryEraOnwardsBabbage -> id
   MaryEraOnwardsConway -> id
-  MaryEraOnwardsDijkstra -> const $ error "maryEraOnwardsConstraints: Dijkstra era is not yet supported"
+  MaryEraOnwardsDijkstra -> const $ error "TODO Dijkstra: maryEraOnwardsConstraints: era not supported"
 
 {-# DEPRECATED maryEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
 maryEraOnwardsToShelleyBasedEra :: MaryEraOnwards era -> ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
@@ -261,7 +261,7 @@ shelleyBasedEraConstraints = \case
   ShelleyBasedEraAlonzo -> id
   ShelleyBasedEraBabbage -> id
   ShelleyBasedEraConway -> id
-  ShelleyBasedEraDijkstra -> const $ error "shelleyBasedEraConstraints: Dijkstra is not yet supported"
+  ShelleyBasedEraDijkstra -> const $ error "TODO Dijkstra: shelleyBasedEraConstraints: era not supported"
 
 data AnyShelleyBasedEra where
   AnyShelleyBasedEra

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/AnyWitness.hs
@@ -125,7 +125,7 @@ getPlutusDatum
 getPlutusDatum L.SPlutusV1 (SpendingScriptDatum d) = Just d
 getPlutusDatum L.SPlutusV2 (SpendingScriptDatum d) = Just d
 getPlutusDatum L.SPlutusV3 (SpendingScriptDatum d) = d
-getPlutusDatum L.SPlutusV4 (SpendingScriptDatum _d) = error "getPlutusDatum: Dijkstra era not supported"
+getPlutusDatum L.SPlutusV4 (SpendingScriptDatum _d) = error "TODO Dijkstra: getPlutusDatum: era not supported"
 getPlutusDatum _ InlineDatum = Nothing
 getPlutusDatum _ NoScriptDatum = Nothing
 

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
@@ -194,7 +194,7 @@ makeUnsignedTx
    . Era era
   -> TxBodyContent (LedgerEra era)
   -> Either MakeUnsignedTxError (UnsignedTx (LedgerEra era))
-makeUnsignedTx DijkstraEra _ = error "makeUnsignedTx: Dijkstra era not supported yet"
+makeUnsignedTx DijkstraEra _ = error "TODO Dijkstra: makeUnsignedTx: era not supported"
 makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
   let TxScriptWitnessRequirements languages scripts datums redeemers = collectTxBodyScriptWitnessRequirements bc
 
@@ -846,7 +846,7 @@ extractWitnessableVotes
 extractWitnessableVotes Nothing = []
 extractWitnessableVotes (Just txVoteProc) =
   case useEra @era of
-    DijkstraEra -> error "extractWitnessableVotes: Dijkstra era not supported"
+    DijkstraEra -> error "TODO Dijkstra: extractWitnessableVotes: era not supported"
     ConwayEra ->
       List.nub
         [ (WitVote vote, wit)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
@@ -71,7 +71,7 @@ makeStakeAddressDelegationCertificate sCred delegatee =
     e@ShelleyBasedEraMary -> cert e delegatee
     e@ShelleyBasedEraAllegra -> cert e delegatee
     e@ShelleyBasedEraShelley -> cert e delegatee
-    ShelleyBasedEraDijkstra -> error "makeStakeAddressDelegationCertificate: Dijkstra era not supported"
+    ShelleyBasedEraDijkstra -> error "TODO Dijkstra: makeStakeAddressDelegationCertificate: era not supported"
  where
   cert
     :: Delegatee era ~ Api.Hash Api.StakePoolKey

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -428,7 +428,7 @@ estimateBalancedTxBody'
           obtainCommonConstraints (useEra @era) $
             TxOut (L.mkBasicTxOut (toShelleyAddr changeaddr) balance)
     case useEra @era of
-      DijkstraEra -> error "estimateBalancedTxBody: DijkstraEra is not supported for fee estimation"
+      DijkstraEra -> error "TODO Dijkstra: estimateBalancedTxBody: era not supported for fee estimation"
       ConwayEra -> do
         when (coinBalance < 0) $
           Left $
@@ -1542,7 +1542,7 @@ makeTransactionBodyAutoBalance
             }
 
     case useEra @era of
-      DijkstraEra -> error "makeTransactionBodyAutoBalance: DijkstraEra not supported"
+      DijkstraEra -> error "TODO Dijkstra: makeTransactionBodyAutoBalance: era not supported"
       ConwayEra -> do
         let balance :: L.MaryValue = evaluateTransactionBalance pp poolids stakeDelegDeposits drepDelegDeposits utxo txbody2
             adaBalance = getAda (useEra @era) balance

--- a/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
@@ -268,9 +268,9 @@ deriving newtype instance ToJSON (Babbage.ApplyTxError Consensus.BabbageEra)
 
 deriving newtype instance ToJSON (Conway.ApplyTxError Consensus.ConwayEra)
 
--- TODO: fix this instance when the Dijkstra era is stable in Ledger
+-- TODO Dijkstra: fix this ToJSON instance when the era is stable in Ledger
 instance ToJSON (Dijkstra.ApplyTxError Consensus.DijkstraEra) where
-  toJSON = error "Dijkstra era is not active yet"
+  toJSON = error "TODO Dijkstra: toJSON @(ApplyTxError DijkstraEra): era not active"
 
 deriving via
   ShowOf (L.Keys.VKey L.Keys.Witness)

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -1165,7 +1165,7 @@ instance FromJSON NodeConfig where
         <*> parseAlonzoHardForkEpoch o
         <*> parseBabbageHardForkEpoch o
         <*> parseConwayHardForkEpoch o
-        <*> pure Consensus.CardanoTriggerHardForkAtDefaultVersion -- TODO: Dijkstra
+        <*> pure Consensus.CardanoTriggerHardForkAtDefaultVersion -- TODO Dijkstra
     parseShelleyHardForkEpoch :: Object -> Parser (Consensus.CardanoHardForkTrigger blk)
     parseShelleyHardForkEpoch o =
       asum
@@ -1511,8 +1511,8 @@ readCardanoGenesisConfig enc = do
   ShelleyConfig shelleyGenesis shelleyGenesisHash <- readShelleyGenesisConfig enc
   alonzoGenesis <- readAlonzoGenesisConfig enc
   conwayGenesis <- readConwayGenesisConfig enc
-  -- TODO: Build dummy dijkstra genesis value
-  let dijkstraGenesis = exampleDijkstraGenesis -- TODO: Dijkstra - add plumbing to read Dijkstra genesis
+  -- TODO Dijkstra: build real genesis value
+  let dijkstraGenesis = exampleDijkstraGenesis -- TODO Dijkstra: add plumbing to read genesis
   let transCfg = Ledger.mkLatestTransitionConfig shelleyGenesis alonzoGenesis conwayGenesis dijkstraGenesis
   pure $ GenesisCardano enc byronGenesis shelleyGenesisHash transCfg
 

--- a/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
+++ b/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
@@ -1426,7 +1426,7 @@ fromShelleyMultiSig = go
   go (Shelley.RequireAllOf s) = RequireAllOf (map go $ toList s)
   go (Shelley.RequireAnyOf s) = RequireAnyOf (map go $ toList s)
   go (Shelley.RequireMOf m s) = RequireMOf m (map go $ toList s)
-  go _ = error "fromShelleyMultiSig: Dijkstra era not supported"
+  go _ = error "TODO Dijkstra: fromShelleyMultiSig: era not supported"
 
 -- | Conversion for the 'Timelock.Timelock' language that is shared between the
 -- Allegra and Mary eras.
@@ -1460,7 +1460,7 @@ fromAllegraTimelock = go
   go (Shelley.RequireAllOf s) = RequireAllOf (map go (toList s))
   go (Shelley.RequireAnyOf s) = RequireAnyOf (map go (toList s))
   go (Shelley.RequireMOf i s) = RequireMOf i (map go (toList s))
-  go _ = error "fromAllegraTimelock: Dijkstra era not supported"
+  go _ = error "TODO Dijkstra: fromAllegraTimelock: era not supported"
 
 type family ToLedgerPlutusLanguage lang where
   ToLedgerPlutusLanguage PlutusScriptV1 = Plutus.PlutusV1

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -2662,7 +2662,7 @@ makeShelleyTransactionBody
 
     txAuxData :: Maybe (L.TxAuxData E.ConwayEra)
     txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
-makeShelleyTransactionBody ShelleyBasedEraDijkstra _ = error "makeShelleyTransactionBody: Dijkstra era not supported"
+makeShelleyTransactionBody ShelleyBasedEraDijkstra _ = error "TODO Dijkstra: makeShelleyTransactionBody: era not supported"
 
 -- ----------------------------------------------------------------------------
 -- Script witnesses within the tx body
@@ -3104,7 +3104,7 @@ extractWitnessableVotes
   :: ConwayEraOnwards era
   -> Maybe (Featured eon era (TxVotingProcedures BuildTx era))
   -> [(Witnessable VoterItem (ShelleyLedgerEra era), BuildTxWith BuildTx (Witness WitCtxStake era))]
-extractWitnessableVotes ConwayEraOnwardsDijkstra _ = error "extractWitnessableVotes: Dijkstra era not supported"
+extractWitnessableVotes ConwayEraOnwardsDijkstra _ = error "TODO Dijkstra: extractWitnessableVotes: era not supported"
 extractWitnessableVotes e@ConwayEraOnwardsConway txVotingProcedures =
   List.nub
     [ (conwayEraOnwardsConstraints e $ WitVote vote, BuildTxWith wit)

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -169,7 +169,7 @@ reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsAlonzo = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsBabbage = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsConway = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
-reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = error "reqSignerHashesTxBodyL: DijkstraEra not supported yet"
+reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = error "TODO Dijkstra: reqSignerHashesTxBodyL: era not supported"
 
 referenceInputsTxBodyL
   :: BabbageEraOnwards era -> Lens' (LedgerTxBody era) (Set L.TxIn)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Unify Dijkstra-era placeholder `error` messages and `TODO` comments
    under the single greppable token `TODO Dijkstra:`, so
    `grep -r 'TODO Dijkstra'` locates every Dijkstra-era placeholder in
    cardano-api in one shot. No behaviour change.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-api
  # - cardano-api-gen
  # - cardano-rpc
  # - cardano-wasm
```

# Context

Follow-up to #1175. A reviewer there noted that Dijkstra-era placeholders in cardano-node use three different conventions, so no single `grep` catches them all. The same problem exists in cardano-api: 27 `error` stubs mentioning Dijkstra, spread across 5+ phrasings (`not supported`, `is not yet supported`, `not supported yet`, `currently not supported`, `is not active yet`), plus 4 `-- TODO` comments in various forms. `grep 'TODO.*Dijkstra'` missed the error stubs; `grep 'Dijkstra era'` missed the TODOs; no single grep caught all 31.

This PR unifies **30 of them** (see exclusions below) under the literal contiguous token `TODO Dijkstra` so `grep -rn 'TODO Dijkstra' cardano-api/src` now returns every Dijkstra-era placeholder a future maintainer needs to audit when Dijkstra-era support lands.

## Format applied

- **Error stubs:** `error \"TODO Dijkstra: <function>: <brief reason>\"` — preserves existing descriptive context so runtime stack traces remain self-explanatory.
- **TODO comments:** `-- TODO Dijkstra: <brief reason>` — colon is after `Dijkstra`, not between `TODO` and `Dijkstra`, otherwise `grep 'TODO Dijkstra'` misses.

## Sites touched (30)

- **Case combinators (7):** `Era/Internal/Case.hs:{55,73,90,107,124,141,158}`
- **Eon constraints (5):** `Era/Internal/Eon/{AllegraEraOnwards,MaryEraOnwards,BabbageEraOnwards,ConwayEraOnwards,ShelleyBasedEra}.hs`
- **Old API (7):** `Certificate/Internal.hs:{829,846}`, `Tx/Internal/Body.hs:{2665,3107}`, `Tx/Internal/Body/Lens.hs:172`, `Plutus/Internal/Script.hs:{1429,1463}`
- **Experimental API (6):** `Experimental/Tx/Internal/Fee.hs:{431,1545}`, `Experimental/Tx/Internal/AnyWitness.hs:128`, `Experimental/Tx/Internal/Certificate/Compatible.hs:74`, `Experimental/Tx/Internal/BodyContent/New.hs:{197,849}`
- **Serialisation orphan (1):** `Internal/Orphans/Serialisation.hs:273` (error) + L271 (adjacent TODO)
- **TODO comments (4):** `Internal/Orphans/Serialisation.hs:271`, `LedgerState.hs:{1168,1514,1515}`

## Intentional exclusions

- **`Tx/Internal/Body.hs:2858`** — `toScriptIndexDijkstra: unexpected DijkstraGuarding at index N` is a runtime invariant assertion, not a \"Dijkstra era not yet supported\" placeholder. `DijkstraGuarding` is a ledger-side constructor with no corresponding `ScriptWitnessIndex` case; the error fires only if the ledger ever hands us one. Fixing that would mean adding a new `ScriptWitnessIndex` variant (a breaking change) — different kind of work from everything else on the list.
- **`Plutus/Internal/Script.hs:1302`** — `toShelleyScript: PlutusV4 not implemented yet.` is a PlutusV4 stub that blocks on ledger exposing a PlutusV4 constructor. Will be tracked as a dedicated issue rather than prefixed with `TODO Dijkstra` (it's PlutusV4-gated, not Dijkstra-gated).

# How to trust this PR

- Verify the greppability claim:
  ```
  grep -rn 'TODO Dijkstra' cardano-api/src | wc -l     # → 30
  grep -rn 'is not yet supported\|currently not supported\|is not active yet\|not supported yet' cardano-api/src  # → no Dijkstra hits
  grep -rn 'DijkstraEra is not supported\|DijkstraEra not supported\|Dijkstra era is not\|Dijkstra era not supported' cardano-api/src  # → no hits
  grep -rn -- '-- TODO: Dijkstra\|TODO: Build dummy dijkstra\|TODO: fix this instance when the Dijkstra' cardano-api/src  # → no hits
  grep -n 'unexpected DijkstraGuarding' cardano-api/src/Cardano/Api/Tx/Internal/Body.hs  # → 1 hit (intentionally preserved)
  ```
- Only strings/comments changed — no type signatures or logic touched. Diff is 30 insertions / 30 deletions on the `.hs` files.
- Builds clean: `cabal build cardano-api -j4`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff