### PR TITLE
Implement server-side transaction validation via LocalStateQuery

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,38 @@ active-repositories:
   , :rest
   , cardano-haskell-packages:override
 
+-- BEGIN SRP STANZAS MANAGED BY STANZAMAN --
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network.git
+  tag: 65da1ad619473f9467d3336a6d6e9a2a8714913d
+  subdir: ouroboros-network
+  --sha256: 1r5y5px0kj4nhb65s9i7pr0sikxghfqwfkzmsgiql2maic4nglwi
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus.git
+  tag: bca18fd361d8342bdbfb8a08366e86479677ce30
+  subdir: .
+  --sha256: 11znnl9zk59bxr6dn76zrni6i0q32bqnlxqf4wprvxikg4r666pa
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network.git
+  tag: 65da1ad619473f9467d3336a6d6e9a2a8714913d
+  subdir: cardano-diffusion
+  --sha256: 1r5y5px0kj4nhb65s9i7pr0sikxghfqwfkzmsgiql2maic4nglwi
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-network.git
+  tag: 65da1ad619473f9467d3336a6d6e9a2a8714913d
+  subdir: network-mux
+  --sha256: 1r5y5px0kj4nhb65s9i7pr0sikxghfqwfkzmsgiql2maic4nglwi
+
+-- END SRP STANZAS MANAGED BY STANZAMAN --
+
 packages:
     cardano-api
     cardano-api-gen

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -243,6 +243,7 @@ library
     Cardano.Api.Experimental.Tx.Internal.Fee
     Cardano.Api.Experimental.Tx.Internal.TxScriptWitnessRequirements
     Cardano.Api.Experimental.Tx.Internal.Type
+    Cardano.Api.Experimental.Tx.Internal.Validate
     Cardano.Api.Genesis.Internal
     Cardano.Api.Genesis.Internal.Parameters
     Cardano.Api.Governance.Internal.Action.ProposalProcedure

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -40,6 +40,7 @@ module Cardano.Api.Experimental
   , Era (..)
   , IsEra (..)
   , Some (..)
+  , InAnyEra (..)
   , LedgerEra
   , DeprecatedEra (..)
   , eraToSbe

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -95,6 +95,11 @@ module Cardano.Api.Experimental
   , makeDrepUpdateCertificate
   , makeStakeAddressAndDRepDelegationCertificate
 
+    -- ** Validation
+  , TxValidationResult (..)
+  , QueryValidateTxError (..)
+  , validateTx
+
     -- * Data family instances
   , AsType (..)
 

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -20,6 +20,7 @@ module Cardano.Api.Experimental.Era
   , Era (..)
   , IsEra (..)
   , Some (..)
+  , InAnyEra (..)
   , Inject (..)
   , Convert (..)
   , LedgerEra
@@ -92,6 +93,11 @@ data Some (f :: k -> Type) where
      . (Typeable a, Typeable (f a))
     => f a
     -> Some f
+
+-- | Pair an era witness with a value indexed by that era,
+-- hiding the era type parameter existentially.
+data InAnyEra f where
+  InAnyEra :: IsEra era => Era era -> f era -> InAnyEra f
 
 -- | Represents the latest Cardano blockchain eras, including
 -- the one currently on mainnet and the upcoming one.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -232,12 +231,10 @@ import Cardano.Api.Experimental.Tx.Internal.Fee
 import Cardano.Api.Experimental.Tx.Internal.TxScriptWitnessRequirements
 import Cardano.Api.Experimental.Tx.Internal.Type
 import Cardano.Api.Experimental.Tx.Internal.Validate (QueryValidateTxError (..), queryValidateTx)
-import Cardano.Api.HasTypeProxy (HasTypeProxy (..), Proxy, asType)
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
 import Cardano.Api.Network.IPC (LocalStateQueryExpr)
 import Cardano.Api.Plutus.Internal.Script qualified as Api
 import Cardano.Api.Pretty (docToString, pretty)
-import Cardano.Api.ProtocolParameters
 import Cardano.Api.Query.Internal.Expr
   ( queryEraHistory
   , queryProtocolParameters
@@ -250,30 +247,18 @@ import Cardano.Api.Query.Internal.Type.QueryInMode
   , toLedgerEpochInfo
   , toLedgerUTxO
   )
-import Cardano.Api.Serialise.Raw
-  ( SerialiseAsRawBytes (..)
-  , SerialiseAsRawBytesError (SerialiseAsRawBytesError)
-  )
 import Cardano.Api.Tx.Internal.Body qualified as Api
 import Cardano.Api.Tx.Internal.Fee (EvalTxExecutionUnitsLog, ScriptExecutionError)
 import Cardano.Api.Tx.Internal.Sign
 
 import Cardano.Crypto.Hash qualified as Hash
-import Cardano.Ledger.Alonzo qualified as LAlonzo
-import Cardano.Ledger.Alonzo.Rules qualified as LAlonzo
 import Cardano.Ledger.Alonzo.Tx qualified as L
 import Cardano.Ledger.Api qualified as L
-import Cardano.Ledger.Babbage qualified as LBabbage
-import Cardano.Ledger.Babbage.Rules qualified as LBabbage
-import Cardano.Ledger.Binary qualified as Ledger
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Hashes qualified as L hiding (Hash)
 import Cardano.Ledger.Shelley.API (ApplyTxError)
-import Cardano.Ledger.Shelley.Rules qualified as LShelley
 
-import Control.Exception (displayException)
 import Data.Bifunctor (bimap, first)
-import Data.ByteString.Lazy (fromStrict)
 import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -306,39 +291,6 @@ makeKeyWitness era (UnsignedTx unsignedTx) wsk =
         vk = getShelleyKeyWitnessVerificationKey sk
         signature = makeShelleySignature txhash sk
      in L.WitVKey vk signature
-
--- | A transaction that has been witnesssed
-data SignedTx era
-  = L.EraTx (LedgerEra era) => SignedTx (Ledger.Tx Ledger.TopTx (LedgerEra era))
-
-deriving instance Eq (SignedTx era)
-
-deriving instance Show (SignedTx era)
-
-instance HasTypeProxy era => HasTypeProxy (SignedTx era) where
-  data AsType (SignedTx era) = AsSignedTx (AsType era)
-  proxyToAsType :: Proxy (SignedTx era) -> AsType (SignedTx era)
-  proxyToAsType _ = AsSignedTx (asType @era)
-
-instance
-  ( HasTypeProxy era
-  , L.EraTx (LedgerEra era)
-  )
-  => SerialiseAsRawBytes (SignedTx era)
-  where
-  serialiseToRawBytes (SignedTx tx) =
-    Ledger.serialize' (Ledger.eraProtVerHigh @(LedgerEra era)) tx
-  deserialiseFromRawBytes _ =
-    bimap wrapError SignedTx
-      . Ledger.decodeFullAnnotator
-        (Ledger.eraProtVerHigh @(LedgerEra era))
-        "SignedTx"
-        Ledger.decCBOR
-      . fromStrict
-   where
-    wrapError
-      :: Ledger.DecoderError -> SerialiseAsRawBytesError
-    wrapError = SerialiseAsRawBytesError . displayException
 
 signTx
   :: Era era
@@ -410,16 +362,19 @@ purposeAsIxItemToAsIx purpose =
   obtainCommonConstraints (useEra @era) $ L.hoistPlutusPurpose L.toAsIx purpose
 
 data TxValidationResult era = TxValidationResult
-  { phase1Result :: Either (ApplyTxError (ShelleyLedgerEra era)) ()
-  , phase2Result :: Map Api.ScriptWitnessIndex (Either ScriptExecutionError (EvalTxExecutionUnitsLog, Api.ExecutionUnits))
+  { phase1Result :: Either (ApplyTxError (LedgerEra era)) ()
+  , phase2Result
+      :: Map
+           Api.ScriptWitnessIndex
+           (Either ScriptExecutionError (EvalTxExecutionUnitsLog, Api.ExecutionUnits))
   }
 
-deriving instance Show (ApplyTxError (ShelleyLedgerEra era)) => Show (TxValidationResult era)
+deriving instance Show (ApplyTxError (LedgerEra era)) => Show (TxValidationResult era)
 
 validateTx
   :: forall era block point r
-   . ShelleyBasedEra era
-  -> Tx era
+   . IsEra era
+  => SignedTx era
   -> LocalStateQueryExpr
        block
        point
@@ -427,87 +382,63 @@ validateTx
        r
        IO
        (Either QueryValidateTxError (TxValidationResult era))
-validateTx sbe tx@(ShelleyTx _sbe ledgerTx) =
-  Api.forEraInEon
-    (Api.toCardanoEra sbe)
-    (error $ "validateTx: unsupported era " <> docToString (pretty sbe))
-    ( \expEra -> obtainCommonConstraints expEra $ do
-        ePhase1 <- queryValidateTx sbe tx
+validateTx stx@(SignedTx ledgerTx) =
+  obtainCommonConstraints (useEra @era) $ do
+    let sbe = convert (useEra @era)
+    ePhase1 <- queryValidateTx stx
 
-        eSystemStart <- querySystemStart
-        eEraHistory <- queryEraHistory
-        ePparams <- queryProtocolParameters sbe
-        let relevantTxIns =
-              Set.map Api.fromShelleyTxIn (ledgerTx ^. L.bodyTxL . L.allInputsTxBodyF)
-        eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
+    eSystemStart <- querySystemStart
+    eEraHistory <- queryEraHistory
+    ePparams <- queryProtocolParameters sbe
+    let relevantTxIns =
+          Set.map Api.fromShelleyTxIn (ledgerTx ^. L.bodyTxL . L.allInputsTxBodyF)
+    eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
 
-        return $ do
-          phase1 <- ePhase1
-          systemStart <- first QueryValidateTxUnsupportedNtcVersion eSystemStart
-          eraHistory <- first QueryValidateTxUnsupportedNtcVersion eEraHistory
-          pparams <-
-            first QueryValidateTxUnsupportedNtcVersion ePparams
-              >>= first QueryValidateTxEraMismatch
-          utxo <-
-            first QueryValidateTxUnsupportedNtcVersion eUtxo
-              >>= first QueryValidateTxEraMismatch
+    return $ do
+      phase1 <- ePhase1
+      systemStart <- first QueryValidateTxUnsupportedNtcVersion eSystemStart
+      eraHistory <- first QueryValidateTxUnsupportedNtcVersion eEraHistory
+      pparams <-
+        first QueryValidateTxUnsupportedNtcVersion ePparams
+          >>= first QueryValidateTxEraMismatch
+      utxo <-
+        first QueryValidateTxUnsupportedNtcVersion eUtxo
+          >>= first QueryValidateTxEraMismatch
 
-          let ledgerUtxo = toLedgerUTxO sbe utxo
-              ledgerEpochInfo = toLedgerEpochInfo eraHistory
-              phase2 =
-                evaluateTransactionExecutionUnits
-                  systemStart
-                  ledgerEpochInfo
-                  pparams
-                  ledgerUtxo
-                  ledgerTx
+      let ledgerUtxo = toLedgerUTxO sbe utxo
+          ledgerEpochInfo = toLedgerEpochInfo eraHistory
+          phase2 =
+            evaluateTransactionExecutionUnits
+              systemStart
+              ledgerEpochInfo
+              pparams
+              ledgerUtxo
+              ledgerTx
 
-          let phase1Filtered = filterScriptFailures sbe phase1
-          Right $ TxValidationResult phase1Filtered phase2
-    )
+      let phase1Filtered = filterScriptFailures (useEra @era) phase1
+      Right $ TxValidationResult phase1Filtered phase2
 
 filterScriptFailures
-  :: ShelleyBasedEra era
-  -> Either (ApplyTxError (ShelleyLedgerEra era)) ()
-  -> Either (ApplyTxError (ShelleyLedgerEra era)) ()
-filterScriptFailures sbe = \case
+  :: Era era
+  -> Either (ApplyTxError (LedgerEra era)) ()
+  -> Either (ApplyTxError (LedgerEra era)) ()
+filterScriptFailures era = \case
   Right () -> Right ()
-  Left err -> case sbe of
-    ShelleyBasedEraShelley -> Left err
-    ShelleyBasedEraAllegra -> Left err
-    ShelleyBasedEraMary -> Left err
-    ShelleyBasedEraAlonzo ->
-      let LAlonzo.AlonzoApplyTxError failures = err
-          isScript = \case
-            LShelley.UtxowFailure (LAlonzo.ShelleyInAlonzoUtxowPredFailure (LShelley.UtxoFailure (LAlonzo.UtxosFailure {}))) -> True
-            LShelley.UtxowFailure {} -> False
-            LShelley.DelegsFailure {} -> False
-            LShelley.ShelleyWithdrawalsMissingAccounts {} -> False
-            LShelley.ShelleyIncompleteWithdrawals {} -> False
-       in filterFailures LAlonzo.AlonzoApplyTxError isScript failures
-    ShelleyBasedEraBabbage ->
-      let LBabbage.BabbageApplyTxError failures = err
-          isScript = \case
-            LShelley.UtxowFailure (LBabbage.UtxoFailure (LBabbage.AlonzoInBabbageUtxoPredFailure (LAlonzo.UtxosFailure {}))) -> True
-            LShelley.UtxowFailure {} -> False
-            LShelley.DelegsFailure {} -> False
-            LShelley.ShelleyWithdrawalsMissingAccounts {} -> False
-            LShelley.ShelleyIncompleteWithdrawals {} -> False
-       in filterFailures LBabbage.BabbageApplyTxError isScript failures
-    ShelleyBasedEraDijkstra -> error "TODO Dijkstra: filterScriptFailures"
-    ShelleyBasedEraConway ->
+  Left err -> case era of
+    DijkstraEra -> error "TODO Dijkstra: filterScriptFailures"
+    ConwayEra ->
       let L.ConwayApplyTxError failures = err
           isScript = \case
-            L.ConwayUtxowFailure (L.UtxoFailure (L.UtxosFailure {})) -> True
-            L.ConwayUtxowFailure {} -> False
-            L.ConwayCertsFailure {} -> False
-            L.ConwayGovFailure {} -> False
-            L.ConwayWdrlNotDelegatedToDRep {} -> False
-            L.ConwayTreasuryValueMismatch {} -> False
-            L.ConwayTxRefScriptsSizeTooBig {} -> False
-            L.ConwayMempoolFailure {} -> False
-            L.ConwayWithdrawalsMissingAccounts {} -> False
-            L.ConwayIncompleteWithdrawals {} -> False
+            L.ConwayUtxowFailure (L.UtxoFailure (L.UtxosFailure{})) -> True
+            L.ConwayUtxowFailure{} -> False
+            L.ConwayCertsFailure{} -> False
+            L.ConwayGovFailure{} -> False
+            L.ConwayWdrlNotDelegatedToDRep{} -> False
+            L.ConwayTreasuryValueMismatch{} -> False
+            L.ConwayTxRefScriptsSizeTooBig{} -> False
+            L.ConwayMempoolFailure{} -> False
+            L.ConwayWithdrawalsMissingAccounts{} -> False
+            L.ConwayIncompleteWithdrawals{} -> False
        in filterFailures L.ConwayApplyTxError isScript failures
 
 filterFailures

--- a/cardano-api/src/Cardano/Api/Experimental/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -205,6 +206,11 @@ module Cardano.Api.Experimental.Tx
   , TxBodyErrorAutoBalance (..)
   , TxFeeEstimationError (..)
 
+    -- * Validation
+  , TxValidationResult (..)
+  , QueryValidateTxError (..)
+  , validateTx
+
     -- ** Internal functions
   , extractExecutionUnits
   , getTxScriptWitnessRequirements
@@ -225,28 +231,50 @@ import Cardano.Api.Experimental.Tx.Internal.BodyContent.New
 import Cardano.Api.Experimental.Tx.Internal.Fee
 import Cardano.Api.Experimental.Tx.Internal.TxScriptWitnessRequirements
 import Cardano.Api.Experimental.Tx.Internal.Type
+import Cardano.Api.Experimental.Tx.Internal.Validate (QueryValidateTxError (..), queryValidateTx)
 import Cardano.Api.HasTypeProxy (HasTypeProxy (..), Proxy, asType)
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
+import Cardano.Api.Network.IPC (LocalStateQueryExpr)
 import Cardano.Api.Plutus.Internal.Script qualified as Api
 import Cardano.Api.Pretty (docToString, pretty)
 import Cardano.Api.ProtocolParameters
+import Cardano.Api.Query.Internal.Expr
+  ( queryEraHistory
+  , queryProtocolParameters
+  , querySystemStart
+  , queryUtxo
+  )
+import Cardano.Api.Query.Internal.Type.QueryInMode
+  ( QueryInMode
+  , QueryUTxOFilter (..)
+  , toLedgerEpochInfo
+  , toLedgerUTxO
+  )
 import Cardano.Api.Serialise.Raw
   ( SerialiseAsRawBytes (..)
   , SerialiseAsRawBytesError (SerialiseAsRawBytesError)
   )
 import Cardano.Api.Tx.Internal.Body qualified as Api
+import Cardano.Api.Tx.Internal.Fee (EvalTxExecutionUnitsLog, ScriptExecutionError)
 import Cardano.Api.Tx.Internal.Sign
 
 import Cardano.Crypto.Hash qualified as Hash
+import Cardano.Ledger.Alonzo qualified as LAlonzo
+import Cardano.Ledger.Alonzo.Rules qualified as LAlonzo
 import Cardano.Ledger.Alonzo.Tx qualified as L
 import Cardano.Ledger.Api qualified as L
+import Cardano.Ledger.Babbage qualified as LBabbage
+import Cardano.Ledger.Babbage.Rules qualified as LBabbage
 import Cardano.Ledger.Binary qualified as Ledger
 import Cardano.Ledger.Core qualified as Ledger
 import Cardano.Ledger.Hashes qualified as L hiding (Hash)
+import Cardano.Ledger.Shelley.API (ApplyTxError)
+import Cardano.Ledger.Shelley.Rules qualified as LShelley
 
 import Control.Exception (displayException)
-import Data.Bifunctor (bimap)
+import Data.Bifunctor (bimap, first)
 import Data.ByteString.Lazy (fromStrict)
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
@@ -380,3 +408,111 @@ purposeAsIxItemToAsIx
   -> L.PlutusPurpose L.AsIx (LedgerEra era)
 purposeAsIxItemToAsIx purpose =
   obtainCommonConstraints (useEra @era) $ L.hoistPlutusPurpose L.toAsIx purpose
+
+data TxValidationResult era = TxValidationResult
+  { phase1Result :: Either (ApplyTxError (ShelleyLedgerEra era)) ()
+  , phase2Result :: Map Api.ScriptWitnessIndex (Either ScriptExecutionError (EvalTxExecutionUnitsLog, Api.ExecutionUnits))
+  }
+
+deriving instance Show (ApplyTxError (ShelleyLedgerEra era)) => Show (TxValidationResult era)
+
+validateTx
+  :: forall era block point r
+   . ShelleyBasedEra era
+  -> Tx era
+  -> LocalStateQueryExpr
+       block
+       point
+       QueryInMode
+       r
+       IO
+       (Either QueryValidateTxError (TxValidationResult era))
+validateTx sbe tx@(ShelleyTx _sbe ledgerTx) =
+  Api.forEraInEon
+    (Api.toCardanoEra sbe)
+    (error $ "validateTx: unsupported era " <> docToString (pretty sbe))
+    ( \expEra -> obtainCommonConstraints expEra $ do
+        ePhase1 <- queryValidateTx sbe tx
+
+        eSystemStart <- querySystemStart
+        eEraHistory <- queryEraHistory
+        ePparams <- queryProtocolParameters sbe
+        let relevantTxIns =
+              Set.map Api.fromShelleyTxIn (ledgerTx ^. L.bodyTxL . L.allInputsTxBodyF)
+        eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
+
+        return $ do
+          phase1 <- ePhase1
+          systemStart <- first QueryValidateTxUnsupportedNtcVersion eSystemStart
+          eraHistory <- first QueryValidateTxUnsupportedNtcVersion eEraHistory
+          pparams <-
+            first QueryValidateTxUnsupportedNtcVersion ePparams
+              >>= first QueryValidateTxEraMismatch
+          utxo <-
+            first QueryValidateTxUnsupportedNtcVersion eUtxo
+              >>= first QueryValidateTxEraMismatch
+
+          let ledgerUtxo = toLedgerUTxO sbe utxo
+              ledgerEpochInfo = toLedgerEpochInfo eraHistory
+              phase2 =
+                evaluateTransactionExecutionUnits
+                  systemStart
+                  ledgerEpochInfo
+                  pparams
+                  ledgerUtxo
+                  ledgerTx
+
+          let phase1Filtered = filterScriptFailures sbe phase1
+          Right $ TxValidationResult phase1Filtered phase2
+    )
+
+filterScriptFailures
+  :: ShelleyBasedEra era
+  -> Either (ApplyTxError (ShelleyLedgerEra era)) ()
+  -> Either (ApplyTxError (ShelleyLedgerEra era)) ()
+filterScriptFailures sbe = \case
+  Right () -> Right ()
+  Left err -> case sbe of
+    ShelleyBasedEraShelley -> Left err
+    ShelleyBasedEraAllegra -> Left err
+    ShelleyBasedEraMary -> Left err
+    ShelleyBasedEraAlonzo ->
+      let LAlonzo.AlonzoApplyTxError failures = err
+          isScript = \case
+            LShelley.UtxowFailure (LAlonzo.ShelleyInAlonzoUtxowPredFailure (LShelley.UtxoFailure (LAlonzo.UtxosFailure {}))) -> True
+            LShelley.UtxowFailure {} -> False
+            LShelley.DelegsFailure {} -> False
+            LShelley.ShelleyWithdrawalsMissingAccounts {} -> False
+            LShelley.ShelleyIncompleteWithdrawals {} -> False
+       in filterFailures LAlonzo.AlonzoApplyTxError isScript failures
+    ShelleyBasedEraBabbage ->
+      let LBabbage.BabbageApplyTxError failures = err
+          isScript = \case
+            LShelley.UtxowFailure (LBabbage.UtxoFailure (LBabbage.AlonzoInBabbageUtxoPredFailure (LAlonzo.UtxosFailure {}))) -> True
+            LShelley.UtxowFailure {} -> False
+            LShelley.DelegsFailure {} -> False
+            LShelley.ShelleyWithdrawalsMissingAccounts {} -> False
+            LShelley.ShelleyIncompleteWithdrawals {} -> False
+       in filterFailures LBabbage.BabbageApplyTxError isScript failures
+    ShelleyBasedEraDijkstra -> error "TODO Dijkstra: filterScriptFailures"
+    ShelleyBasedEraConway ->
+      let L.ConwayApplyTxError failures = err
+          isScript = \case
+            L.ConwayUtxowFailure (L.UtxoFailure (L.UtxosFailure {})) -> True
+            L.ConwayUtxowFailure {} -> False
+            L.ConwayCertsFailure {} -> False
+            L.ConwayGovFailure {} -> False
+            L.ConwayWdrlNotDelegatedToDRep {} -> False
+            L.ConwayTreasuryValueMismatch {} -> False
+            L.ConwayTxRefScriptsSizeTooBig {} -> False
+            L.ConwayMempoolFailure {} -> False
+            L.ConwayWithdrawalsMissingAccounts {} -> False
+            L.ConwayIncompleteWithdrawals {} -> False
+       in filterFailures L.ConwayApplyTxError isScript failures
+
+filterFailures
+  :: (NE.NonEmpty a -> b) -> (a -> Bool) -> NE.NonEmpty a -> Either b ()
+filterFailures wrap isScript failures =
+  case NE.nonEmpty (filter (not . isScript) (NE.toList failures)) of
+    Nothing -> Right ()
+    Just remaining -> Left (wrap remaining)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Type.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Type.hs
@@ -14,10 +14,12 @@
 
 module Cardano.Api.Experimental.Tx.Internal.Type
   ( UnsignedTx (..)
+  , SignedTx (..)
   )
 where
 
 import Cardano.Api.Era.Internal.Core qualified as Api
+import Cardano.Api.Experimental.Era (LedgerEra)
 import Cardano.Api.HasTypeProxy (HasTypeProxy (..), asType)
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
 import Cardano.Api.ProtocolParameters
@@ -97,5 +99,38 @@ instance
     wrapError = SerialiseAsRawBytesError . displayException
 
 deriving instance Eq (UnsignedTx era)
+
+-- | A transaction that has been witnessed
+data SignedTx era
+  = L.EraTx (LedgerEra era) => SignedTx (Ledger.Tx Ledger.TopTx (LedgerEra era))
+
+deriving instance Eq (SignedTx era)
+
+deriving instance Show (SignedTx era)
+
+instance HasTypeProxy era => HasTypeProxy (SignedTx era) where
+  data AsType (SignedTx era) = AsSignedTx (AsType era)
+  proxyToAsType :: Proxy (SignedTx era) -> AsType (SignedTx era)
+  proxyToAsType _ = AsSignedTx (asType @era)
+
+instance
+  ( HasTypeProxy era
+  , L.EraTx (LedgerEra era)
+  )
+  => SerialiseAsRawBytes (SignedTx era)
+  where
+  serialiseToRawBytes (SignedTx tx) =
+    Ledger.serialize' (Ledger.eraProtVerHigh @(LedgerEra era)) tx
+  deserialiseFromRawBytes _ =
+    bimap wrapError SignedTx
+      . Ledger.decodeFullAnnotator
+        (Ledger.eraProtVerHigh @(LedgerEra era))
+        "SignedTx"
+        Ledger.decCBOR
+      . fromStrict
+   where
+    wrapError
+      :: Ledger.DecoderError -> SerialiseAsRawBytesError
+    wrapError = SerialiseAsRawBytesError . displayException
 
 deriving instance Show (UnsignedTx era)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
@@ -10,48 +10,23 @@ module Cardano.Api.Experimental.Tx.Internal.Validate
   )
 where
 
-import Cardano.Api.Block (ChainPoint (..))
-import Cardano.Api.Era
+import Cardano.Api.Era.Internal.Eon.Convert (convert)
 import Cardano.Api.Experimental.Era (IsEra, LedgerEra, obtainCommonConstraints, useEra)
 import Cardano.Api.Experimental.Tx.Internal.Type (SignedTx (..))
-import Cardano.Api.Genesis.Internal (shelleyGenesisDefaults)
-import Cardano.Api.Genesis.Internal.Parameters
 import Cardano.Api.Network.IPC (LocalStateQueryExpr)
 import Cardano.Api.Network.IPC.Internal.Version (UnsupportedNtcVersionError)
-import Cardano.Api.Network.Internal.NetworkId (NetworkMagic (..), toNetworkMagic, toShelleyNetwork)
 import Cardano.Api.Query.Internal.Expr
 import Cardano.Api.Query.Internal.Type.QueryInMode
-import Cardano.Api.Tx.Internal.TxIn (fromShelleyTxIn)
+import Cardano.Api.Tx.Internal.Sign (Tx (..))
 
-import Cardano.Binary qualified as CBOR
-import Cardano.Ledger.BaseTypes (boundRational)
-import Cardano.Ledger.Coin (unCoin)
-import Cardano.Ledger.Core (allInputsTxBodyF, bodyTxL)
-import Cardano.Ledger.Shelley.API (ApplyTxError, EpochState (..), LedgerEnv (..), applyTx)
-import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), mkShelleyGlobals)
-import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL)
-import Cardano.Ledger.State (utxoL)
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Ledger.Shelley.API (ApplyTxError)
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
-
-import Control.Monad (void)
-import Data.Bifunctor (first)
-import Data.Set qualified as Set
-import Lens.Micro (set, (^.))
 
 data QueryValidateTxError
   = QueryValidateTxUnsupportedNtcVersion UnsupportedNtcVersionError
   | QueryValidateTxEraMismatch EraMismatch
-  | QueryValidateTxEpochStateDecodeError CBOR.DecoderError
   deriving Show
 
--- | Run applyTx against the node's current ledger state and return the raw result.
---
--- TODO: Replace this provisional implementation (which queries the full
--- EpochState from the node and runs applyTx client-side) with a dedicated
--- node-side consensus query that runs applyTx server-side without
--- transferring the ledger state. The replacement should have the same type
--- signature as a normal local state query.
 queryValidateTx
   :: forall era block point r
    . IsEra era
@@ -64,73 +39,9 @@ queryValidateTx
        IO
        (Either QueryValidateTxError (Either (ApplyTxError (LedgerEra era)) ()))
 queryValidateTx (SignedTx ledgerTx) = obtainCommonConstraints (useEra @era) $ do
-  let sbe = convert (useEra @era)
-  eGenParams <- queryGenesisParameters sbe
-  eSerEpochState <- queryCurrentEpochState sbe
-  eEraHistory <- queryEraHistory
-  eChainPoint <- queryChainPoint
-  -- QueryCurrentEpochState uses DebugEpochState (QFNoTables), so the
-  -- returned epoch state has empty UTxO tables.  We query the relevant
-  -- UTxOs separately and inject them before running applyTx.
-  let relevantTxIns =
-        Set.map
-          fromShelleyTxIn
-          (ledgerTx ^. bodyTxL . allInputsTxBodyF)
-  eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
-  return $ do
-    genParams <-
-      first QueryValidateTxUnsupportedNtcVersion eGenParams
-        >>= first QueryValidateTxEraMismatch
-    serEpochState <-
-      first QueryValidateTxUnsupportedNtcVersion eSerEpochState
-        >>= first QueryValidateTxEraMismatch
-    eraHistory <- first QueryValidateTxUnsupportedNtcVersion eEraHistory
-    chainPoint <- first QueryValidateTxUnsupportedNtcVersion eChainPoint
-    utxo <-
-      first QueryValidateTxUnsupportedNtcVersion eUtxo
-        >>= first QueryValidateTxEraMismatch
-    epochState <-
-      first QueryValidateTxEpochStateDecodeError $
-        decodeCurrentEpochState sbe serEpochState
-    let CurrentEpochState es = epochState
-        LedgerEpochInfo epochInfo = toLedgerEpochInfo eraHistory
-        globals = mkShelleyGlobals (toShelleyGenesis genParams) epochInfo
-        slotNo = chainPointToSlotNo chainPoint
-    Right $
-      shelleyBasedEraConstraints sbe $
-        let esWithUtxo = set utxoL (toLedgerUTxO sbe utxo) es
-         in void $ applyTx globals (mkMempoolEnv @era esWithUtxo slotNo) (esLState esWithUtxo) ledgerTx
-
-chainPointToSlotNo :: ChainPoint -> SlotNo
-chainPointToSlotNo ChainPointAtGenesis = SlotNo 0
-chainPointToSlotNo (ChainPoint slotNo _) = slotNo
-
-mkMempoolEnv
-  :: forall era. IsEra era => EpochState (LedgerEra era) -> SlotNo -> LedgerEnv (LedgerEra era)
-mkMempoolEnv epochState slotNo =
-  obtainCommonConstraints (useEra @era) $
-    LedgerEnv
-      { ledgerSlotNo = slotNo
-      , ledgerEpochNo = Nothing
-      , ledgerIx = minBound
-      , ledgerPp = epochState ^. curPParamsEpochStateL
-      , ledgerAccount = esChainAccountState epochState
-      }
-
-toShelleyGenesis :: GenesisParameters ShelleyEra -> ShelleyGenesis
-toShelleyGenesis gp =
-  shelleyGenesisDefaults
-    { sgSystemStart = protocolParamSystemStart gp
-    , sgNetworkMagic = let NetworkMagic m = toNetworkMagic (protocolParamNetworkId gp) in m
-    , sgNetworkId = toShelleyNetwork (protocolParamNetworkId gp)
-    , sgActiveSlotsCoeff = case boundRational (protocolParamActiveSlotsCoefficient gp) of
-        Nothing -> error "toShelleyGenesis: invalid activeSlotsCoefficient"
-        Just r -> r
-    , sgSecurityParam = protocolParamSecurity gp
-    , sgEpochLength = protocolParamEpochLength gp
-    , sgSlotsPerKESPeriod = fromIntegral (protocolParamSlotsPerKESPeriod gp)
-    , sgMaxKESEvolutions = fromIntegral (protocolParamMaxKESEvolutions gp)
-    , sgUpdateQuorum = fromIntegral (protocolParamUpdateQuorum gp)
-    , sgMaxLovelaceSupply = fromIntegral (unCoin (protocolParamMaxLovelaceSupply gp))
-    , sgProtocolParams = protocolInitialUpdateableProtocolParameters gp
-    }
+  let tx = ShelleyTx (convert (useEra @era)) ledgerTx
+  result <- querySbe (useEra @era) (QueryValidateTx tx)
+  return $ case result of
+    Left err -> Left (QueryValidateTxUnsupportedNtcVersion err)
+    Right (Left mismatch) -> Left (QueryValidateTxEraMismatch mismatch)
+    Right (Right r) -> Right r

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.Api.Experimental.Tx.Internal.Validate
+  ( queryValidateTx
+  , QueryValidateTxError (..)
+  )
+where
+
+import Cardano.Api.Block (ChainPoint (..))
+import Cardano.Api.Era
+import Cardano.Api.Genesis.Internal (shelleyGenesisDefaults)
+import Cardano.Api.Genesis.Internal.Parameters
+import Cardano.Api.Network.IPC (LocalStateQueryExpr)
+import Cardano.Api.Network.IPC.Internal.Version (UnsupportedNtcVersionError)
+import Cardano.Api.Network.Internal.NetworkId (NetworkMagic (..), toNetworkMagic, toShelleyNetwork)
+import Cardano.Api.Query.Internal.Expr
+import Cardano.Api.Query.Internal.Type.QueryInMode
+import Cardano.Api.Tx.Internal.Sign (Tx (..))
+import Cardano.Api.Tx.Internal.TxIn (fromShelleyTxIn)
+
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
+
+import Cardano.Binary qualified as CBOR
+import Cardano.Ledger.BaseTypes (boundRational)
+import Cardano.Ledger.Coin (unCoin)
+import Cardano.Ledger.Core (allInputsTxBodyF, bodyTxL)
+import Cardano.Ledger.Shelley.API (ApplyTxError, EpochState (..), LedgerEnv (..), applyTx)
+import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), mkShelleyGlobals)
+import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL)
+import Cardano.Ledger.State (utxoL)
+import Cardano.Slotting.Slot (SlotNo (..))
+
+import Control.Monad (void)
+import Data.Bifunctor (first)
+import Data.Set qualified as Set
+import Lens.Micro (set, (^.))
+
+data QueryValidateTxError
+  = QueryValidateTxUnsupportedNtcVersion UnsupportedNtcVersionError
+  | QueryValidateTxEraMismatch EraMismatch
+  | QueryValidateTxEpochStateDecodeError CBOR.DecoderError
+  deriving Show
+
+-- | Run applyTx against the node's current ledger state and return the raw result.
+--
+-- TODO: Replace this provisional implementation (which queries the full
+-- EpochState from the node and runs applyTx client-side) with a dedicated
+-- node-side consensus query that runs applyTx server-side without
+-- transferring the ledger state. The replacement should have the same type
+-- signature as a normal local state query.
+queryValidateTx
+  :: forall era block point r
+   . ShelleyBasedEra era
+  -> Tx era
+  -> LocalStateQueryExpr
+       block
+       point
+       QueryInMode
+       r
+       IO
+       (Either QueryValidateTxError (Either (ApplyTxError (ShelleyLedgerEra era)) ()))
+queryValidateTx sbe (ShelleyTx _sbe ledgerTx) = do
+  eGenParams <- queryGenesisParameters sbe
+  eSerEpochState <- queryCurrentEpochState sbe
+  eEraHistory <- queryEraHistory
+  eChainPoint <- queryChainPoint
+  -- QueryCurrentEpochState uses DebugEpochState (QFNoTables), so the
+  -- returned epoch state has empty UTxO tables.  We query the relevant
+  -- UTxOs separately and inject them before running applyTx.
+  let relevantTxIns =
+        Set.map fromShelleyTxIn
+          (shelleyBasedEraConstraints sbe $ ledgerTx ^. bodyTxL . allInputsTxBodyF)
+  eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
+  return $ do
+    genParams <-
+      first QueryValidateTxUnsupportedNtcVersion eGenParams
+        >>= first QueryValidateTxEraMismatch
+    serEpochState <-
+      first QueryValidateTxUnsupportedNtcVersion eSerEpochState
+        >>= first QueryValidateTxEraMismatch
+    eraHistory <- first QueryValidateTxUnsupportedNtcVersion eEraHistory
+    chainPoint <- first QueryValidateTxUnsupportedNtcVersion eChainPoint
+    utxo <-
+      first QueryValidateTxUnsupportedNtcVersion eUtxo
+        >>= first QueryValidateTxEraMismatch
+    epochState <- first QueryValidateTxEpochStateDecodeError $
+      decodeCurrentEpochState sbe serEpochState
+    let CurrentEpochState es = epochState
+        LedgerEpochInfo epochInfo = toLedgerEpochInfo eraHistory
+        globals = mkShelleyGlobals (toShelleyGenesis genParams) epochInfo
+        slotNo = chainPointToSlotNo chainPoint
+    Right $ shelleyBasedEraConstraints sbe $
+      let esWithUtxo = set utxoL (toLedgerUTxO sbe utxo) es
+       in void $ applyTx globals (mkMempoolEnv sbe esWithUtxo slotNo) (esLState esWithUtxo) ledgerTx
+
+chainPointToSlotNo :: ChainPoint -> SlotNo
+chainPointToSlotNo ChainPointAtGenesis = SlotNo 0
+chainPointToSlotNo (ChainPoint slotNo _) = slotNo
+
+mkMempoolEnv
+  :: ShelleyBasedEra era -> EpochState (ShelleyLedgerEra era) -> SlotNo -> LedgerEnv (ShelleyLedgerEra era)
+mkMempoolEnv sbe epochState slotNo =
+  shelleyBasedEraConstraints sbe $
+    LedgerEnv
+      { ledgerSlotNo = slotNo
+      , ledgerEpochNo = Nothing
+      , ledgerIx = minBound
+      , ledgerPp = epochState ^. curPParamsEpochStateL
+      , ledgerAccount = esChainAccountState epochState
+      }
+
+toShelleyGenesis :: GenesisParameters ShelleyEra -> ShelleyGenesis
+toShelleyGenesis gp =
+  shelleyGenesisDefaults
+    { sgSystemStart = protocolParamSystemStart gp
+    , sgNetworkMagic = let NetworkMagic m = toNetworkMagic (protocolParamNetworkId gp) in m
+    , sgNetworkId = toShelleyNetwork (protocolParamNetworkId gp)
+    , sgActiveSlotsCoeff = case boundRational (protocolParamActiveSlotsCoefficient gp) of
+        Nothing -> error "toShelleyGenesis: invalid activeSlotsCoefficient"
+        Just r -> r
+    , sgSecurityParam = protocolParamSecurity gp
+    , sgEpochLength = protocolParamEpochLength gp
+    , sgSlotsPerKESPeriod = fromIntegral (protocolParamSlotsPerKESPeriod gp)
+    , sgMaxKESEvolutions = fromIntegral (protocolParamMaxKESEvolutions gp)
+    , sgUpdateQuorum = fromIntegral (protocolParamUpdateQuorum gp)
+    , sgMaxLovelaceSupply = fromIntegral (unCoin (protocolParamMaxLovelaceSupply gp))
+    , sgProtocolParams = protocolInitialUpdateableProtocolParameters gp
+    }

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Validate.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Api.Experimental.Tx.Internal.Validate
   ( queryValidateTx
@@ -11,6 +12,8 @@ where
 
 import Cardano.Api.Block (ChainPoint (..))
 import Cardano.Api.Era
+import Cardano.Api.Experimental.Era (IsEra, LedgerEra, obtainCommonConstraints, useEra)
+import Cardano.Api.Experimental.Tx.Internal.Type (SignedTx (..))
 import Cardano.Api.Genesis.Internal (shelleyGenesisDefaults)
 import Cardano.Api.Genesis.Internal.Parameters
 import Cardano.Api.Network.IPC (LocalStateQueryExpr)
@@ -18,10 +21,7 @@ import Cardano.Api.Network.IPC.Internal.Version (UnsupportedNtcVersionError)
 import Cardano.Api.Network.Internal.NetworkId (NetworkMagic (..), toNetworkMagic, toShelleyNetwork)
 import Cardano.Api.Query.Internal.Expr
 import Cardano.Api.Query.Internal.Type.QueryInMode
-import Cardano.Api.Tx.Internal.Sign (Tx (..))
 import Cardano.Api.Tx.Internal.TxIn (fromShelleyTxIn)
-
-import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 
 import Cardano.Binary qualified as CBOR
 import Cardano.Ledger.BaseTypes (boundRational)
@@ -32,6 +32,7 @@ import Cardano.Ledger.Shelley.Genesis (ShelleyGenesis (..), mkShelleyGlobals)
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL)
 import Cardano.Ledger.State (utxoL)
 import Cardano.Slotting.Slot (SlotNo (..))
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (EraMismatch)
 
 import Control.Monad (void)
 import Data.Bifunctor (first)
@@ -53,16 +54,17 @@ data QueryValidateTxError
 -- signature as a normal local state query.
 queryValidateTx
   :: forall era block point r
-   . ShelleyBasedEra era
-  -> Tx era
+   . IsEra era
+  => SignedTx era
   -> LocalStateQueryExpr
        block
        point
        QueryInMode
        r
        IO
-       (Either QueryValidateTxError (Either (ApplyTxError (ShelleyLedgerEra era)) ()))
-queryValidateTx sbe (ShelleyTx _sbe ledgerTx) = do
+       (Either QueryValidateTxError (Either (ApplyTxError (LedgerEra era)) ()))
+queryValidateTx (SignedTx ledgerTx) = obtainCommonConstraints (useEra @era) $ do
+  let sbe = convert (useEra @era)
   eGenParams <- queryGenesisParameters sbe
   eSerEpochState <- queryCurrentEpochState sbe
   eEraHistory <- queryEraHistory
@@ -71,8 +73,9 @@ queryValidateTx sbe (ShelleyTx _sbe ledgerTx) = do
   -- returned epoch state has empty UTxO tables.  We query the relevant
   -- UTxOs separately and inject them before running applyTx.
   let relevantTxIns =
-        Set.map fromShelleyTxIn
-          (shelleyBasedEraConstraints sbe $ ledgerTx ^. bodyTxL . allInputsTxBodyF)
+        Set.map
+          fromShelleyTxIn
+          (ledgerTx ^. bodyTxL . allInputsTxBodyF)
   eUtxo <- queryUtxo sbe (QueryUTxOByTxIn relevantTxIns)
   return $ do
     genParams <-
@@ -86,24 +89,26 @@ queryValidateTx sbe (ShelleyTx _sbe ledgerTx) = do
     utxo <-
       first QueryValidateTxUnsupportedNtcVersion eUtxo
         >>= first QueryValidateTxEraMismatch
-    epochState <- first QueryValidateTxEpochStateDecodeError $
-      decodeCurrentEpochState sbe serEpochState
+    epochState <-
+      first QueryValidateTxEpochStateDecodeError $
+        decodeCurrentEpochState sbe serEpochState
     let CurrentEpochState es = epochState
         LedgerEpochInfo epochInfo = toLedgerEpochInfo eraHistory
         globals = mkShelleyGlobals (toShelleyGenesis genParams) epochInfo
         slotNo = chainPointToSlotNo chainPoint
-    Right $ shelleyBasedEraConstraints sbe $
-      let esWithUtxo = set utxoL (toLedgerUTxO sbe utxo) es
-       in void $ applyTx globals (mkMempoolEnv sbe esWithUtxo slotNo) (esLState esWithUtxo) ledgerTx
+    Right $
+      shelleyBasedEraConstraints sbe $
+        let esWithUtxo = set utxoL (toLedgerUTxO sbe utxo) es
+         in void $ applyTx globals (mkMempoolEnv @era esWithUtxo slotNo) (esLState esWithUtxo) ledgerTx
 
 chainPointToSlotNo :: ChainPoint -> SlotNo
 chainPointToSlotNo ChainPointAtGenesis = SlotNo 0
 chainPointToSlotNo (ChainPoint slotNo _) = slotNo
 
 mkMempoolEnv
-  :: ShelleyBasedEra era -> EpochState (ShelleyLedgerEra era) -> SlotNo -> LedgerEnv (ShelleyLedgerEra era)
-mkMempoolEnv sbe epochState slotNo =
-  shelleyBasedEraConstraints sbe $
+  :: forall era. IsEra era => EpochState (LedgerEra era) -> SlotNo -> LedgerEnv (LedgerEra era)
+mkMempoolEnv epochState slotNo =
+  obtainCommonConstraints (useEra @era) $
     LedgerEnv
       { ledgerSlotNo = slotNo
       , ledgerEpochNo = Nothing

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -46,6 +46,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   -- Core
   , Addr
   , Coin (..)
+  , DeltaCoin (..)
   , Compactible (..)
   , partialCompactFL
   , toCompactPartial
@@ -71,6 +72,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   , Val (..)
   , addDeltaCoin
   , castSafeHash
+  , coinTxOutL
   , getScriptsNeeded
   , mkBasicTxOut
   , toDeltaCoin
@@ -84,6 +86,22 @@ module Cardano.Api.Ledger.Internal.Reexport
   -- Dijkstra
   , DijkstraPlutusPurpose (..)
   -- Conway
+  , ApplyTxError (..)
+  , ConwayLedgerPredFailure (..)
+  , ConwayUtxowPredFailure (..)
+  , ConwayUtxoPredFailure (..)
+  , ConwayCertsPredFailure (..)
+  , ConwayCertPredFailure (..)
+  , ConwayDelegPredFailure (..)
+  , ConwayGovCertPredFailure (..)
+  , ConwayGovPredFailure (..)
+  , ConwayUtxosPredFailure (..)
+  , ShelleyPoolPredFailure (..)
+  , TagMismatchDescription (..)
+  , FailureDescription (..)
+  , CollectError (..)
+  , IsValid (..)
+  , Withdrawals (..)
   , Anchor (..)
   , Committee (..)
   , Delegatee (..)
@@ -148,6 +166,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   , AlonzoEraTxWits (..)
   , AlonzoPlutusPurpose (..)
   , AlonzoScriptsNeeded (..)
+  , AsItem (..)
   , AsIx (..)
   , CoinPerWord (..)
   , Data (..)
@@ -179,6 +198,8 @@ module Cardano.Api.Ledger.Internal.Reexport
   , showTimelock
   , toAsIx
   -- Base
+  , Mismatch (..)
+  , Relation (..)
   , boundRational
   , unboundRational
   , DnsName
@@ -201,12 +222,16 @@ module Cardano.Api.Ledger.Internal.Reexport
   -- Crypto
   , hashToBytes
   , hashFromBytes
+  , hashToTextAsHex
   , Crypto
   , StandardCrypto
   , ADDRHASH
   -- Slotting
   , EpochNo (..)
   -- SafeHash
+  , ScriptHash (..)
+  , DataHash
+  , TxAuxDataHash (..)
   , SafeHash
   , unsafeMakeSafeHash
   , extractHash
@@ -215,13 +240,14 @@ module Cardano.Api.Ledger.Internal.Reexport
   )
 where
 
-import Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes)
-import Cardano.Ledger.Address (AccountAddress (..), Addr (..))
+import Cardano.Crypto.Hash.Class (hashFromBytes, hashToBytes, hashToTextAsHex)
+import Cardano.Ledger.Address (AccountAddress (..), Addr (..), Withdrawals (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..), Timelock (..), showTimelock)
 import Cardano.Ledger.Alonzo.Core
   ( AlonzoEraScript (..)
   , AlonzoEraTxBody (..)
   , AlonzoEraTxWits (..)
+  , AsItem (..)
   , AsIx (..)
   , AsIxItem (AsIxItem)
   , CoinPerWord (..)
@@ -244,6 +270,9 @@ import Cardano.Ledger.Alonzo.Scripts
   , plutusScriptLanguage
   , toAsIx
   )
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules (FailureDescription (..), TagMismatchDescription (..))
+import Cardano.Ledger.Alonzo.Tx (IsValid (..))
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
 import Cardano.Ledger.Api
@@ -276,9 +305,11 @@ import Cardano.Ledger.BaseTypes
   , DnsName
   , EpochInterval (..)
   , Inject (..)
+  , Mismatch (..)
   , Network (..)
   , NonNegativeInterval
   , ProtVer (..)
+  , Relation (..)
   , StrictMaybe (..)
   , UnitInterval
   , Url
@@ -306,7 +337,7 @@ import Cardano.Ledger.Binary
   , toPlainDecoder
   )
 import Cardano.Ledger.Binary.Plain (Decoder, serializeAsHexText)
-import Cardano.Ledger.Coin (Coin (..), addDeltaCoin, toDeltaCoin)
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), addDeltaCoin, toDeltaCoin)
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Conway.Core
   ( DRepVotingThresholds (..)
@@ -317,7 +348,19 @@ import Cardano.Ledger.Conway.Core
   , dvtPPTechnicalGroupL
   , dvtUpdateToConstitutionL
   )
+import Cardano.Ledger.Conway (ApplyTxError (..))
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
+import Cardano.Ledger.Conway.Rules
+  ( ConwayCertPredFailure (..)
+  , ConwayCertsPredFailure (..)
+  , ConwayDelegPredFailure (..)
+  , ConwayGovCertPredFailure (..)
+  , ConwayGovPredFailure (..)
+  , ConwayLedgerPredFailure (..)
+  , ConwayUtxoPredFailure (..)
+  , ConwayUtxosPredFailure (..)
+  , ConwayUtxowPredFailure (..)
+  )
 import Cardano.Ledger.Conway.Governance
   ( Anchor (..)
   , Committee (..)
@@ -350,6 +393,7 @@ import Cardano.Ledger.Core
   , PoolCert (..)
   , TxOut
   , Value
+  , coinTxOutL
   , fromEraCBOR
   , mkBasicTxOut
   , ppMinFeeAL
@@ -362,7 +406,10 @@ import Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
 import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
 import Cardano.Ledger.Hashes
   ( ADDRHASH
+  , DataHash
   , SafeHash
+  , ScriptHash (..)
+  , TxAuxDataHash (..)
   , castSafeHash
   , extractHash
   , unsafeMakeSafeHash
@@ -394,6 +441,7 @@ import Cardano.Ledger.Shelley.API
   , WitVKey (..)
   , hashKey
   )
+import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure (..))
 import Cardano.Ledger.Shelley.Genesis
   ( ShelleyGenesisStaking (..)
   , secondsToNominalDiffTimeMicro

--- a/cardano-api/src/Cardano/Api/Query.hs
+++ b/cardano-api/src/Cardano/Api/Query.hs
@@ -89,6 +89,8 @@ module Cardano.Api.Query
   , queryProposals
   , queryStakePoolDefaultVote
   , queryLedgerConfig
+  , queryValidateTx
+  , QueryValidateTxError (..)
   , DelegationsAndRewards (..)
   , mergeDelegsAndRewards
 
@@ -99,6 +101,7 @@ module Cardano.Api.Query
   )
 where
 
+import Cardano.Api.Experimental.Tx.Internal.Validate
 import Cardano.Api.Query.Internal.Convenience
 import Cardano.Api.Query.Internal.Expr
 import Cardano.Api.Query.Internal.Type.DebugLedgerState

--- a/cardano-api/src/Cardano/Api/Query/Internal/Expr.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Expr.hs
@@ -43,6 +43,7 @@ module Cardano.Api.Query.Internal.Expr
   , queryStakePoolDefaultVote
   , queryLedgerConfig
   , queryDRepDelegations
+  , querySbe
   )
 where
 

--- a/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
@@ -87,6 +87,7 @@ import Cardano.Api.Serialise.TextEnvelope.Internal
   , TextEnvelopeType
   )
 import Cardano.Api.Tx.Internal.Body
+import Cardano.Api.Tx.Internal.Sign (Tx (..))
 import Cardano.Api.UTxO (UTxO (..))
 
 import Cardano.Binary qualified as CBOR
@@ -342,6 +343,9 @@ data QueryInShelleyBasedEra era result where
   GetDRepDelegations
     :: Set Ledger.DRep
     -> QueryInShelleyBasedEra era (Map Ledger.DRep (Set (Ledger.Credential Ledger.Staking)))
+  QueryValidateTx
+    :: Tx era
+    -> QueryInShelleyBasedEra era (Either (Ledger.ApplyTxError (ShelleyLedgerEra era)) ())
 
 deriving instance Show (QueryInShelleyBasedEra era result)
 
@@ -576,7 +580,7 @@ toConsensusQueryShelleyBased
    . HasCallStack
   => ConsensusBlockForEra era ~ Consensus.ShelleyBlock protocol (ShelleyLedgerEra era)
   => Consensus.CardanoBlock StandardCrypto ~ block
-  => L.EraGov (ShelleyLedgerEra era)
+  => Consensus.ShelleyCompatible protocol (ShelleyLedgerEra era)
   => ShelleyBasedEra era
   -> QueryInShelleyBasedEra era result
   -> Some (Consensus.Query block)
@@ -746,6 +750,8 @@ toConsensusQueryShelleyBased sbe = \case
             (consensusQueryInEraInMode era (Consensus.GetDRepDelegations dreps))
       )
       sbe
+  QueryValidateTx (ShelleyTx _ tx) ->
+    Some (consensusQueryInEraInMode era (Consensus.ValidateTx (Consensus.mkShelleyTx tx)))
  where
   era = toCardanoEra sbe
 
@@ -1073,6 +1079,11 @@ fromConsensusQueryResultShelleyBased sbe sbeQuery q' r' =
     GetDRepDelegations{} ->
       case q' of
         Consensus.GetDRepDelegations{} ->
+          r'
+        _ -> fromConsensusQueryResultMismatch
+    QueryValidateTx{} ->
+      case q' of
+        Consensus.ValidateTx{} ->
           r'
         _ -> fromConsensusQueryResultMismatch
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Cip129.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Cip129.hs
@@ -11,7 +11,6 @@ import Cardano.Api
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.Ledger.Api.Governance qualified as Gov
-import Cardano.Ledger.Core qualified as L
 
 import Data.Text qualified as T
 import GHC.Stack


### PR DESCRIPTION
<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-api -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

Implements the `cardano-api` portion of server-side transaction validation via the `LocalStateQuery` protocol.

Part of [IntersectMBO/cardano-cli#1380](https://github.com/IntersectMBO/cardano-cli/issues/1380).

**Big picture:** `transaction validate` currently applies `applyTx` client-side with an empty UTxO set, making it unable to properly validate transactions. This cross-repo change adds a new `ValidateTx` query to the `LocalStateQuery` protocol so the node validates transactions against its real ledger state and UTxO set.

`transaction validate` PR list:
- [ouroboros-network] https://github.com/IntersectMBO/ouroboros-network/pull/5377
- [ouroboros-consensus] https://github.com/IntersectMBO/ouroboros-consensus/pull/2052
- [cardano-api] **(this PR)**
- [cardano-cli] https://github.com/IntersectMBO/cardano-cli/pull/1386
- [cardano-node] https://github.com/IntersectMBO/cardano-node/pull/6582

## What this PR does

- Adds `QueryValidateTx` to `QueryInShelleyBasedEra`, wrapping a `Tx era` and wiring it to the consensus `ValidateTx` query via `toConsensusQueryShelleyBased`
- Adds `queryValidateTx` (in `Cardano.Api.Experimental.Tx.Internal.Validate`) to issue the query through `LocalStateQueryExpr`
- Adds a high-level `validateTx` function (in `Cardano.Api.Experimental.Tx`) that combines phase-1 validation (via the node query) with phase-2 script execution unit evaluation, filtering script failures from phase-1 results to avoid double-reporting
- Moves `SignedTx` from `Cardano.Api.Experimental.Tx` to its own `Internal.Type` module
- Exposes `InAnyEra` existential wrapper in `Cardano.Api.Experimental.Era`
- Re-exports Conway/Alonzo ledger validation error types through `Cardano.Api.Ledger.Internal.Reexport` (e.g. `ApplyTxError`, `ConwayLedgerPredFailure`, `Mismatch`, `IsValid`, `CollectError`, etc.) for downstream error rendering
- Exports `querySbe` from `Cardano.Api.Query.Internal.Expr`
- Exports `queryValidateTx`, `QueryValidateTxError`, `TxValidationResult`, and `validateTx` through the public `Cardano.Api.Query` and `Cardano.Api.Experimental` modules

# How to trust this PR

Integration tests in `cardano-testnet` (in the [cardano-node PR](https://github.com/IntersectMBO/cardano-node/pull/6582)) exercise the full round-trip: valid simple txs, valid Plutus txs, fee-too-low, value-not-conserved, missing witnesses, missing script witnesses, no collateral, max-tx-size exceeded, phase-2 failures, and multi-error scenarios.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`