### PR TITLE
Widen Exp.SignedTx to all Shelley-based eras

### DIFF
--- a/.changes/20260505_cardano_api_widen_signed_tx_to_shelley_based_eras.yml
+++ b/.changes/20260505_cardano_api_widen_signed_tx_to_shelley_based_eras.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 0
+kind:
+  - compatible
+description: |
+  Widen `Cardano.Api.Experimental.SignedTx era` to all Shelley-based eras (Shelley through Dijkstra) by reparameterising it on `ShelleyLedgerEra era` instead of `LedgerEra era`. This allows deserialising `SignedTx` for any Shelley-based era via `SerialiseAsRawBytes` without widening the `LedgerEra` family or its Conway-onwards constraint surface.

--- a/.changes/20260505_cardano_api_widen_signed_tx_to_shelley_based_eras.yml
+++ b/.changes/20260505_cardano_api_widen_signed_tx_to_shelley_based_eras.yml
@@ -1,5 +1,5 @@
 project: cardano-api
-pr: 0
+pr: 1199
 kind:
   - compatible
 description: |

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -281,7 +281,7 @@ makeKeyWitness era (UnsignedTx unsignedTx) wsk =
 
 -- | A transaction that has been witnesssed
 data SignedTx era
-  = L.EraTx (LedgerEra era) => SignedTx (Ledger.Tx Ledger.TopTx (LedgerEra era))
+  = L.EraTx (ShelleyLedgerEra era) => SignedTx (Ledger.Tx Ledger.TopTx (ShelleyLedgerEra era))
 
 deriving instance Eq (SignedTx era)
 
@@ -294,16 +294,16 @@ instance HasTypeProxy era => HasTypeProxy (SignedTx era) where
 
 instance
   ( HasTypeProxy era
-  , L.EraTx (LedgerEra era)
+  , L.EraTx (ShelleyLedgerEra era)
   )
   => SerialiseAsRawBytes (SignedTx era)
   where
   serialiseToRawBytes (SignedTx tx) =
-    Ledger.serialize' (Ledger.eraProtVerHigh @(LedgerEra era)) tx
+    Ledger.serialize' (Ledger.eraProtVerHigh @(ShelleyLedgerEra era)) tx
   deserialiseFromRawBytes _ =
     bimap wrapError SignedTx
       . Ledger.decodeFullAnnotator
-        (Ledger.eraProtVerHigh @(LedgerEra era))
+        (Ledger.eraProtVerHigh @(ShelleyLedgerEra era))
         "SignedTx"
         Ledger.decCBOR
       . fromStrict

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -149,7 +149,7 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
   exampleTransactionExperimentalWay
     :: H.MonadTest m
     => Exp.Era Exp.ConwayEra
-    -> m (Ledger.Tx L.TopTx (Exp.LedgerEra Exp.ConwayEra))
+    -> m (Ledger.Tx L.TopTx (Api.ShelleyLedgerEra Exp.ConwayEra))
   exampleTransactionExperimentalWay era = do
     txBodyContent <- exampleTxBodyContentExperimental era
     signingKey <- exampleSigningKey
@@ -160,7 +160,7 @@ prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do
     let bootstrapWitnesses = []
         keyWitnesses = [witness]
 
-    let Exp.SignedTx (signedTx :: Ledger.Tx L.TopTx (Exp.LedgerEra Exp.ConwayEra)) = Exp.signTx era bootstrapWitnesses keyWitnesses unsignedTx
+    let Exp.SignedTx (signedTx :: Ledger.Tx L.TopTx (Api.ShelleyLedgerEra Exp.ConwayEra)) = Exp.signTx era bootstrapWitnesses keyWitnesses unsignedTx
     return signedTx
 
 prop_balance_transaction_two_ways :: Property


### PR DESCRIPTION
# Context

Reparameterise `Cardano.Api.Experimental.SignedTx` and its `SerialiseAsRawBytes` instance on `ShelleyLedgerEra era` instead of `LedgerEra era`, so `SignedTx era` types for every Shelley-based era (Shelley → Dijkstra) — not just Conway+.

The motivation is unblocking the cardano-cli debug transaction view (`runTransactionViewCmd` handles `InAnyShelleyBasedEra`). Migrating it off the legacy `TxBodyContent` decomposition onto `Exp.SignedTx era` + ledger-side lenses regresses on pre-Conway tx files unless `Exp.SignedTx` is reachable for all Shelley-based eras.

# How to trust this PR

The change is deliberately surgical — 12 lines across two files, plus a changelog fragment.

**Why the `LedgerEra` family is left alone:** `EraCommonConstraints` (Era.hs:301) bundles Conway-onwards ledger constraints (`L.ConwayEraGov`, `L.ConwayEraTxBody`, `L.ConwayEraTxCert`, `L.ConwayEraCertState`, `L.GovState ~ L.ConwayGovState`) over `LedgerEra era`. Widening `LedgerEra` would break every site that uses `obtainCommonConstraints` or `IsEra era` — i.e. `Tx.hs` builders, `Certificate.hs`, `BodyContent/New.hs`. Switching only `SignedTx` (which needs only `L.EraTx (ShelleyLedgerEra era)`, available for every Shelley-based era via `ShelleyBasedEraConstraints`) avoids that ripple entirely.

**Build paths still Conway+ gated:** `signTx`, `makeKeyWitness`, and `convertTxBodyToUnsignedTx` take `Era era`, whose constructors are `ConwayEra`/`DijkstraEra` only. For those eras, `LedgerEra era ~ ShelleyLedgerEra era` is supplied by `obtainCommonConstraints`, so `SignedTx signedTx` (Tx.hs:332) elaborates without code change.

**Byron is irrelevant:** `ShelleyLedgerEra` is undefined for Byron, and `runTransactionViewCmd` already excludes Byron via `InAnyShelleyBasedEra`. Byron tx is the separate `ATxAux` type.

**Reachability:** `ShelleyLedgerEra` is already reachable to downstream code via `import Cardano.Api` (transitively re-exported through `Cardano.Api.Era` → `Cardano.Api.Era.Internal.Eon.ShelleyBasedEra`), so no new exports were needed.

To verify:
- `cabal build cardano-api -j4` — clean.
- `cabal test cardano-api:cardano-api-test --test-show-details=direct -j4` — all 220 tests pass locally.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`