### PR TITLE
Deprecate TxBody and TxBodyContent in favour of the experimental API

### DIFF
--- a/.changes/20260507_cardano_api_deprecate_txbody_txbodycontent.yml
+++ b/.changes/20260507_cardano_api_deprecate_txbody_txbodycontent.yml
@@ -1,0 +1,14 @@
+project: cardano-api
+pr: 1200
+kind:
+  - compatible
+description: |
+  Deprecate the old-API transaction body surface in favour of `Cardano.Api.Experimental`. The following are now annotated with `{-# DEPRECATED #-}`:
+
+  - `TxBody` (data type), `ShelleyTxBody` (constructor)
+  - `TxBodyContent` (type/constructor)
+  - `createTransactionBody`, `defaultTxBodyContent`
+  - `getTxBody`, `getTxBodyContent`
+  - `BalancedTxBody`
+
+  Internal modules that still consume these symbols are annotated with `-Wno-deprecations` so `-Werror` stays green; they will be migrated in a follow-up alongside the setter family. The pre-existing `TxBody` pattern-synonym deprecation message is updated for consistency.

--- a/.changes/20260511_cardano_rpc_migrate_txid.yml
+++ b/.changes/20260511_cardano_rpc_migrate_txid.yml
@@ -1,0 +1,8 @@
+project: cardano-rpc
+pr: 1200
+kind:
+  - refactoring
+description: |
+  Migrate the UtxoRpc submit handler off the deprecated `getTxBody` /
+  `getTxId` chain. The transaction id is now computed directly from the
+  ledger transaction via `Cardano.Ledger.Core.txIdTx`.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Api.Experimental.Tx
   ( -- * Creating transactions using the new API

--- a/cardano-api/src/Cardano/Api/Governance/Internal/Poll.hs
+++ b/cardano-api/src/Cardano/Api/Governance/Internal/Poll.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- | An API for driving on-chain poll for SPOs.
 --

--- a/cardano-api/src/Cardano/Api/Network/IPC/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Network/IPC/Internal.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -15,6 +15,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Api.Tx.Internal.Body
   ( -- * Contents
@@ -861,6 +862,8 @@ indexWitnessedTxProposalProcedures (TxProposalProcedures proposals) = do
 -- If you extend this type, consider updating:
 -- - the 'makeShelleyTransactionBody' function of the relevant era below, and
 -- - the @friendly*@ family of functions in cardano-cli.
+{-# DEPRECATED TxBodyContent "Use 'TxBodyContent' from 'Cardano.Api.Experimental.Tx' instead." #-}
+
 data TxBodyContent build era
   = TxBodyContent
   { txIns :: TxIns build era
@@ -890,6 +893,7 @@ data TxBodyContent build era
   }
   deriving (Eq, Show)
 
+{-# DEPRECATED defaultTxBodyContent "Use 'defaultTxBodyContent' from 'Cardano.Api.Experimental.Tx' instead." #-}
 defaultTxBodyContent
   :: ()
   => ShelleyBasedEra era
@@ -1252,6 +1256,7 @@ instance Error TxBodyError where
         <> "in input "
         <> pretty txin
 
+{-# DEPRECATED createTransactionBody "Use 'makeUnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
 createTransactionBody
   :: forall era
    . HasCallStack
@@ -1434,12 +1439,13 @@ txBodyContentHasTxIns txIns = guard (not (null txIns)) ?! TxBodyEmptyTxIns
 maxShelleyTxInIx :: Word
 maxShelleyTxInIx = fromIntegral $ maxBound @Word16
 
-{-# DEPRECATED TxBody "Use getTxBodyContent $ getTxBody instead" #-}
+{-# DEPRECATED TxBody "Use 'UnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
 pattern TxBody :: TxBodyContent ViewTx era -> TxBody era
 pattern TxBody txbodycontent <- (getTxBodyContent -> txbodycontent)
 
 {-# COMPLETE TxBody #-}
 
+{-# DEPRECATED getTxBodyContent "Use 'UnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
 getTxBodyContent :: TxBody era -> TxBodyContent ViewTx era
 getTxBodyContent = \case
   ShelleyTxBody sbe body _scripts scriptdata mAux scriptValidity ->

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Convenience.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Convenience.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- | Convenience transaction construction functions
 module Cardano.Api.Tx.Internal.Convenience

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- | Calculating fees.
 module Cardano.Api.Tx.Internal.Fee
@@ -959,6 +960,8 @@ handleExUnitsErrors ScriptValid failuresMap exUnitsMap =
 handleExUnitsErrors ScriptInvalid failuresMap exUnitsMap
   | null failuresMap = Left TxBodyScriptBadScriptValidity
   | otherwise = Right $ Map.map (\_ -> ExecutionUnits 0 0) failuresMap <> exUnitsMap
+
+{-# DEPRECATED BalancedTxBody "Use 'Cardano.Api.Experimental' transaction balancing instead." #-}
 
 data BalancedTxBody era
   = BalancedTxBody

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 -- The Shelley ledger uses promoted data kinds which we have to use, but we do
 -- not export any from this API. We also use them unticked as nature intended.
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
@@ -246,6 +247,7 @@ deserialiseShelleyBasedTx mkTx bs =
 -- NB: This is called in getTxBodyAndWitnesses which is fine as
 -- getTxBodyAndWitnesses is only called in the context of a
 -- shelley based era anyways. ByronTx will eventually be removed.
+{-# DEPRECATED getTxBody "Use 'UnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
 getTxBody :: Tx era -> TxBody era
 getTxBody (ShelleyTx sbe tx) =
   caseShelleyToMaryOrAlonzoEraOnwards
@@ -294,6 +296,10 @@ instance IsShelleyBasedEra era => HasTextEnvelope (Tx era) where
 --
 -- TODO: We can use Ledger.Tx era here however we would need to rename TxBody
 -- as technically it is not strictly a transaction body.
+{-# DEPRECATED TxBody "Use 'UnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
+
+{-# DEPRECATED ShelleyTxBody "Use 'UnsignedTx' from 'Cardano.Api.Experimental' instead." #-}
+
 data TxBody era where
   ShelleyTxBody
     :: ShelleyBasedEra era

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.Cardano.Api.Experimental
   ( tests

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.Cardano.Api.Transaction.Autobalance
   ( tests

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/TxBody.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/TxBody.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Test.Cardano.Api.TxBody
   ( tests

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Submit.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Submit.hs
@@ -21,6 +21,8 @@ import Cardano.Rpc.Server.Internal.Monad
 import Cardano.Rpc.Server.Internal.Orphans ()
 import Cardano.Rpc.Server.Internal.Tracing
 
+import Cardano.Ledger.Core qualified as L
+
 import RIO hiding (toList)
 
 import Data.Default
@@ -61,7 +63,9 @@ submitTxMethod req = do
       submitTxToNodeLocal nodeConnInfo (TxInMode sbe tx) <&> \case
         TxSubmitError e -> Left $ TraceRpcSubmitN2cConnectionError e
         TxSubmitFail reason -> Left $ TraceRpcSubmitTxValidationError reason
-        TxSubmitSuccess -> Right $ getTxId $ getTxBody tx
+        TxSubmitSuccess ->
+          let ShelleyTx _ ledgerTx = tx
+           in Right $ shelleyBasedEraConstraints sbe $ fromShelleyTxId (L.txIdTx ledgerTx)
     putTraceThrowEither result
 
   putTraceThrowEither v = withFrozenCallStack $ do


### PR DESCRIPTION
# Context

Deprecates the old-API transaction body surface (the type, its constructor, and direct producers/consumers) so users are pointed at `Cardano.Api.Experimental`. Internal modules that still use these symbols are annotated with `-Wno-deprecations` to keep `-Werror` green; they will be migrated in a follow-up along with the setter family.

Deprecations introduced:

- `TxBody` (data type), `ShelleyTxBody` (constructor)
- `TxBodyContent` (type/constructor)
- `createTransactionBody`, `defaultTxBodyContent`
- `getTxBody`, `getTxBodyContent`
- `BalancedTxBody`

The existing pattern-synonym `TxBody` deprecation message is updated for consistency with the new messages.

# How to trust this PR

- Single commit; mechanical addition of `{-# DEPRECATED ... #-}` pragmas plus `-Wno-deprecations` `OPTIONS_GHC` in modules that still consume the deprecated surface internally (so `-Werror` stays green until the follow-up migrates those callers).
- `cabal build cardano-api -j4` is clean against current `master`.
- Diff is +23/-1 across 10 files; no behavioural change.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/` (will add once PR number is assigned)