### PR TITLE
Remove deprecated era conversion functions superseded by convert

### DIFF
--- a/.changes/20260615_remove_deprecated_convert_fns.yml
+++ b/.changes/20260615_remove_deprecated_convert_fns.yml
@@ -1,0 +1,5 @@
+project: cardano-api
+kind:
+  - breaking
+description: |
+  Remove deprecated era conversion functions that were superseded by 'convert': shelleyToAlonzoEraToShelleyToBabbageEra, alonzoEraOnwardsToMaryEraOnwards, babbageEraOnwardsToMaryEraOnwards, babbageEraOnwardsToAlonzoEraOnwards, eraToSbe, eraToBabbageEraOnwards, shelleyToMaryEraToShelleyBasedEra, conwayEraOnwardsToShelleyBasedEra, conwayEraOnwardsToBabbageEraOnwards, maryEraOnwardsToShelleyBasedEra, babbageEraOnwardsToShelleyBasedEra, shelleyEraOnlyToShelleyBasedEra, alonzoEraOnwardsToShelleyBasedEra, shelleyToBabbageEraToShelleyBasedEra, allegraEraOnwardsToShelleyBasedEra, shelleyToAllegraEraToShelleyBasedEra. Use 'convert' instead.

--- a/.changes/20260615_remove_deprecated_convert_fns.yml
+++ b/.changes/20260615_remove_deprecated_convert_fns.yml
@@ -1,4 +1,5 @@
 project: cardano-api
+pr: 1234
 kind:
   - breaking
 description: |

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -981,7 +981,7 @@ genTxMintValue =
       policies <- Gen.list (Range.constant 1 3) genPolicyId
       assets <- forM policies $ \policy -> do
         mintValue <- genPolicyAssets
-        witness <- genScriptWitnessForMint (maryEraOnwardsToShelleyBasedEra w)
+        witness <- genScriptWitnessForMint (convert w)
         pure (policy, (mintValue, pure witness))
 
       Gen.choice

--- a/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
@@ -13,11 +13,6 @@ module Cardano.Api.Era.Internal.Case
   , caseShelleyToMaryOrAlonzoEraOnwards
   , caseShelleyToAlonzoOrBabbageEraOnwards
   , caseShelleyToBabbageOrConwayEraOnwards
-  -- Conversions
-  , shelleyToAlonzoEraToShelleyToBabbageEra
-  , alonzoEraOnwardsToMaryEraOnwards
-  , babbageEraOnwardsToMaryEraOnwards
-  , babbageEraOnwardsToAlonzoEraOnwards
   )
 where
 
@@ -156,45 +151,3 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway -> r ConwayEraOnwardsConway
   ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToBabbageOrConwayEraOnwards: era not supported"
-
-{-# DEPRECATED shelleyToAlonzoEraToShelleyToBabbageEra "Use convert instead" #-}
-shelleyToAlonzoEraToShelleyToBabbageEra
-  :: ()
-  => ShelleyToAlonzoEra era
-  -> ShelleyToBabbageEra era
-shelleyToAlonzoEraToShelleyToBabbageEra = \case
-  ShelleyToAlonzoEraShelley -> ShelleyToBabbageEraShelley
-  ShelleyToAlonzoEraAllegra -> ShelleyToBabbageEraAllegra
-  ShelleyToAlonzoEraMary -> ShelleyToBabbageEraMary
-  ShelleyToAlonzoEraAlonzo -> ShelleyToBabbageEraAlonzo
-
-{-# DEPRECATED alonzoEraOnwardsToMaryEraOnwards "Use convert instead" #-}
-alonzoEraOnwardsToMaryEraOnwards
-  :: ()
-  => AlonzoEraOnwards era
-  -> MaryEraOnwards era
-alonzoEraOnwardsToMaryEraOnwards = \case
-  AlonzoEraOnwardsAlonzo -> MaryEraOnwardsAlonzo
-  AlonzoEraOnwardsBabbage -> MaryEraOnwardsBabbage
-  AlonzoEraOnwardsConway -> MaryEraOnwardsConway
-  AlonzoEraOnwardsDijkstra -> MaryEraOnwardsDijkstra
-
-{-# DEPRECATED babbageEraOnwardsToMaryEraOnwards "Use convert instead" #-}
-babbageEraOnwardsToMaryEraOnwards
-  :: ()
-  => BabbageEraOnwards era
-  -> MaryEraOnwards era
-babbageEraOnwardsToMaryEraOnwards = \case
-  BabbageEraOnwardsBabbage -> MaryEraOnwardsBabbage
-  BabbageEraOnwardsConway -> MaryEraOnwardsConway
-  BabbageEraOnwardsDijkstra -> MaryEraOnwardsDijkstra
-
-{-# DEPRECATED babbageEraOnwardsToAlonzoEraOnwards "Use convert instead" #-}
-babbageEraOnwardsToAlonzoEraOnwards
-  :: ()
-  => BabbageEraOnwards era
-  -> AlonzoEraOnwards era
-babbageEraOnwardsToAlonzoEraOnwards = \case
-  BabbageEraOnwardsBabbage -> AlonzoEraOnwardsBabbage
-  BabbageEraOnwardsConway -> AlonzoEraOnwardsConway
-  BabbageEraOnwardsDijkstra -> AlonzoEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.AllegraEraOnwards
   ( AllegraEraOnwards (..)
   , allegraEraOnwardsConstraints
-  , allegraEraOnwardsToShelleyBasedEra
   , AllegraEraOnwardsConstraints
   , IsAllegraBasedEra (..)
   )
@@ -121,10 +120,6 @@ allegraEraOnwardsConstraints = \case
   AllegraEraOnwardsBabbage -> id
   AllegraEraOnwardsConway -> id
   _ -> const $ error "TODO Dijkstra: allegraEraOnwardsConstraints: era not supported"
-
-{-# DEPRECATED allegraEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
-allegraEraOnwardsToShelleyBasedEra :: AllegraEraOnwards era -> ShelleyBasedEra era
-allegraEraOnwardsToShelleyBasedEra = convert
 
 class IsShelleyBasedEra era => IsAllegraBasedEra era where
   allegraBasedEra :: AllegraEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AlonzoEraOnwards.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.AlonzoEraOnwards
   ( AlonzoEraOnwards (..)
   , alonzoEraOnwardsConstraints
-  , alonzoEraOnwardsToShelleyBasedEra
   , AlonzoEraOnwardsConstraints
   , IsAlonzoBasedEra (..)
   )
@@ -129,10 +128,6 @@ alonzoEraOnwardsConstraints = \case
   AlonzoEraOnwardsBabbage -> id
   AlonzoEraOnwardsConway -> id
   AlonzoEraOnwardsDijkstra -> id
-
-{-# DEPRECATED alonzoEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
-alonzoEraOnwardsToShelleyBasedEra :: AlonzoEraOnwards era -> ShelleyBasedEra era
-alonzoEraOnwardsToShelleyBasedEra = convert
 
 class IsMaryBasedEra era => IsAlonzoBasedEra era where
   alonzoBasedEra :: AlonzoEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
@@ -13,7 +13,6 @@
 module Cardano.Api.Era.Internal.Eon.BabbageEraOnwards
   ( BabbageEraOnwards (..)
   , babbageEraOnwardsConstraints
-  , babbageEraOnwardsToShelleyBasedEra
   , BabbageEraOnwardsConstraints
   , IsBabbageBasedEra (..)
   )
@@ -138,10 +137,6 @@ babbageEraOnwardsConstraints = \case
   BabbageEraOnwardsBabbage -> id
   BabbageEraOnwardsConway -> id
   BabbageEraOnwardsDijkstra -> const $ error "TODO Dijkstra: babbageEraOnwardsConstraints: era not supported"
-
-{-# DEPRECATED babbageEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
-babbageEraOnwardsToShelleyBasedEra :: BabbageEraOnwards era -> ShelleyBasedEra era
-babbageEraOnwardsToShelleyBasedEra = convert
 
 class IsAlonzoBasedEra era => IsBabbageBasedEra era where
   babbageBasedEra :: BabbageEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
@@ -12,8 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
   ( ConwayEraOnwards (..)
   , conwayEraOnwardsConstraints
-  , conwayEraOnwardsToShelleyBasedEra
-  , conwayEraOnwardsToBabbageEraOnwards
   , ConwayEraOnwardsConstraints
   , IsConwayBasedEra (..)
   )
@@ -146,14 +144,6 @@ conwayEraOnwardsConstraints
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id
   _ -> const $ error "TODO Dijkstra: conwayEraOnwardsConstraints: era not supported"
-
-{-# DEPRECATED conwayEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
-conwayEraOnwardsToShelleyBasedEra :: ConwayEraOnwards era -> ShelleyBasedEra era
-conwayEraOnwardsToShelleyBasedEra = convert
-
-{-# DEPRECATED conwayEraOnwardsToBabbageEraOnwards "Use 'convert' instead." #-}
-conwayEraOnwardsToBabbageEraOnwards :: ConwayEraOnwards era -> BabbageEraOnwards era
-conwayEraOnwardsToBabbageEraOnwards = convert
 
 class IsBabbageBasedEra era => IsConwayBasedEra era where
   conwayBasedEra :: ConwayEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.MaryEraOnwards
   ( MaryEraOnwards (..)
   , maryEraOnwardsConstraints
-  , maryEraOnwardsToShelleyBasedEra
   , MaryEraOnwardsConstraints
   , IsMaryBasedEra (..)
   )
@@ -122,10 +121,6 @@ maryEraOnwardsConstraints = \case
   MaryEraOnwardsBabbage -> id
   MaryEraOnwardsConway -> id
   MaryEraOnwardsDijkstra -> const $ error "TODO Dijkstra: maryEraOnwardsConstraints: era not supported"
-
-{-# DEPRECATED maryEraOnwardsToShelleyBasedEra "Use 'convert' instead." #-}
-maryEraOnwardsToShelleyBasedEra :: MaryEraOnwards era -> ShelleyBasedEra era
-maryEraOnwardsToShelleyBasedEra = convert
 
 class IsAllegraBasedEra era => IsMaryBasedEra era where
   maryBasedEra :: MaryEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyEraOnly.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyEraOnly.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.ShelleyEraOnly
   ( ShelleyEraOnly (..)
   , shelleyEraOnlyConstraints
-  , shelleyEraOnlyToShelleyBasedEra
   , ShelleyEraOnlyConstraints
   )
 where
@@ -109,7 +108,3 @@ shelleyEraOnlyConstraints
   -> a
 shelleyEraOnlyConstraints = \case
   ShelleyEraOnlyShelley -> id
-
-{-# DEPRECATED shelleyEraOnlyToShelleyBasedEra "Use 'convert' instead." #-}
-shelleyEraOnlyToShelleyBasedEra :: ShelleyEraOnly era -> ShelleyBasedEra era
-shelleyEraOnlyToShelleyBasedEra = convert

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToAllegraEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToAllegraEra.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.ShelleyToAllegraEra
   ( ShelleyToAllegraEra (..)
   , shelleyToAllegraEraConstraints
-  , shelleyToAllegraEraToShelleyBasedEra
   , ShelleyToAllegraEraConstraints
   )
 where
@@ -113,7 +112,3 @@ shelleyToAllegraEraConstraints
 shelleyToAllegraEraConstraints = \case
   ShelleyToAllegraEraShelley -> id
   ShelleyToAllegraEraAllegra -> id
-
-{-# DEPRECATED shelleyToAllegraEraToShelleyBasedEra "Use 'convert' instead." #-}
-shelleyToAllegraEraToShelleyBasedEra :: ShelleyToAllegraEra era -> ShelleyBasedEra era
-shelleyToAllegraEraToShelleyBasedEra = convert

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToBabbageEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToBabbageEra.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.ShelleyToBabbageEra
   ( ShelleyToBabbageEra (..)
   , shelleyToBabbageEraConstraints
-  , shelleyToBabbageEraToShelleyBasedEra
   , ShelleyToBabbageEraConstraints
   )
 where
@@ -121,7 +120,3 @@ shelleyToBabbageEraConstraints = \case
   ShelleyToBabbageEraMary -> id
   ShelleyToBabbageEraAlonzo -> id
   ShelleyToBabbageEraBabbage -> id
-
-{-# DEPRECATED shelleyToBabbageEraToShelleyBasedEra "Use 'convert' instead." #-}
-shelleyToBabbageEraToShelleyBasedEra :: ShelleyToBabbageEra era -> ShelleyBasedEra era
-shelleyToBabbageEraToShelleyBasedEra = convert

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToMaryEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyToMaryEra.hs
@@ -12,7 +12,6 @@
 module Cardano.Api.Era.Internal.Eon.ShelleyToMaryEra
   ( ShelleyToMaryEra (..)
   , shelleyToMaryEraConstraints
-  , shelleyToMaryEraToShelleyBasedEra
   , ShelleyToMaryEraConstraints
   )
 where
@@ -114,7 +113,3 @@ shelleyToMaryEraConstraints = \case
   ShelleyToMaryEraShelley -> id
   ShelleyToMaryEraAllegra -> id
   ShelleyToMaryEraMary -> id
-
-{-# DEPRECATED shelleyToMaryEraToShelleyBasedEra "Use 'convert' instead." #-}
-shelleyToMaryEraToShelleyBasedEra :: ShelleyToMaryEra era -> ShelleyBasedEra era
-shelleyToMaryEraToShelleyBasedEra = convert

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -49,8 +49,6 @@ module Cardano.Api.Experimental
   , Some (..)
   , LedgerEra
   , DeprecatedEra (..)
-  , eraToSbe
-  , eraToBabbageEraOnwards
   , sbeToEra
 
     -- ** Witness related

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -29,8 +29,6 @@ module Cardano.Api.Experimental.Era
   , obtainCommonConstraints
   , eraProtVerHigh
   , obtainConwayConstraints
-  , eraToSbe
-  , eraToBabbageEraOnwards
   , sbeToEra
   )
 where
@@ -210,12 +208,6 @@ eraFromStringLike = \case
 -- instance IsEra ConwayEra where
 --   useEra = ConwayEra
 -- @
-{-# DEPRECATED eraToSbe "Use 'convert' instead." #-}
-eraToSbe
-  :: Era era
-  -> ShelleyBasedEra era
-eraToSbe = convert
-
 instance Convert Era Api.CardanoEra where
   convert = \case
     ConwayEra -> Api.ConwayEra
@@ -272,10 +264,6 @@ sbeToEra e@ShelleyBasedEraAlonzo = throwError $ DeprecatedEra e
 sbeToEra e@ShelleyBasedEraMary = throwError $ DeprecatedEra e
 sbeToEra e@ShelleyBasedEraAllegra = throwError $ DeprecatedEra e
 sbeToEra e@ShelleyBasedEraShelley = throwError $ DeprecatedEra e
-
-{-# DEPRECATED eraToBabbageEraOnwards "Use 'convert' instead." #-}
-eraToBabbageEraOnwards :: Era era -> BabbageEraOnwards era
-eraToBabbageEraOnwards = convert
 
 -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Removes 16 deprecated era conversion functions that were all just aliases for `convert` (e.g. `maryEraOnwardsToShelleyBasedEra`, `eraToSbe`, `conwayEraOnwardsToShelleyBasedEra`, etc.)
- Updates the one remaining call site in `gen/Test/Gen/Cardano/Api/Typed.hs` to use `convert` directly
- All removed functions carried a `{-# DEPRECATED ... "Use 'convert' instead." #-}` pragma

## Context

These functions were thin wrappers (`= convert`) that were deprecated in favour of the `Convert` type class. This PR completes that cleanup by removing them entirely.

## How to trust this PR

- Build passes: `cabal build cardano-api -j4`
- No functional changes — every removed function was literally `= convert`, and the one call site has been updated to call `convert` directly

## Checklist

- [x] Build passes
- [x] Changelog fragment added
- [x] Fourmolu formatting applied

# Changelog

```yaml
- description: |
    Remove deprecated era conversion functions that were superseded by 'convert': shelleyToAlonzoEraToShelleyToBabbageEra, alonzoEraOnwardsToMaryEraOnwards, babbageEraOnwardsToMaryEraOnwards, babbageEraOnwardsToAlonzoEraOnwards, eraToSbe, eraToBabbageEraOnwards, shelleyToMaryEraToShelleyBasedEra, conwayEraOnwardsToShelleyBasedEra, conwayEraOnwardsToBabbageEraOnwards, maryEraOnwardsToShelleyBasedEra, babbageEraOnwardsToShelleyBasedEra, shelleyEraOnlyToShelleyBasedEra, alonzoEraOnwardsToShelleyBasedEra, shelleyToBabbageEraToShelleyBasedEra, allegraEraOnwardsToShelleyBasedEra, shelleyToAllegraEraToShelleyBasedEra. Use 'convert' instead.
  type:
   - breaking
  projects:
   - cardano-api
```