### PR TITLE
Remove unreachable error constructors

### DIFF
--- a/.changes/20260515_cardano_api_remove_unreachable_error_constructors.yml
+++ b/.changes/20260515_cardano_api_remove_unreachable_error_constructors.yml
@@ -1,0 +1,15 @@
+project: cardano-api
+pr: 1211
+kind:
+  - breaking
+description: |
+  Remove unreachable error constructors. None of these were produced anywhere in the repo — only defined, pretty-printed, and listed in golden fixtures.
+
+  Removed:
+
+  - `TransactionValidityError` (entire type, both constructors `TransactionValidityIntervalError` and `TransactionValidityCostModelError`).
+  - `TxFeeEstimationTransactionTranslationError`, the `TxFeeEstimationError` constructor that wrapped the now-removed `TransactionValidityError`.
+  - `TxBodyErrorByronEraNotSupported`, `TxBodyErrorMissingParamMinUTxO`, and `TxBodyErrorNonAdaAssetsUnbalanced` from the legacy `Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance`.
+  - `TxBodyErrorNonAdaAssetsUnbalanced` from the experimental `Cardano.Api.Experimental.Tx.Internal.Fee.TxBodyErrorAutoBalance`.
+
+  The corresponding `test_TransactionValidityError` golden test, the three dead `TxBodyErrorAutoBalance` fixture entries, and their expected `.txt` files are dropped too. The `Ouroboros.Consensus.HardFork.History` import in `Fee.hs` becomes unused and is removed.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -118,7 +118,6 @@ data TxBodyErrorAutoBalance era
       -- ^ Offending TxOut
       L.Coin
       -- ^ Minimum UTXO
-  | TxBodyErrorNonAdaAssetsUnbalanced Value
   | TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap
       ScriptWitnessIndex
       (Map ScriptWitnessIndex ExecutionUnits)
@@ -180,8 +179,6 @@ instance Error (TxBodyErrorAutoBalance era) where
         [ "Minimum UTxO threshold not met for tx output: " <> pretty (show txout) <> "\n"
         , "Minimum required UTxO: " <> pretty minUTxO
         ]
-    TxBodyErrorNonAdaAssetsUnbalanced val ->
-      "Non-Ada assets are unbalanced: " <> pretty (renderValue val)
     TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap sIndex eUnitsMap ->
       mconcat
         [ "ScriptWitnessIndex (redeemer pointer): " <> pshow sIndex <> " is missing from the execution "

--- a/cardano-api/src/Cardano/Api/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Tx.hs
@@ -731,7 +731,6 @@ module Cardano.Api.Tx
   , evaluateTransactionExecutionUnits
   , evaluateTransactionExecutionUnitsShelley
   , ScriptExecutionError (..)
-  , TransactionValidityError (..)
 
     -- ** Transaction balance
   , evaluateTransactionBalance

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -25,7 +25,6 @@ module Cardano.Api.Tx.Internal.Fee
   , evaluateTransactionExecutionUnits
   , evaluateTransactionExecutionUnitsShelley
   , ScriptExecutionError (..)
-  , TransactionValidityError (..)
 
     -- ** Transaction balance
   , evaluateTransactionBalance
@@ -88,7 +87,6 @@ import Cardano.Ledger.Coin qualified as L
 import Cardano.Ledger.Conway.Governance qualified as L
 import Cardano.Ledger.Credential as Ledger (Credential)
 import Cardano.Ledger.Plutus.Language qualified as Plutus
-import Ouroboros.Consensus.HardFork.History qualified as Consensus
 
 import Data.Bifunctor (bimap, first, second)
 import Data.Bitraversable (bitraverse)
@@ -179,8 +177,7 @@ estimateOrCalculateBalancedTxBody era feeEstMode pparams txBodyContent poolids s
           )
 
 data TxFeeEstimationError era
-  = TxFeeEstimationTransactionTranslationError (TransactionValidityError era)
-  | TxFeeEstimationScriptExecutionError (TxBodyErrorAutoBalance era)
+  = TxFeeEstimationScriptExecutionError (TxBodyErrorAutoBalance era)
   | TxFeeEstimationBalanceError (TxBodyErrorAutoBalance era)
   | TxFeeEstimationxBodyError TxBodyError
   | TxFeeEstimationFinalConstructionError TxBodyError
@@ -189,7 +186,6 @@ data TxFeeEstimationError era
 
 instance Error (TxFeeEstimationError era) where
   prettyError = \case
-    TxFeeEstimationTransactionTranslationError e -> prettyError e
     TxFeeEstimationScriptExecutionError e -> prettyError e
     TxFeeEstimationBalanceError e -> prettyError e
     TxFeeEstimationxBodyError e -> prettyError e
@@ -638,61 +634,6 @@ instance Error ScriptExecutionError where
     ScriptErrorTranslationError e ->
       "Error translating the transaction context: " <> pshow e
 
-data TransactionValidityError era where
-  -- | The transaction validity interval is too far into the future.
-  --
-  -- Transactions containing Plutus scripts must have a validity interval that is
-  -- not excessively far in the future. This ensures that the UTC
-  -- corresponding to the validity interval expressed in slot numbers,
-  -- can be reliably determined.
-  --
-  -- Plutus scripts are given the transaction validity interval in UTC to
-  -- prevent sensitivity to variations in slot lengths.
-  --
-  -- If either end of the validity interval exceeds the \"time horizon\", the
-  -- consensus algorithm cannot reliably establish the relationship between
-  -- slots and time.
-  --
-  -- This error occurs when thevalidity interval exceeds the time horizon.
-  -- For the Cardano mainnet, the time horizon is set to 36 hours beyond the
-  -- current time. This effectively restricts the submission and validation
-  -- of transactions that include Plutus scripts if the end of their validity
-  -- interval extends more than 36 hours into the future.
-  TransactionValidityIntervalError
-    :: Consensus.PastHorizonException -> TransactionValidityError era
-  TransactionValidityCostModelError
-    :: (Map AnyPlutusScriptVersion CostModel) -> String -> TransactionValidityError era
-
-deriving instance Show (TransactionValidityError era)
-
-instance Error (TransactionValidityError era) where
-  prettyError = \case
-    TransactionValidityIntervalError pastTimeHorizon ->
-      mconcat
-        [ "The transaction validity interval is too far in the future. "
-        , "For this network it must not be more than "
-        , pretty (timeHorizonSlots pastTimeHorizon)
-        , "slots ahead of the current time slot. "
-        , "(Transactions with Plutus scripts must have validity intervals that "
-        , "are close enough in the future that we can reliably turn the slot "
-        , "numbers into UTC wall clock times.)"
-        ]
-     where
-      timeHorizonSlots :: Consensus.PastHorizonException -> Word
-      timeHorizonSlots Consensus.PastHorizon{Consensus.pastHorizonSummary}
-        | eraSummaries@(_ : _) <- pastHorizonSummary
-        , Consensus.StandardSafeZone slots <-
-            (Consensus.eraSafeZone . Consensus.eraParams . last) eraSummaries =
-            fromIntegral slots
-        | otherwise =
-            0 -- This should be impossible.
-    TransactionValidityCostModelError cModels err ->
-      mconcat
-        [ "An error occurred while converting from the cardano-api cost"
-        , " models to the cardano-ledger cost models. Error: " <> pretty err
-        , " Cost models: " <> pshow cModels
-        ]
-
 -- | Compute the 'ExecutionUnits' required for each script in the transaction.
 --
 -- This process involves executing all scripts and counting the actual execution units
@@ -874,18 +815,12 @@ data TxBodyErrorAutoBalance era
       -- ^ Minimum UTxO
       L.Coin
       -- ^ Tx balance
-  | -- | 'makeTransactionBodyAutoBalance' does not yet support the Byron era.
-    TxBodyErrorByronEraNotSupported
-  | -- | The 'ProtocolParameters' must provide the value for the min utxo
-    -- parameter, for eras that use this parameter.
-    TxBodyErrorMissingParamMinUTxO
   | -- | The minimum spendable UTxO threshold has not been met.
     TxBodyErrorMinUTxONotMet
       TxOutInAnyEra
       -- ^ Offending TxOut
       L.Coin
       -- ^ Minimum UTXO
-  | TxBodyErrorNonAdaAssetsUnbalanced Value
   | TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap
       ScriptWitnessIndex
       (Map ScriptWitnessIndex ExecutionUnits)
@@ -926,17 +861,11 @@ instance Error (TxBodyErrorAutoBalance era) where
         , "The usual solution is to provide more inputs, or inputs with more ada to "
         , "meet the minimum UTxO threshold"
         ]
-    TxBodyErrorByronEraNotSupported ->
-      "The Byron era is not yet supported by makeTransactionBodyAutoBalance"
-    TxBodyErrorMissingParamMinUTxO ->
-      "The minUTxOValue protocol parameter is required but missing"
     TxBodyErrorMinUTxONotMet txout minUTxO ->
       mconcat
         [ "Minimum UTxO threshold not met for tx output: " <> pretty (prettyRenderTxOut txout) <> "\n"
         , "Minimum required UTxO: " <> pretty minUTxO
         ]
-    TxBodyErrorNonAdaAssetsUnbalanced val ->
-      "Non-Ada assets are unbalanced: " <> pretty (renderValue val)
     TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap sIndex eUnitsMap ->
       mconcat
         [ "ScriptWitnessIndex (redeemer pointer): " <> pshow sIndex <> " is missing from the execution "

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -22,7 +22,6 @@ module Test.Golden.ErrorsSpec
   , test_StakePoolMetadataValidationError
   , test_TextEnvelopeCddlError
   , test_TextEnvelopeError
-  , test_TransactionValidityError
   , test_TxBodyError
   , test_TxBodyErrorAutoBalance
   , test_TxMetadataJsonError
@@ -389,28 +388,6 @@ test_TextEnvelopeError =
 testPastHorizonValue :: Ledger.AlonzoContextError Ledger.AlonzoEra
 testPastHorizonValue = Ledger.TimeTranslationPastHorizon text
 
-test_TransactionValidityError :: TestTree
-test_TransactionValidityError =
-  testAllErrorMessages_
-    "Cardano.Api.Tx.Internal.Fee"
-    "TransactionValidityError"
-    [
-      ( "TransactionValidityCostModelError"
-      , TransactionValidityCostModelError
-          (fromList [(AnyPlutusScriptVersion PlutusScriptV2, costModel)])
-          string
-      )
-      -- TODO Implement this when we get access to data constructors of PastHorizon or its fields' types' constructors
-      -- or we get a dummy value for such purposes.
-      --
-      -- , ("TransactionValidityIntervalError", TransactionValidityIntervalError $
-      --     Qry.PastHorizon
-      --     { Qry.pastHorizonCallStack = GHC.callStack
-      --     , Qry.pastHorizonExpression = error "" -- Some $ Qry.ClosedExpr $ Qry.ELit 0
-      --     , Qry.pastHorizonSummary = []
-      --     })
-    ]
-
 test_TxBodyError :: TestTree
 test_TxBodyError =
   testAllErrorMessages_
@@ -439,13 +416,7 @@ test_TxBodyErrorAutoBalance =
     , ("TxBodyScriptBadScriptValidity", TxBodyScriptBadScriptValidity)
     , ("TxBodyErrorBalanceNegative", TxBodyErrorBalanceNegative (-1) mempty)
     , ("TxBodyErrorAdaBalanceTooSmall", TxBodyErrorAdaBalanceTooSmall txOutInAnyEra1 0 1)
-    , ("TxBodyErrorByronEraNotSupported", TxBodyErrorByronEraNotSupported)
-    , ("TxBodyErrorMissingParamMinUTxO", TxBodyErrorMissingParamMinUTxO)
     , ("TxBodyErrorMinUTxONotMet", TxBodyErrorMinUTxONotMet txOutInAnyEra1 1)
-    ,
-      ( "TxBodyErrorNonAdaAssetsUnbalanced"
-      , TxBodyErrorNonAdaAssetsUnbalanced (fromList [(AdaAssetId, Quantity 1)])
-      )
     ,
       ( "TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap"
       , TxBodyErrorScriptWitnessIndexMissingFromExecUnitsMap

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TransactionValidityError/TransactionValidityCostModelError.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TransactionValidityError/TransactionValidityCostModelError.txt
@@ -1,1 +1,0 @@
-An error occurred while converting from the cardano-api cost models to the cardano-ledger cost models. Error: <string> Cost models: fromList [(AnyPlutusScriptVersion PlutusScriptV2,CostModel [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42])]

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorByronEraNotSupported.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorByronEraNotSupported.txt
@@ -1,1 +1,0 @@
-The Byron era is not yet supported by makeTransactionBodyAutoBalance

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorMissingParamMinUTxO.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorMissingParamMinUTxO.txt
@@ -1,1 +1,0 @@
-The minUTxOValue protocol parameter is required but missing

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorNonAdaAssetsUnbalanced.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance/TxBodyErrorNonAdaAssetsUnbalanced.txt
@@ -1,1 +1,0 @@
-Non-Ada assets are unbalanced: 1 lovelace


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove unreachable error constructors. None of these were produced
    anywhere in the repo — only defined, pretty-printed, and listed in
    golden fixtures.

    Removed:

    - `TransactionValidityError` (entire type, both constructors:
      `TransactionValidityIntervalError`,
      `TransactionValidityCostModelError`).
    - `TxFeeEstimationTransactionTranslationError`, the
      `TxFeeEstimationError` constructor that wrapped the now-removed
      `TransactionValidityError`.
    - `TxBodyErrorByronEraNotSupported`,
      `TxBodyErrorMissingParamMinUTxO`, and
      `TxBodyErrorNonAdaAssetsUnbalanced` from the legacy
      `Cardano.Api.Tx.Internal.Fee.TxBodyErrorAutoBalance`.
    - `TxBodyErrorNonAdaAssetsUnbalanced` from the experimental
      `Cardano.Api.Experimental.Tx.Internal.Fee.TxBodyErrorAutoBalance`.

    The corresponding `test_TransactionValidityError` golden test, the
    three dead `TxBodyErrorAutoBalance` fixture entries, and their
    expected `.txt` files are dropped too. The
    `Ouroboros.Consensus.HardFork.History` import in `Fee.hs` becomes
    unused and is removed.
  type:
   - breaking
  projects:
   - cardano-api
```

# Context

Continuing the pattern of [PR #1180 / commit 926606fdd](https://github.com/IntersectMBO/cardano-api/commit/926606fdd) ("Remove unused `TxBodyProtocolParamsConversionError` constructor"). An audit of the `TxBodyError` / `TxBodyErrorAutoBalance` / `TxFeeEstimationError` / `TransactionValidityError` types found six error constructors with no production producers — only the data declaration, the `prettyError` pattern match, and golden fixtures referenced them.

Construction-site search (across `cardano-api/src`, `cardano-api/test`, `cardano-api/gen`) found zero call sites of the form ``Left X …`` / ``X …`` / ``first X …`` / ``\$ X …`` for any of the constructors removed here.

Since both `TransactionValidityError` constructors are dead, the whole GADT is removed, which in turn makes `TxFeeEstimationTransactionTranslationError` unreachable.

# How to trust this PR

```bash
cabal build cardano-api -j4
cabal test cardano-api-golden     # 121 / 121 pass
```

Sanity-check that no producer remains for any removed constructor:

```bash
git grep -nE 'TransactionValidity(Interval|CostModel)Error|TxFeeEstimationTransactionTranslationError|TxBodyErrorByronEraNotSupported|TxBodyErrorMissingParamMinUTxO|TxBodyErrorNonAdaAssetsUnbalanced'
```

After this PR the only matches should be in `CHANGELOG.md` / release notes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/` (added in a follow-up commit once PR number is known, matching the project's existing pattern)