### PR TITLE
getLedgerTablesUTxOValues: use getOriginalTxIn instead of coerceMapKeys

### DIFF
--- a/.changes/20260615_getLedgerTablesUTxOValues_use_getOriginalTxIn.yml
+++ b/.changes/20260615_getLedgerTablesUTxOValues_use_getOriginalTxIn.yml
@@ -1,0 +1,9 @@
+project: cardano-api
+
+pr: 1235
+
+kind:
+  - maintenance
+
+description: |
+  In getLedgerTablesUTxOValues, replace coerceMapKeys with Shelley.getOriginalTxIn for TxIn key conversion, removing the Wno-x-ord-preserving-coercions suppression pragma.

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -11,10 +10,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
-
-#if __GLASGOW_HASKELL__ >= 910
-{-# OPTIONS_GHC -Wno-x-ord-preserving-coercions #-}
-#endif
 
 module Cardano.Api.LedgerState
   ( -- * Initialization / Accumulation
@@ -213,7 +208,6 @@ import Ouroboros.Consensus.Shelley.HFEras qualified as Shelley
 import Ouroboros.Consensus.Shelley.Ledger.Block qualified as Shelley
 import Ouroboros.Consensus.Shelley.Ledger.Ledger qualified as Shelley
 import Ouroboros.Consensus.TypeFamilyWrappers (WrapLedgerEvent (WrapLedgerEvent))
-import Ouroboros.Consensus.Util (coerceMapKeys)
 import Ouroboros.Network.Block (blockNo)
 import Ouroboros.Network.Block qualified
 import Ouroboros.Network.Protocol.ChainSync.Client qualified as CS
@@ -2295,7 +2289,7 @@ getLedgerTablesUTxOValues sbe tbs =
       -> Map TxIn (TxOut CtxUTxO era)
     ejectTables idx =
       let Consensus.LedgerTables (Ledger.ValuesMK values) = HFC.ejectLedgerTables idx tbs
-       in Map.mapKeys fromShelleyTxIn $ coerceMapKeys $ Map.map (fromShelleyTxOut sbe) values
+       in Map.mapKeys (fromShelleyTxIn . Shelley.getOriginalTxIn) $ Map.map (fromShelleyTxOut sbe) values
    in
     case sbe of
       ShelleyBasedEraShelley -> ejectTables (IS IZ)


### PR DESCRIPTION
# Context

Replace `coerceMapKeys` with `Shelley.getOriginalTxIn` in `getLedgerTablesUTxOValues`. The previous implementation used `coerceMapKeys` to convert `Shelley.TxIn` map keys, which required suppressing the GHC 9.10+ `-Wno-x-ord-preserving-coercions` warning. Using `getOriginalTxIn` makes the conversion explicit and safe, removing the need for the suppression pragma.

# How to trust this PR

The diff is small — one import removed, one pragma removed, one line changed in `ejectTables`. Verify that `fromShelleyTxIn . Shelley.getOriginalTxIn` does the same thing as `fromShelleyTxIn $ coerceMapKeys` previously did.

```bash
cabal build cardano-api -j4
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`
