### PR TITLE
Implement makeShelleyTransactionBody for Dijkstra era

### DIFF
--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -2662,7 +2662,148 @@ makeShelleyTransactionBody
 
     txAuxData :: Maybe (L.TxAuxData E.ConwayEra)
     txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
-makeShelleyTransactionBody ShelleyBasedEraDijkstra _ = error "TODO Dijkstra: makeShelleyTransactionBody: era not supported"
+makeShelleyTransactionBody
+  sbe@ShelleyBasedEraDijkstra
+  txbodycontent@TxBodyContent
+    { txIns
+    , txInsCollateral
+    , txInsReference
+    , txReturnCollateral
+    , txTotalCollateral
+    , txOuts
+    , txFee
+    , txValidityLowerBound
+    , txValidityUpperBound
+    , txMetadata
+    , txAuxScripts
+    , txExtraKeyWits = _txExtraKeyWits
+    , txProtocolParams
+    , txWithdrawals
+    , txCertificates
+    , txMintValue
+    , txScriptValidity
+    , txProposalProcedures
+    , txVotingProcedures
+    , txCurrentTreasuryValue
+    , txTreasuryDonation
+    } = do
+    let aOn = AllegraEraOnwardsDijkstra
+    let mOn = MaryEraOnwardsDijkstra
+    let bOn = BabbageEraOnwardsDijkstra
+    validateTxBodyContent sbe txbodycontent
+    let scriptIntegrityHash =
+          convPParamsToScriptIntegrityHash AlonzoEraOnwardsDijkstra txProtocolParams redeemers datums languages
+    let txbody =
+          ( mkCommonTxBody sbe txIns txOuts txFee txWithdrawals txAuxData
+              & A.collateralInputsTxBodyL azOn
+                .~ case txInsCollateral of
+                  TxInsCollateralNone -> Set.empty
+                  TxInsCollateral _ txins -> fromList (map toShelleyTxIn txins)
+              & A.referenceInputsTxBodyL bOn
+                .~ convReferenceInputs txInsReference
+              & A.collateralReturnTxBodyL bOn
+                .~ convReturnCollateral sbe txReturnCollateral
+              & A.totalCollateralTxBodyL bOn
+                .~ convTotalCollateral txTotalCollateral
+              & A.certsTxBodyL sbe
+                .~ convCertificates sbe txCertificates
+              & A.invalidBeforeTxBodyL aOn
+                .~ convValidityLowerBound txValidityLowerBound
+              & A.invalidHereAfterTxBodyL sbe
+                .~ convValidityUpperBound sbe txValidityUpperBound
+              & A.mintTxBodyL mOn
+                .~ convMintValue txMintValue
+              & A.scriptIntegrityHashTxBodyL azOn
+                .~ scriptIntegrityHash
+              & (A.txBodyL . L.votingProceduresTxBodyL)
+                .~ convVotingProcedures (maybe TxVotingProceduresNone unFeatured txVotingProcedures)
+              & (A.txBodyL . L.proposalProceduresTxBodyL)
+                .~ convProposalProcedures (maybe TxProposalProceduresNone unFeatured txProposalProcedures)
+              & (A.txBodyL . L.currentTreasuryValueTxBodyL)
+                .~ Ledger.maybeToStrictMaybe (unFeatured =<< txCurrentTreasuryValue)
+              & (A.txBodyL . L.treasuryDonationTxBodyL)
+                .~ maybe (L.Coin 0) unFeatured txTreasuryDonation
+          )
+            ^. A.txBodyL
+    return $
+      ShelleyTxBody
+        sbe
+        txbody
+        scripts
+        ( TxBodyScriptData
+            AlonzoEraOnwardsDijkstra
+            datums
+            redeemers
+        )
+        txAuxData
+        txScriptValidity
+   where
+    azOn = AlonzoEraOnwardsDijkstra
+
+    witnesses :: [(ScriptWitnessIndex, AnyScriptWitness DijkstraEra)]
+    witnesses = collectTxBodyScriptWitnesses sbe txbodycontent
+
+    scripts :: [Ledger.Script (ShelleyLedgerEra DijkstraEra)]
+    scripts =
+      catMaybes
+        [ toShelleyScript <$> getScriptWitnessScript scriptwitness
+        | (_, AnyScriptWitness scriptwitness) <- witnesses
+        ]
+
+    datums :: Alonzo.TxDats (ShelleyLedgerEra DijkstraEra)
+    datums =
+      Alonzo.TxDats $
+        fromList
+          [ (L.hashData d, d)
+          | d <- toAlonzoData <$> scriptdata
+          ]
+
+    scriptdata :: [HashableScriptData]
+    scriptdata =
+      [d | TxOut _ _ (TxOutSupplementalDatum _ d) _ <- txOuts]
+        <> [ d
+           | ( _
+               , AnyScriptWitness
+                   ( PlutusScriptWitness
+                       _
+                       _
+                       _
+                       (ScriptDatumForTxIn (Just d))
+                       _
+                       _
+                     )
+               ) <-
+               witnesses
+           ]
+
+    redeemers :: Alonzo.Redeemers (ShelleyLedgerEra DijkstraEra)
+    redeemers =
+      Alonzo.Redeemers $
+        fromList
+          [ (i, (toAlonzoData d, toAlonzoExUnits e))
+          | ( idx
+              , AnyScriptWitness
+                  (PlutusScriptWitness _ _ _ _ d e)
+              ) <-
+              witnesses
+          , Just i <- [fromScriptWitnessIndex azOn idx]
+          ]
+
+    languages :: Set Plutus.Language
+    languages =
+      fromList $
+        catMaybes
+          [ getScriptLanguage sw
+          | (_, AnyScriptWitness sw) <- witnesses
+          ]
+
+    getScriptLanguage :: ScriptWitness witctx era -> Maybe Plutus.Language
+    getScriptLanguage (PlutusScriptWitness _ v _ _ _ _) =
+      Just $ toAlonzoLanguage (AnyPlutusScriptVersion v)
+    getScriptLanguage SimpleScriptWitness{} = Nothing
+
+    txAuxData :: Maybe (L.TxAuxData (ShelleyLedgerEra DijkstraEra))
+    txAuxData = toAuxiliaryData sbe txMetadata txAuxScripts
 
 -- ----------------------------------------------------------------------------
 -- Script witnesses within the tx body


### PR DESCRIPTION
Replaces the TODO stub with a full implementation, structurally identical to the Conway case but using DijkstraEraOnwards witnesses and skipping reqSignerHashesTxBodyL (gated AtMostEra Conway).

<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-api -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
