### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/.changes/20260504_160309_cardano-api_dermetfan_no_intel_mac.yml
+++ b/.changes/20260504_160309_cardano-api_dermetfan_no_intel_mac.yml
@@ -1,0 +1,5 @@
+description: The project is no longer built for x86_64-darwin.
+kind:
+- maintenance
+pr: 1197
+project: cardano-api

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,6 @@
   outputs = inputs: let
     supportedSystems = [
       "x86_64-linux"
-      "x86_64-darwin"
       "aarch64-linux"
       "aarch64-darwin"
     ];


### PR DESCRIPTION
<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-api -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

<!--
Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.
-->

- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

# How to trust this PR

<!--
Highlight important bits of the PR that will make the review faster. If there are commands
the reviewer can run to observe the new behavior, describe them.
-->

~~I ran `nix run github:input-output-hk/cardano-dev#herald -- new` as suggested in the PR template's comment, but it only printed `Yaml file not found: .herald.yml`.~~

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] ~~New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details~~
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
