### PR TITLE
Migrate to validation >= 1.2

### DIFF
--- a/.changes/20260527_cardano_api_validation_1_2.yml
+++ b/.changes/20260527_cardano_api_validation_1_2.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1227
+kind:
+  - maintenance
+description: |
+  Migrate to validation >= 1.2 API, replacing removed toEither and liftError with direct pattern matching on Failure/Success constructors. Bump hackage index-state to 2026-05-27.

--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,5 @@ cardano-wasm/examples/*/cardano-api.js
 cardano-wasm/examples/*/main.js
 cardano-wasm/examples/*/cardano_node_grpc_web_pb.js
 .ghc-wasm/
+.serena/
 

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2026-04-17T09:20:55Z
+  , hackage.haskell.org 2026-05-27T06:20:37Z
   , cardano-haskell-packages 2026-05-25T13:25:40Z
 
 active-repositories:

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -198,7 +198,7 @@ library
     transformers,
     transformers-except ^>=0.1.3,
     typed-protocols ^>=1.2,
-    validation,
+    validation >=1.2,
     vector,
     yaml,
 

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Sign.hs
@@ -777,20 +777,17 @@ decodeShelleyBasedWitness
   -> ByteString
   -> Either CBOR.DecoderError (KeyWitness era)
 decodeShelleyBasedWitness sbe bs =
-  let e =
-        Valid.toEither $
-          mconcat $
-            map
-              (Valid.liftError return)
-              [ bootstrapWitnessDecoder bs
-              , shelleyKeyWitnessDecoder bs
-              , legacyKeyWitnessDecoder bs
-              ]
-   in case e of
-        Left errs ->
-          let allErrs = Text.unlines $ map renderBuildable errs
-           in Left $ CBOR.DecoderErrorCustom "Failed to deserialise key witness" allErrs
-        Right res -> return res
+  case mconcat $
+    map
+      (either (Valid.Failure . pure) Valid.Success)
+      [ bootstrapWitnessDecoder bs
+      , shelleyKeyWitnessDecoder bs
+      , legacyKeyWitnessDecoder bs
+      ] of
+    Valid.Failure errs ->
+      let allErrs = Text.unlines $ map renderBuildable errs
+       in Left $ CBOR.DecoderErrorCustom "Failed to deserialise key witness" allErrs
+    Valid.Success res -> return res
  where
   shelleyKeyWitnessDecoder b =
     ShelleyKeyWitness sbe

--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1776418279,
-        "narHash": "sha256-f5k3OgWcbQkd+3cod1bWro4+YS9uIfVtw1kit4sIR1k=",
+        "lastModified": 1779863847,
+        "narHash": "sha256-L+V9ltCj3tSfCRyz2dGSIpvAHmi1NayUDsfxfSKGK3c=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "9bfd4439b2534c7766c8126228ae524fd97d3cee",
+        "rev": "41bc4850d72373d1585154c715a4395a985b53c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Migrate `cardano-api` from the pre-1.2 `validation` API (`toEither`, `liftError`) to direct pattern matching on `Failure`/`Success` constructors.
- Add `validation >= 1.2` lower bound in `cardano-api.cabal`.
- Bump hackage index-state to `2026-05-27`.

## Context
`validation` 1.2 removed `toEither`, `validate`, and `liftError`.
This was found when bumping `hackage.nix` in CHaP ([IntersectMBO/ouroboros-consensus#2051](https://github.com/IntersectMBO/ouroboros-consensus/issues/2051)).

Blocked on a new CHaP release of `ouroboros-consensus` which also needs the same migration (already done on their `main`).

## Test plan
- [ ] CI passes once `ouroboros-consensus` is released to CHaP with validation 1.2 support