### PR TITLE
Remove SRP for `haskell-lmdb-mock`

### DIFF
--- a/.changes/20260428_132126_cardano-wasm_pablo.lamela_remove_srp_for_haskell_lmdb_mock.yml
+++ b/.changes/20260428_132126_cardano-wasm_pablo.lamela_remove_srp_for_haskell_lmdb_mock.yml
@@ -1,0 +1,5 @@
+description: Removed SRP for `haskell-lmdb-mock` which is no longer needed.
+kind:
+- maintenance
+pr: 1192
+project: cardano-wasm

--- a/cabal.project
+++ b/cabal.project
@@ -96,12 +96,6 @@ if arch(wasm32)
 
   source-repository-package
     type: git
-    location: https://github.com/palas/haskell-lmdb-mock.git
-    tag: c8d61e6eee03ee271e7768c0576110da885aec48
-    --sha256: sha256-+gB1MmM6qRApz1p7tFsdvKoAWDrYB4a+bJ9Djm6ieYI=
-
-  source-repository-package
-    type: git
     location: https://github.com/palas/double-conversion.git
     tag: b2030245727ee56de76507fe305e3741f6ce3260
     --sha256: sha256-kzwHHQzHPfPnIDtnSDAom7YGSzWjr0113x0zsfI/Tb0=

--- a/flake.nix
+++ b/flake.nix
@@ -294,6 +294,19 @@
                 src = nixpkgs.blst.src;
               });
           };
+          # Stub pkg-config file so the cabal solver can resolve
+          # cardano-lmdb (a transitive dependency of ouroboros-consensus
+          # that nothing in this project actually needs). Without this,
+          # the solver rejects cardano-lmdb because lmdb is not
+          # available for wasm. Per-component builds ensure it is never
+          # actually compiled.
+          lmdb-pkg-config-stub = wasm-pkgs.writeTextDir "lib/pkgconfig/lmdb.pc" ''
+            Name: lmdb
+            Description: Stub for cabal solver — not actually built
+            Version: 0.9.33
+            Libs: -llmdb
+            Cflags:
+          '';
         in
           lib.optionalAttrs (system != "x86_64-darwin") {
             wasm = wasm-pkgs.mkShell {
@@ -308,6 +321,7 @@
                   wasm.libsodium
                   wasm.secp256k1
                   wasm.blst
+                  lmdb-pkg-config-stub
                 ]
                 ++ lib.optional (system == "x86_64-linux" || system == "aarch64-linux") wasm-pkgs.envoy-bin;
             };


### PR DESCRIPTION
# Context

`haskell-lmdb` is no longer a dependency of `cardano-api`, so we don't need to mock it. This PR removes the SRP for `haskell-lmdb-mock`.

# How to trust this PR

If it compiles it should be fine, because it means it was an unnecessary dependency.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

