### PR TITLE
Add script for preparing the wasm libraries for building without Nix

### DIFF
--- a/.changes/20260706_cardano_wasm_wasm_libs_without_nix_script.yml
+++ b/.changes/20260706_cardano_wasm_wasm_libs_without_nix_script.yml
@@ -1,0 +1,7 @@
+project: cardano-wasm
+pr: 1194
+kind:
+  - maintenance
+description: |
+  Add `scripts/wasm-without-nix/build-wasm-libs.sh` for building the wasm32-wasi
+  C library dependencies (libsodium, libsecp256k1, libblst) without Nix

--- a/cardano-wasm/README.md
+++ b/cardano-wasm/README.md
@@ -13,8 +13,10 @@ Enter the Nix shell by writing `nix develop .#wasm` on a shell in this folder an
 For the installation we will need some dependencies. In Debian based distros we can install them using apt like this:
 
 ```bash
-sudo apt install happy pkgconf libtool git wget curl jq unzip zstd tar gzip
+sudo apt install happy pkgconf libtool make automake autoconf file git wget curl jq unzip zstd tar gzip
 ```
+
+(`jq`, `unzip`, `zstd`, `wget` and `curl` are needed by ghc-wasm-meta's installer rather than by the build itself, and `happy` is needed by some Haskell dependencies during the build.)
 
 #### Installing `ghc` for wasm
 
@@ -40,7 +42,17 @@ And that should not return:
 wasm32-wasi-ghc: command not found
 ```
 
+If the reported version is not 9.10.x, double-check the `FLAVOUR` used above before continuing: with a different `base` version the build will only fail much later, with confusing dependency resolution errors.
+
 Then we need to compile three libraries to WASM: `libblst`, `libsodium`, and `libsecp256k1`.
+
+The script [`scripts/wasm-without-nix/build-wasm-libs.sh`](../scripts/wasm-without-nix/build-wasm-libs.sh) automates all the steps in this section: it builds the same pinned versions of the libraries as the Nix build, installs them into a prefix of your choice, verifies the results are really wasm, and generates a `cabal.project` fragment that points the build at them. From the root of this repository run:
+
+```bash
+PREFIX=wasm-libs SRC_ROOT=wasm-libs-src ./scripts/wasm-without-nix/build-wasm-libs.sh
+```
+
+and then follow the instructions it prints at the end (in particular, exporting `PKG_CONFIG_PATH`). In that case you can skip straight to the [Compiling `cardano-wasm` section](#compiling-cardano-wasm). The rest of this section explains the equivalent manual steps.
 
 In order to not interfere with the system library installation, we will create a folder to serve as our prefix:
 

--- a/scripts/wasm-without-nix/build-wasm-libs.sh
+++ b/scripts/wasm-without-nix/build-wasm-libs.sh
@@ -4,11 +4,17 @@
 # extra-include-dirs. Mirrors ./nix/{libsodium,secp256k1,blst}.nix but uses
 # wasm32-wasi-clang directly (no Nix).
 #
+# Usage:
+#   PREFIX=wasm-libs SRC_ROOT=wasm-libs-src ./scripts/wasm-without-nix/build-wasm-libs.sh [--yes] [--force]
+#
+#   --yes    add the import block to cabal.project without prompting
+#   --force  rebuild the libraries even if they are already installed in PREFIX
+#
 # Requirements on PATH: wasm32-wasi-clang, wasm-ld, llvm-ar and llvm-ranlib
 # (all provided by the wasi-sdk / ghc-wasm environment), plus autoreconf,
-# automake, libtoolize, make, git, pkg-config, ar, file, mktemp and nproc.
+# automake, libtoolize, make, git, pkg-config, ar, file and mktemp.
 
-set -euo pipefail
+set -Eeuo pipefail
 
 # Script must be run from the root of the project
 PROJECT_DIR="$(pwd)"
@@ -16,6 +22,19 @@ PROJECT_DIR="$(pwd)"
     echo "Error: cabal.project not found in $PROJECT_DIR. Run this script from the root of the project" >&2
     exit 1
 }
+
+ASSUME_YES=""
+FORCE=""
+for arg in "$@"; do
+    case "$arg" in
+        --yes)   ASSUME_YES=1 ;;
+        --force) FORCE=1 ;;
+        *)
+            echo "Error: unknown argument: $arg (supported: --yes, --force)" >&2
+            exit 1
+            ;;
+    esac
+done
 
 missing=()
 [ -n "${PREFIX:-}" ]   || missing+=(PREFIX)
@@ -36,9 +55,13 @@ Both values are interpreted relative to the cabal.project directory
             will be cloned into as \$SRC_ROOT/{libsodium,secp256k1,blst}),
             e.g. wasm-deps.
 
+Flags:
+  --yes     add the import block to cabal.project without prompting
+  --force   rebuild the libraries even if they are already installed in PREFIX
+
 Requirements on PATH: wasm32-wasi-clang, wasm-ld, llvm-ar and llvm-ranlib
 (all provided by the wasi-sdk / ghc-wasm environment), plus autoreconf,
-automake, libtoolize, make, git, pkg-config, ar, file, mktemp and nproc.
+automake, libtoolize, make, git, pkg-config, ar, file and mktemp.
 
 Example:
   PREFIX=wasm-libs SRC_ROOT=wasm-libs-src $0
@@ -61,7 +84,7 @@ ABS_SRC_ROOT="$(resolve_rel "$SRC_ROOT")"
 # because some distros (e.g. Debian) package libtool without a libtool
 # executable, and the autogen.sh scripts only need libtoolize.
 tools_missing=()
-for t in autoreconf automake libtoolize make git pkg-config ar file mktemp nproc; do
+for t in autoreconf automake libtoolize make git pkg-config ar file mktemp; do
     command -v "$t" >/dev/null 2>&1 || tools_missing+=("$t")
 done
 if [ "${#tools_missing[@]}" -gt 0 ]; then
@@ -96,33 +119,58 @@ EOF
     exit 1
 fi
 
+# nproc is not available on macOS; getconf is POSIX.
+JOBS="$(nproc 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"
+
+# libsodium is pinned to the same revision as ./nix/libsodium.nix
 LIBSODIUM_REV="9511c982fb1d046470a8b42aa36556cdb7da15de"
 LIBSODIUM_REPO="https://github.com/jedisct1/libsodium.git"
+# secp256k1 (v0.3.2) and blst (v0.3.14) are pinned to the same revisions as
+# the Nix build.
 SECP256K1_REV="acf5c55ae6a94e5ca847e07def40427547876101"
 SECP256K1_REPO="https://github.com/bitcoin-core/secp256k1.git"
 BLST_REV="8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355"
 BLST_REPO="https://github.com/supranational/blst.git"
 
+echo "Configuration:"
+echo "  PREFIX:     $ABS_PREFIX"
+echo "  SRC_ROOT:   $ABS_SRC_ROOT"
+echo "  jobs:       $JOBS"
+echo "  libsodium:  $LIBSODIUM_REV"
+echo "  secp256k1:  $SECP256K1_REV"
+echo "  blst:       $BLST_REV"
+echo "  toolchain:  $(command -v wasm32-wasi-clang) ($(wasm32-wasi-clang --version | head -1))"
+echo
+
 mkdir -p "$ABS_PREFIX/lib" "$ABS_PREFIX/include" "$ABS_PREFIX/lib/pkgconfig"
 mkdir -p "$ABS_SRC_ROOT"
 
-clone_if_missing() {
+# Fetch only the pinned revision (shallow) instead of a full clone; GitHub
+# allows fetching arbitrary commit hashes.
+checkout_rev() {
     local repo="$1" dir="$2" rev="$3"
     if [ ! -d "$dir/.git" ]; then
-        git clone "$repo" "$dir"
+        git init -q "$dir"
+        git -C "$dir" remote add origin "$repo"
     fi
-    git -C "$dir" fetch --tags origin "$rev" 2>/dev/null || true
-    git -C "$dir" checkout "$rev"
+    if [ "$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)" != "$rev" ]; then
+        git -C "$dir" fetch --depth 1 origin "$rev"
+        git -C "$dir" checkout -q "$rev"
+    fi
 }
 
 build_libsodium() {
+    if [ -z "$FORCE" ] && [ -f "$ABS_PREFIX/lib/libsodium.a" ] && [ -f "$ABS_PREFIX/lib/libsodium.so" ]; then
+        echo "already installed in $ABS_PREFIX, skipping (use --force to rebuild)"
+        return
+    fi
     local dir="$ABS_SRC_ROOT/libsodium"
-    clone_if_missing "$LIBSODIUM_REPO" "$dir" "$LIBSODIUM_REV"
+    checkout_rev "$LIBSODIUM_REPO" "$dir" "$LIBSODIUM_REV"
     cd "$dir"
     [ -x ./configure ] || ./autogen.sh -s
     CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib \
         ./configure --host=wasm32-wasi --prefix="$ABS_PREFIX"
-    make -j"$(nproc)"
+    make -j"$JOBS"
     make install
     wasm32-wasi-clang -shared -Wl,--whole-archive \
         "$ABS_PREFIX/lib/libsodium.a" \
@@ -131,8 +179,12 @@ build_libsodium() {
 }
 
 build_secp256k1() {
+    if [ -z "$FORCE" ] && [ -f "$ABS_PREFIX/lib/libsecp256k1.a" ] && [ -f "$ABS_PREFIX/lib/libsecp256k1.so" ]; then
+        echo "already installed in $ABS_PREFIX, skipping (use --force to rebuild)"
+        return
+    fi
     local dir="$ABS_SRC_ROOT/secp256k1"
-    clone_if_missing "$SECP256K1_REPO" "$dir" "$SECP256K1_REV"
+    checkout_rev "$SECP256K1_REPO" "$dir" "$SECP256K1_REV"
     cd "$dir"
     [ -x ./configure ] || ./autogen.sh
     CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib \
@@ -141,7 +193,7 @@ build_secp256k1() {
         --enable-module-schnorrsig \
         --prefix="$ABS_PREFIX" \
         SECP_CFLAGS=-fPIC
-    make -j"$(nproc)"
+    make -j"$JOBS"
     make install
     wasm32-wasi-clang -shared -Wl,--whole-archive \
         "$ABS_PREFIX/lib/libsecp256k1.a" \
@@ -150,8 +202,13 @@ build_secp256k1() {
 }
 
 build_blst() {
+    if [ -z "$FORCE" ] && [ -f "$ABS_PREFIX/lib/libblst.a" ] && [ -f "$ABS_PREFIX/lib/libblst.so" ] \
+        && [ -f "$ABS_PREFIX/lib/pkgconfig/libblst.pc" ]; then
+        echo "already installed in $ABS_PREFIX, skipping (use --force to rebuild)"
+        return
+    fi
     local dir="$ABS_SRC_ROOT/blst"
-    clone_if_missing "$BLST_REPO" "$dir" "$BLST_REV"
+    checkout_rev "$BLST_REPO" "$dir" "$BLST_REV"
     cd "$dir"
     CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib ./build.sh
 
@@ -202,22 +259,46 @@ verify_wasm() {
     fi
 }
 
-build_libsodium 2>&1 | sed -u $'s/^/\033[1;32mlibsodium\033[0m > /'
-build_secp256k1 2>&1 | sed -u $'s/^/\033[1;36msecp256k1\033[0m > /'
-build_blst      2>&1 | sed -u $'s/^/\033[1;33mblst\033[0m      > /'
+# Line-buffered and portable replacement for 'sed -u' (BSD sed has no -u).
+prefix_log() {
+    while IFS= read -r line; do printf '%s > %s\n' "$1" "$line"; done
+}
+
+# Report which library was being built when a failure aborts the script.
+# ('set -E' above makes functions inherit this ERR trap; wrapping the build
+# in 'if !' instead would disable 'set -e' inside the build functions.)
+CURRENT_LIB=""
+trap '[ -z "$CURRENT_LIB" ] || [ "$BASH_SUBSHELL" != 0 ] || printf "ERROR: building %s failed, see the log above.\n" "$CURRENT_LIB" >&2' ERR
+
+run_build() {
+    CURRENT_LIB="$1"
+    "$2" 2>&1 | prefix_log "$(printf '%s%-9s\033[0m' "$3" "$1")"
+    CURRENT_LIB=""
+}
+
+run_build libsodium build_libsodium $'\033[1;32m'
+run_build secp256k1 build_secp256k1 $'\033[1;36m'
+run_build blst      build_blst      $'\033[1;33m'
 
 verify_wasm "$ABS_PREFIX/lib/libsodium.a"
 verify_wasm "$ABS_PREFIX/lib/libsecp256k1.a"
 verify_wasm "$ABS_PREFIX/lib/libblst.a"
 
+# Run the same checks that cabal will run during dependency resolution, so a
+# broken pkg-config setup is reported here with a clear message instead of
+# surfacing later as a confusing solver error. The libblst bound mirrors
+# cardano-crypto-class's 'pkgconfig-depends: libblst >= 0.3.14'.
+if ! PKG_CONFIG_PATH="$ABS_PREFIX/lib/pkgconfig" \
+        pkg-config --exists 'libblst >= 0.3.14' libsodium libsecp256k1; then
+    cat >&2 <<EOF
+ERROR: pkg-config cannot resolve the installed libraries from
+$ABS_PREFIX/lib/pkgconfig. Check the .pc files in that directory.
+EOF
+    exit 1
+fi
+
 echo
 echo "Done. Installed to: $ABS_PREFIX"
-echo
-echo "Some packages (e.g. cardano-crypto-class and cardano-crypto-praos) find"
-echo "these libraries through pkg-config. Since $ABS_PREFIX/lib/pkgconfig is"
-echo "not a standard pkg-config location, export it before building:"
-echo
-echo "  export PKG_CONFIG_PATH=$ABS_PREFIX/lib/pkgconfig"
 
 FRAGMENT="$ABS_PREFIX/wasm-libs-without-nix.cabal"
 cat > "$FRAGMENT" <<EOF
@@ -234,7 +315,6 @@ package cardano-crypto-praos
   extra-lib-dirs: $ABS_PREFIX/lib
   extra-include-dirs: $ABS_PREFIX/include
 EOF
-echo
 echo "Wrote project fragment: $FRAGMENT"
 
 CABAL_PROJECT="$PROJECT_DIR/cabal.project"
@@ -247,9 +327,15 @@ esac
 if grep -qF "wasm-libs-without-nix.cabal" "$CABAL_PROJECT"; then
     echo "cabal.project already imports wasm-libs-without-nix.cabal — nothing to do."
 else
-    read -r -p "Add 'if arch(wasm32) / import: $IMPORT_PATH' block to cabal.project? [y/N] " answer || answer=""
-    case "${answer,,}" in
-        y|yes)
+    if [ -n "$ASSUME_YES" ]; then
+        answer=y
+    elif [ -t 0 ]; then
+        read -r -p "Add 'if arch(wasm32) / import: $IMPORT_PATH' block to cabal.project? [y/N] " answer || answer=""
+    else
+        answer=""
+    fi
+    case "$answer" in
+        [yY]|[yY][eE][sS])
             cat >> "$CABAL_PROJECT" <<EOF
 
 if arch(wasm32)
@@ -259,7 +345,8 @@ EOF
             ;;
         *)
             cat <<EOF
-Skipped. To enable, append to cabal.project:
+Skipped (pass --yes to add it without prompting). To enable, append to
+cabal.project:
 
 if arch(wasm32)
   import: $IMPORT_PATH
@@ -267,3 +354,16 @@ EOF
             ;;
     esac
 fi
+
+cat <<EOF
+
+Next steps — to build the wasm module:
+
+  # cardano-crypto-class and cardano-crypto-praos locate the libraries
+  # through pkg-config, and the directory below is not a standard
+  # pkg-config location:
+  export PKG_CONFIG_PATH=$ABS_PREFIX/lib/pkgconfig
+
+  wasm32-wasi-cabal update
+  wasm32-wasi-cabal build cardano-wasm
+EOF

--- a/scripts/wasm-without-nix/build-wasm-libs.sh
+++ b/scripts/wasm-without-nix/build-wasm-libs.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Build libsodium, libsecp256k1, and libblst for wasm32-wasi and install them
+# into a single prefix that cabal.project can point at via extra-lib-dirs /
+# extra-include-dirs. Mirrors ./nix/{libsodium,secp256k1,blst}.nix but uses
+# wasm32-wasi-clang directly (no Nix).
+#
+# Requirements on PATH: wasm32-wasi-clang (from wasi-sdk), autoreconf,
+# automake, libtool, make, git, pkg-config.
+
+set -euo pipefail
+
+# Script must be run from the root of the project
+PROJECT_DIR="$(pwd)"
+[ -f "$PROJECT_DIR/cabal.project" ] || {
+    echo "Error: cabal.project not found in $PROJECT_DIR. Run this script from the root of the project" >&2
+    exit 1
+}
+
+missing=()
+[ -n "${PREFIX:-}" ]   || missing+=(PREFIX)
+[ -n "${SRC_ROOT:-}" ] || missing+=(SRC_ROOT)
+if [ "${#missing[@]}" -gt 0 ]; then
+    cat >&2 <<EOF
+Error: required environment variable(s) not set: ${missing[*]}
+
+Both values are interpreted relative to the cabal.project directory
+($PROJECT_DIR) unless given as an absolute path.
+
+  PREFIX    where the wasm libs/headers will be installed, e.g. wasm-libs.
+            Will be created if missing. Point cabal.project's
+            extra-lib-dirs / extra-include-dirs at \$PREFIX/lib and
+            \$PREFIX/include.
+
+  SRC_ROOT  where the libsodium / secp256k1 / blst source trees live (or
+            will be cloned into as \$SRC_ROOT/{libsodium,secp256k1,blst}),
+            e.g. wasm-deps.
+
+Example:
+  PREFIX=wasm-libs SRC_ROOT=wasm-libs-src $0
+EOF
+    exit 1
+fi
+
+resolve_rel() {
+    case "$1" in
+        /*) printf '%s\n' "$1" ;;
+        *)  printf '%s\n' "$PROJECT_DIR/$1" ;;
+    esac
+}
+
+ABS_PREFIX="$(resolve_rel "$PREFIX")"
+ABS_SRC_ROOT="$(resolve_rel "$SRC_ROOT")"
+
+# Toolchain check: wasm32-wasi-clang must be on PATH (drives both compile and
+# link). The other wasm32-wasi-* tools come along with it via the wasi-sdk /
+# ghc-wasm env.
+toolchain_missing=()
+for t in wasm32-wasi-clang wasm-ld; do
+    command -v "$t" >/dev/null 2>&1 || toolchain_missing+=("$t")
+done
+if [ "${#toolchain_missing[@]}" -gt 0 ]; then
+    cat >&2 <<EOF
+Error: wasm toolchain not on PATH (missing: ${toolchain_missing[*]}).
+
+The ghc-wasm / wasi-sdk environment doesn't appear to be active. Activate it
+with:
+
+  source ~/.ghc-wasm/env
+
+then re-run this script.
+EOF
+    exit 1
+fi
+
+LIBSODIUM_REV="9511c982fb1d046470a8b42aa36556cdb7da15de"
+LIBSODIUM_REPO="https://github.com/jedisct1/libsodium.git"
+SECP256K1_REPO="https://github.com/bitcoin-core/secp256k1.git"
+BLST_REPO="https://github.com/supranational/blst.git"
+
+mkdir -p "$ABS_PREFIX/lib" "$ABS_PREFIX/include" "$ABS_PREFIX/lib/pkgconfig"
+
+clone_if_missing() {
+    local repo="$1" dir="$2" rev="${3:-}"
+    if [ ! -d "$dir/.git" ]; then
+        git clone "$repo" "$dir"
+    fi
+    if [ -n "$rev" ]; then
+        git -C "$dir" fetch --tags origin "$rev" 2>/dev/null || true
+        git -C "$dir" checkout "$rev"
+    fi
+}
+
+build_libsodium() {
+    local dir="$ABS_SRC_ROOT/libsodium"
+    clone_if_missing "$LIBSODIUM_REPO" "$dir" "$LIBSODIUM_REV"
+    cd "$dir"
+    [ -x ./configure ] || ./autogen.sh -s
+    ./configure --host=wasm32-wasi --prefix="$ABS_PREFIX"
+    make -j"$(nproc)"
+    make install
+    wasm32-wasi-clang -shared -Wl,--whole-archive \
+        "$ABS_PREFIX/lib/libsodium.a" \
+        -o "$ABS_PREFIX/lib/libsodium.so"
+}
+
+build_secp256k1() {
+    local dir="$ABS_SRC_ROOT/secp256k1"
+    clone_if_missing "$SECP256K1_REPO" "$dir"
+    cd "$dir"
+    [ -x ./configure ] || ./autogen.sh
+    ./configure \
+        --host=wasm32-wasi \
+        --enable-module-schnorrsig \
+        --prefix="$ABS_PREFIX" \
+        SECP_CFLAGS=-fPIC
+    make -j"$(nproc)"
+    make install
+    wasm32-wasi-clang -shared -Wl,--whole-archive \
+        "$ABS_PREFIX/lib/libsecp256k1.a" \
+        -o "$ABS_PREFIX/lib/libsecp256k1.so"
+}
+
+build_blst() {
+    local dir="$ABS_SRC_ROOT/blst"
+    clone_if_missing "$BLST_REPO" "$dir"
+    cd "$dir"
+    CC=wasm32-wasi-clang ./build.sh
+
+    cp libblst.a "$ABS_PREFIX/lib/"
+    cp bindings/blst.h bindings/blst_aux.h "$ABS_PREFIX/include/"
+
+    wasm32-wasi-clang -shared -Wl,--whole-archive \
+        "$ABS_PREFIX/lib/libblst.a" \
+        -o "$ABS_PREFIX/lib/libblst.so"
+
+    local version
+    version="$(git -C "$dir" describe --tags --always 2>/dev/null || echo 0.0.0)"
+    cat > "$ABS_PREFIX/lib/pkgconfig/libblst.pc" <<EOF
+prefix=$ABS_PREFIX
+exec_prefix=\${prefix}
+libdir=\${exec_prefix}/lib
+includedir=\${prefix}/include
+
+Name: libblst
+Description: blst BLS12-381 signature library
+URL: https://github.com/supranational/blst
+Version: $version
+
+Cflags: -I\${includedir}
+Libs: -L\${libdir} -lblst
+Libs.private:
+EOF
+}
+
+verify_wasm() {
+    local archive="$1"
+    local tmp
+    tmp="$(mktemp -d)"
+    ( cd "$tmp" && ar x "$archive" && \
+      first_obj="$(ls *.o 2>/dev/null | head -1)" && \
+      [ -n "$first_obj" ] && file "$first_obj" | grep -q WebAssembly )
+    local rc=$?
+    rm -rf "$tmp"
+    if [ "$rc" -ne 0 ]; then
+        echo "ERROR: $archive does not appear to contain wasm objects" >&2
+        exit 1
+    fi
+}
+
+build_libsodium 2>&1 | sed -u $'s/^/\033[1;32mlibsodium\033[0m > /'
+build_secp256k1 2>&1 | sed -u $'s/^/\033[1;36msecp256k1\033[0m > /'
+build_blst      2>&1 | sed -u $'s/^/\033[1;33mblst\033[0m      > /'
+
+verify_wasm "$ABS_PREFIX/lib/libsodium.a"
+verify_wasm "$ABS_PREFIX/lib/libsecp256k1.a"
+verify_wasm "$ABS_PREFIX/lib/libblst.a"
+
+echo
+echo "Done. Installed to: $ABS_PREFIX"
+
+FRAGMENT="$PROJECT_DIR/wasm-libs-without-nix.cabal"
+cat > "$FRAGMENT" <<EOF
+shared: True
+
+package cardano-crypto-class
+  extra-lib-dirs: $ABS_PREFIX/lib
+  extra-include-dirs: $ABS_PREFIX/include
+
+package cardano-crypto-praos
+  extra-lib-dirs: $ABS_PREFIX/lib
+  extra-include-dirs: $ABS_PREFIX/include
+EOF
+echo "Wrote project fragment: $FRAGMENT"
+
+CABAL_PROJECT="$PROJECT_DIR/cabal.project"
+
+if grep -qF "wasm-libs-without-nix.cabal" "$CABAL_PROJECT"; then
+    echo "cabal.project already imports wasm-libs-without-nix.cabal — nothing to do."
+else
+    read -r -p "Add 'if arch(wasm32) / import: wasm-libs-without-nix.cabal' block to cabal.project? [y/N] " answer || answer=""
+    case "${answer,,}" in
+        y|yes)
+            cat >> "$CABAL_PROJECT" <<'EOF'
+
+if arch(wasm32)
+  import: wasm-libs-without-nix.cabal
+EOF
+            echo "Added to $CABAL_PROJECT"
+            ;;
+        *)
+            cat <<'EOF'
+Skipped. To enable, append to cabal.project:
+
+if arch(wasm32)
+  import: wasm-libs-without-nix.cabal
+EOF
+            ;;
+    esac
+fi

--- a/scripts/wasm-without-nix/build-wasm-libs.sh
+++ b/scripts/wasm-without-nix/build-wasm-libs.sh
@@ -4,8 +4,9 @@
 # extra-include-dirs. Mirrors ./nix/{libsodium,secp256k1,blst}.nix but uses
 # wasm32-wasi-clang directly (no Nix).
 #
-# Requirements on PATH: wasm32-wasi-clang (from wasi-sdk), autoreconf,
-# automake, libtool, make, git, pkg-config.
+# Requirements on PATH: wasm32-wasi-clang, wasm-ld, llvm-ar and llvm-ranlib
+# (all provided by the wasi-sdk / ghc-wasm environment), plus autoreconf,
+# automake, libtoolize, make, git, pkg-config, ar, file, mktemp and nproc.
 
 set -euo pipefail
 
@@ -35,6 +36,10 @@ Both values are interpreted relative to the cabal.project directory
             will be cloned into as \$SRC_ROOT/{libsodium,secp256k1,blst}),
             e.g. wasm-deps.
 
+Requirements on PATH: wasm32-wasi-clang, wasm-ld, llvm-ar and llvm-ranlib
+(all provided by the wasi-sdk / ghc-wasm environment), plus autoreconf,
+automake, libtoolize, make, git, pkg-config, ar, file, mktemp and nproc.
+
 Example:
   PREFIX=wasm-libs SRC_ROOT=wasm-libs-src $0
 EOF
@@ -51,11 +56,28 @@ resolve_rel() {
 ABS_PREFIX="$(resolve_rel "$PREFIX")"
 ABS_SRC_ROOT="$(resolve_rel "$SRC_ROOT")"
 
-# Toolchain check: wasm32-wasi-clang must be on PATH (drives both compile and
-# link). The other wasm32-wasi-* tools come along with it via the wasi-sdk /
+# Check for all the required tools up front so that failures are detected
+# early with a clear message. libtoolize is checked instead of libtool
+# because some distros (e.g. Debian) package libtool without a libtool
+# executable, and the autogen.sh scripts only need libtoolize.
+tools_missing=()
+for t in autoreconf automake libtoolize make git pkg-config ar file mktemp nproc; do
+    command -v "$t" >/dev/null 2>&1 || tools_missing+=("$t")
+done
+if [ "${#tools_missing[@]}" -gt 0 ]; then
+    cat >&2 <<EOF
+Error: required tool(s) not on PATH: ${tools_missing[*]}
+
+Install them with your system's package manager and re-run this script.
+EOF
+    exit 1
+fi
+
+# Toolchain check: the wasm32-wasi-* / llvm-* tools drive the compilation,
+# linking and archiving of the libraries. They all come with the wasi-sdk /
 # ghc-wasm env.
 toolchain_missing=()
-for t in wasm32-wasi-clang wasm-ld; do
+for t in wasm32-wasi-clang wasm-ld llvm-ar llvm-ranlib; do
     command -v "$t" >/dev/null 2>&1 || toolchain_missing+=("$t")
 done
 if [ "${#toolchain_missing[@]}" -gt 0 ]; then
@@ -67,27 +89,30 @@ with:
 
   source ~/.ghc-wasm/env
 
-then re-run this script.
+then re-run this script. If it is not installed, see
+https://gitlab.haskell.org/haskell-wasm/ghc-wasm-meta/-/tree/master
+for installation instructions.
 EOF
     exit 1
 fi
 
 LIBSODIUM_REV="9511c982fb1d046470a8b42aa36556cdb7da15de"
 LIBSODIUM_REPO="https://github.com/jedisct1/libsodium.git"
+SECP256K1_REV="acf5c55ae6a94e5ca847e07def40427547876101"
 SECP256K1_REPO="https://github.com/bitcoin-core/secp256k1.git"
+BLST_REV="8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355"
 BLST_REPO="https://github.com/supranational/blst.git"
 
 mkdir -p "$ABS_PREFIX/lib" "$ABS_PREFIX/include" "$ABS_PREFIX/lib/pkgconfig"
+mkdir -p "$ABS_SRC_ROOT"
 
 clone_if_missing() {
-    local repo="$1" dir="$2" rev="${3:-}"
+    local repo="$1" dir="$2" rev="$3"
     if [ ! -d "$dir/.git" ]; then
         git clone "$repo" "$dir"
     fi
-    if [ -n "$rev" ]; then
-        git -C "$dir" fetch --tags origin "$rev" 2>/dev/null || true
-        git -C "$dir" checkout "$rev"
-    fi
+    git -C "$dir" fetch --tags origin "$rev" 2>/dev/null || true
+    git -C "$dir" checkout "$rev"
 }
 
 build_libsodium() {
@@ -95,20 +120,23 @@ build_libsodium() {
     clone_if_missing "$LIBSODIUM_REPO" "$dir" "$LIBSODIUM_REV"
     cd "$dir"
     [ -x ./configure ] || ./autogen.sh -s
-    ./configure --host=wasm32-wasi --prefix="$ABS_PREFIX"
+    CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib \
+        ./configure --host=wasm32-wasi --prefix="$ABS_PREFIX"
     make -j"$(nproc)"
     make install
     wasm32-wasi-clang -shared -Wl,--whole-archive \
         "$ABS_PREFIX/lib/libsodium.a" \
         -o "$ABS_PREFIX/lib/libsodium.so"
+    cd -
 }
 
 build_secp256k1() {
     local dir="$ABS_SRC_ROOT/secp256k1"
-    clone_if_missing "$SECP256K1_REPO" "$dir"
+    clone_if_missing "$SECP256K1_REPO" "$dir" "$SECP256K1_REV"
     cd "$dir"
     [ -x ./configure ] || ./autogen.sh
-    ./configure \
+    CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib \
+        ./configure \
         --host=wasm32-wasi \
         --enable-module-schnorrsig \
         --prefix="$ABS_PREFIX" \
@@ -118,13 +146,14 @@ build_secp256k1() {
     wasm32-wasi-clang -shared -Wl,--whole-archive \
         "$ABS_PREFIX/lib/libsecp256k1.a" \
         -o "$ABS_PREFIX/lib/libsecp256k1.so"
+    cd -
 }
 
 build_blst() {
     local dir="$ABS_SRC_ROOT/blst"
-    clone_if_missing "$BLST_REPO" "$dir"
+    clone_if_missing "$BLST_REPO" "$dir" "$BLST_REV"
     cd "$dir"
-    CC=wasm32-wasi-clang ./build.sh
+    CC=wasm32-wasi-clang AR=llvm-ar RANLIB=llvm-ranlib ./build.sh
 
     cp libblst.a "$ABS_PREFIX/lib/"
     cp bindings/blst.h bindings/blst_aux.h "$ABS_PREFIX/include/"
@@ -135,6 +164,11 @@ build_blst() {
 
     local version
     version="$(git -C "$dir" describe --tags --always 2>/dev/null || echo 0.0.0)"
+    # pkg-config cannot compare versions that have a leading 'v' or a
+    # '-<n>-g<hash>' git-describe suffix, and cabal relies on that comparison
+    # (e.g. cardano-crypto-class declares 'pkgconfig-depends: libblst >= 0.3.14').
+    version="${version#v}"
+    version="${version%%-*}"
     cat > "$ABS_PREFIX/lib/pkgconfig/libblst.pc" <<EOF
 prefix=$ABS_PREFIX
 exec_prefix=\${prefix}
@@ -150,6 +184,7 @@ Cflags: -I\${includedir}
 Libs: -L\${libdir} -lblst
 Libs.private:
 EOF
+    cd -
 }
 
 verify_wasm() {
@@ -177,9 +212,18 @@ verify_wasm "$ABS_PREFIX/lib/libblst.a"
 
 echo
 echo "Done. Installed to: $ABS_PREFIX"
+echo
+echo "Some packages (e.g. cardano-crypto-class and cardano-crypto-praos) find"
+echo "these libraries through pkg-config. Since $ABS_PREFIX/lib/pkgconfig is"
+echo "not a standard pkg-config location, export it before building:"
+echo
+echo "  export PKG_CONFIG_PATH=$ABS_PREFIX/lib/pkgconfig"
 
-FRAGMENT="$PROJECT_DIR/wasm-libs-without-nix.cabal"
+FRAGMENT="$ABS_PREFIX/wasm-libs-without-nix.cabal"
 cat > "$FRAGMENT" <<EOF
+-- Generated by scripts/wasm-without-nix/build-wasm-libs.sh. The paths are
+-- absolute because relative extra-lib-dirs are not resolved reliably for
+-- non-local packages; re-run the script if this checkout or the prefix moves.
 shared: True
 
 package cardano-crypto-class
@@ -190,29 +234,35 @@ package cardano-crypto-praos
   extra-lib-dirs: $ABS_PREFIX/lib
   extra-include-dirs: $ABS_PREFIX/include
 EOF
+echo
 echo "Wrote project fragment: $FRAGMENT"
 
 CABAL_PROJECT="$PROJECT_DIR/cabal.project"
 
+case "$FRAGMENT" in
+    "$PROJECT_DIR"/*) IMPORT_PATH="${FRAGMENT#"$PROJECT_DIR"/}" ;;
+    *)                IMPORT_PATH="$FRAGMENT" ;;
+esac
+
 if grep -qF "wasm-libs-without-nix.cabal" "$CABAL_PROJECT"; then
     echo "cabal.project already imports wasm-libs-without-nix.cabal — nothing to do."
 else
-    read -r -p "Add 'if arch(wasm32) / import: wasm-libs-without-nix.cabal' block to cabal.project? [y/N] " answer || answer=""
+    read -r -p "Add 'if arch(wasm32) / import: $IMPORT_PATH' block to cabal.project? [y/N] " answer || answer=""
     case "${answer,,}" in
         y|yes)
-            cat >> "$CABAL_PROJECT" <<'EOF'
+            cat >> "$CABAL_PROJECT" <<EOF
 
 if arch(wasm32)
-  import: wasm-libs-without-nix.cabal
+  import: $IMPORT_PATH
 EOF
             echo "Added to $CABAL_PROJECT"
             ;;
         *)
-            cat <<'EOF'
+            cat <<EOF
 Skipped. To enable, append to cabal.project:
 
 if arch(wasm32)
-  import: wasm-libs-without-nix.cabal
+  import: $IMPORT_PATH
 EOF
             ;;
     esac

--- a/scripts/wasm-without-nix/build-wasm-libs.sh
+++ b/scripts/wasm-without-nix/build-wasm-libs.sh
@@ -249,7 +249,7 @@ verify_wasm() {
     local tmp
     tmp="$(mktemp -d)"
     ( cd "$tmp" && ar x "$archive" && \
-      first_obj="$(ls *.o 2>/dev/null | head -1)" && \
+      first_obj="$(find . -maxdepth 1 -name '*.o' -print -quit)" && \
       [ -n "$first_obj" ] && file "$first_obj" | grep -q WebAssembly )
     local rc=$?
     rm -rf "$tmp"


### PR DESCRIPTION
<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-api -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
