### PR TITLE
 Fix non-canonical inline datum JSON round-trip

### DIFF
--- a/.changes/20260625_fix_non_canonical_inline_datum_json_roundtrip.yml
+++ b/.changes/20260625_fix_non_canonical_inline_datum_json_roundtrip.yml
@@ -1,0 +1,7 @@
+project: cardano-api
+pr: 1238
+kind:
+  - bugfix
+description: |
+  FromJSON (TxOut) crashes when parsing a TxOut whose inline datum was encoded with non-canonical CBOR bytes (e.g. definite-length arrays instead of the indefinite-length form Plutus normally emits).
+  

--- a/.changes/20260625_fix_non_canonical_inline_datum_json_roundtrip.yml
+++ b/.changes/20260625_fix_non_canonical_inline_datum_json_roundtrip.yml
@@ -1,0 +1,7 @@
+project: cardano-api
+pr: 1238
+kind:
+  - bugfix
+description: |
+  FromJSON (TxOut) no longer crashes when parsing a TxOut whose inline datum was encoded with non-canonical CBOR bytes (e.g. definite-length arrays instead of the indefinite-length form Plutus normally emits).
+  

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -44,6 +44,7 @@ module Test.Gen.Cardano.Api.Typed
 
     -- * Scripts
   , genHashableScriptData
+  , genNonCanonicalHashableScriptData
   , genReferenceScript
   , genScript
   , genValidScript
@@ -188,7 +189,7 @@ import Data.Int (Int64)
 import Data.Maybe
 import Data.Ratio (Ratio, (%))
 import Data.String
-import Data.Word (Word32, Word64)
+import Data.Word (Word32, Word64, Word8)
 import GHC.Exts (IsList (..))
 import GHC.Stack
 import Numeric.Natural (Natural)
@@ -390,6 +391,26 @@ genHashableScriptData = do
   case deserialiseFromCBOR AsHashableScriptData $ serialiseToCBOR sd of
     Left e -> error $ "genHashableScriptData: " <> show e
     Right r -> return r
+
+-- | Generate 'HashableScriptData' whose CBOR uses a definite-length array
+-- instead of the canonical indefinite-length form that Plutus normally emits.
+-- This means 'hashScriptDataBytes' of the result differs from
+-- 'hashScriptDataBytes' of its canonical re-encoding, exposing any JSON
+-- round-trip that reconstructs CBOR rather than preserving original bytes.
+genNonCanonicalHashableScriptData :: HasCallStack => Gen HashableScriptData
+genNonCanonicalHashableScriptData = do
+  constrIdx <- Gen.integral (Range.linear 0 6 :: Range.Range Int)
+  args <- Gen.list (Range.linear 1 5) (Gen.integral (Range.linear 0 23 :: Range.Range Int))
+  -- Plutus constructor n uses CBOR tag 121+n.
+  -- Canonical encoding wraps fields in an indefinite-length array (0x9f..0xff).
+  -- We use a definite-length array (0x80+len) to produce non-canonical bytes.
+  let tagBytes = [0xd8, fromIntegral (0x79 + constrIdx)] :: [Word8]
+      arrayHdr = [fromIntegral (0x80 + length args)] :: [Word8]
+      argBytes = map fromIntegral args :: [Word8]
+      bytes = BS.pack (tagBytes <> arrayHdr <> argBytes)
+  case deserialiseFromCBOR AsHashableScriptData bytes of
+    Left e -> error $ "genNonCanonicalHashableScriptData: " <> show e
+    Right r -> pure r
 
 {-# DEPRECATED genScriptData "Use genHashableScriptData" #-}
 genScriptData :: Gen ScriptData

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -44,6 +44,7 @@ module Test.Gen.Cardano.Api.Typed
 
     -- * Scripts
   , genHashableScriptData
+  , genNonCanonicalHashableScriptData
   , genReferenceScript
   , genScript
   , genValidScript
@@ -189,7 +190,7 @@ import Data.Int (Int64)
 import Data.Maybe
 import Data.Ratio (Ratio, (%))
 import Data.String
-import Data.Word (Word32, Word64)
+import Data.Word (Word32, Word64, Word8)
 import GHC.Exts (IsList (..))
 import GHC.Stack
 import Numeric.Natural (Natural)
@@ -391,6 +392,26 @@ genHashableScriptData = do
   case deserialiseFromCBOR AsHashableScriptData $ serialiseToCBOR sd of
     Left e -> error $ "genHashableScriptData: " <> show e
     Right r -> return r
+
+-- | Generate 'HashableScriptData' whose CBOR uses a definite-length array
+-- instead of the canonical indefinite-length form that Plutus normally emits.
+-- This means 'hashScriptDataBytes' of the result differs from
+-- 'hashScriptDataBytes' of its canonical re-encoding, exposing any JSON
+-- round-trip that reconstructs CBOR rather than preserving original bytes.
+genNonCanonicalHashableScriptData :: HasCallStack => Gen HashableScriptData
+genNonCanonicalHashableScriptData = do
+  constrIdx <- Gen.integral (Range.linear 0 6 :: Range.Range Int)
+  args <- Gen.list (Range.linear 1 5) (Gen.integral (Range.linear 0 23 :: Range.Range Int))
+  -- Plutus constructor n uses CBOR tag 121+n.
+  -- Canonical encoding wraps fields in an indefinite-length array (0x9f..0xff).
+  -- We use a definite-length array (0x80+len) to produce non-canonical bytes.
+  let tagBytes = [0xd8, fromIntegral (0x79 + constrIdx)] :: [Word8]
+      arrayHdr = [fromIntegral (0x80 + length args)] :: [Word8]
+      argBytes = map fromIntegral args :: [Word8]
+      bytes = BS.pack (tagBytes <> arrayHdr <> argBytes)
+  case deserialiseFromCBOR AsHashableScriptData bytes of
+    Left e -> error $ "genNonCanonicalHashableScriptData: " <> show e -- impossible case: we should always be able to deserialize cbor
+    Right r -> pure r
 
 {-# DEPRECATED genScriptData "Use genHashableScriptData" #-}
 genScriptData :: Gen ScriptData

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -431,6 +431,26 @@ txOutToJsonValue era (TxOut addr val dat refScript) =
       ReferenceScript _ s -> toJSON s
       ReferenceScriptNone -> Aeson.Null
 
+-- | Parse 'HashableScriptData' from a JSON object, preferring the raw CBOR
+-- bytes in @inlineDatumRaw@ when present to preserve non-canonical encodings,
+-- falling back to the supplied parser for JSON that lacks the field.
+parseInlineDatum
+  :: Aeson.Object
+  -> Aeson.Value
+  -> Hash ScriptData
+  -> (Aeson.Value -> Aeson.Parser HashableScriptData)
+  -> Aeson.Parser HashableScriptData
+parseInlineDatum o dVal h fallback = do
+  mRaw <- o .:? "inlineDatumRaw"
+  hashableData <- case mRaw of
+    Just rawHex -> do
+      rawBytes <- either fail pure $ Base16.decode (Text.encodeUtf8 rawHex)
+      either (fail . show) pure $ deserialiseFromCBOR AsHashableScriptData rawBytes
+    Nothing -> fallback dVal
+  if hashScriptDataBytes hashableData /= h
+    then fail "Inline datum not equivalent to inline datum hash"
+    else pure hashableData
+
 instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
   parseJSON = withObject "TxOut" $ \o -> do
     case shelleyBasedEra :: ShelleyBasedEra era of
@@ -462,13 +482,12 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              case scriptDataJsonToHashable ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right hashableData -> do
-                  if hashScriptDataBytes hashableData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataJsonToHashable ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right hsd -> pure hsd
+              return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail
@@ -485,14 +504,13 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsConway sData
+            (Just dVal, Just h) -> do
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right sData -> pure sData
+              return $ TxOutDatumInline BabbageEraOnwardsConway hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail
@@ -509,14 +527,13 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsDijkstra sData
+            (Just dVal, Just h) -> do
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right sData -> pure sData
+              return $ TxOutDatumInline BabbageEraOnwardsDijkstra hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail
@@ -645,13 +662,12 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              case scriptDataJsonToHashable ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right hashableData -> do
-                  if hashScriptDataBytes hashableData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataJsonToHashable ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right hsd -> pure hsd
+              return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail
@@ -669,14 +685,13 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsConway sData
+            (Just dVal, Just h) -> do
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right sData -> pure sData
+              return $ TxOutDatumInline BabbageEraOnwardsConway hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail
@@ -694,14 +709,13 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsDijkstra sData
+            (Just dVal, Just h) -> do
+              hashableData <-
+                parseInlineDatum o dVal h $ \v ->
+                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
+                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+                    Right sData -> pure sData
+              return $ TxOutDatumInline BabbageEraOnwardsDijkstra hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
               fail

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -90,6 +90,7 @@ import Cardano.Ledger.Plutus.Data qualified as Plutus
 import Data.Aeson (object, withObject, (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Aeson
+import Data.Aeson.Text qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString.Base16 qualified as Base16
@@ -98,6 +99,7 @@ import Data.Map.Strict qualified as Map
 import Data.Scientific (toBoundedInteger)
 import Data.Sequence.Strict qualified as Seq
 import Data.Text.Encoding qualified as Text
+import Data.Text.Lazy (unpack)
 import Data.Type.Equality
 import Data.Typeable (Typeable)
 import Data.Word
@@ -433,22 +435,25 @@ txOutToJsonValue era (TxOut addr val dat refScript) =
 
 -- | Parse 'HashableScriptData' from a JSON object, preferring the raw CBOR
 -- bytes in @inlineDatumRaw@ when present to preserve non-canonical encodings,
--- falling back to the supplied parser for JSON that lacks the field.
+-- falling back to the detailed-schema JSON for objects that lack the field.
 parseInlineDatum
   :: Aeson.Object
   -> Aeson.Value
   -> Hash ScriptData
-  -> (Aeson.Value -> Aeson.Parser HashableScriptData)
   -> Aeson.Parser HashableScriptData
-parseInlineDatum o dVal h fallback = do
+parseInlineDatum o dVal h = do
   mRaw <- o .:? "inlineDatumRaw"
   hashableData <- case mRaw of
     Just rawHex -> do
       rawBytes <- either fail pure $ Base16.decode (Text.encodeUtf8 rawHex)
       either (fail . show) pure $ deserialiseFromCBOR AsHashableScriptData rawBytes
-    Nothing -> fallback dVal
+    Nothing ->
+      case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
+        Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+        Right sData -> pure sData
   if hashScriptDataBytes hashableData /= h
-    then fail "Inline datum not equivalent to inline datum hash"
+    then
+      fail $ "Inline datum not equivalent to inline datum hash. " <> unpack (Aeson.encodeToLazyText o)
     else pure hashableData
 
 instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
@@ -482,11 +487,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataJsonToHashable ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right hsd -> pure hsd
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
@@ -505,11 +506,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData -> pure sData
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsConway hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
@@ -528,11 +525,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData -> pure sData
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsDijkstra hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
@@ -662,11 +655,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataJsonToHashable ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right hsd -> pure hsd
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
@@ -686,11 +675,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData -> pure sData
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsConway hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->
@@ -710,11 +695,7 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
         mInlineDatum <-
           case (inlineDatum, inlineDatumHash) of
             (Just dVal, Just h) -> do
-              hashableData <-
-                parseInlineDatum o dVal h $ \v ->
-                  case scriptDataFromJson ScriptDataJsonDetailedSchema v of
-                    Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
-                    Right sData -> pure sData
+              hashableData <- parseInlineDatum o dVal h
               return $ TxOutDatumInline BabbageEraOnwardsDijkstra hashableData
             (Nothing, Nothing) -> return TxOutDatumNone
             (_, _) ->

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -90,6 +90,7 @@ import Cardano.Ledger.Plutus.Data qualified as Plutus
 import Data.Aeson (object, withObject, (.:), (.:?), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Aeson
+import Data.Aeson.Text qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString.Base16 qualified as Base16
@@ -98,6 +99,7 @@ import Data.Map.Strict qualified as Map
 import Data.Scientific (toBoundedInteger)
 import Data.Sequence.Strict qualified as Seq
 import Data.Text.Encoding qualified as Text
+import Data.Text.Lazy (unpack)
 import Data.Type.Equality
 import Data.Typeable (Typeable)
 import Data.Word
@@ -431,6 +433,36 @@ txOutToJsonValue era (TxOut addr val dat refScript) =
       ReferenceScript _ s -> toJSON s
       ReferenceScriptNone -> Aeson.Null
 
+-- | Parse 'HashableScriptData' from a JSON object, preferring the raw CBOR
+-- bytes in @inlineDatumRaw@ when present to preserve non-canonical encodings,
+-- falling back to the detailed-schema JSON for objects that lack the field.
+parseInlineDatum
+  :: Aeson.Object
+  -> Aeson.Parser (Maybe HashableScriptData)
+parseInlineDatum o = do
+  -- We check for the existence of inline datums
+  inlineDatumHash <- o .:? "inlineDatumhash"
+  inlineDatum <- o .:? "inlineDatum"
+  mRaw <- o .:? "inlineDatumRaw"
+  case (inlineDatum, inlineDatumHash) of
+    (Just dVal, Just h) -> do
+      hashableData <- case mRaw of
+        Just rawHex -> do
+          rawBytes <- either fail pure $ Base16.decode (Text.encodeUtf8 rawHex) -- 'inlineDatum' is ignored in this case
+          either (fail . show) pure $ deserialiseFromCBOR AsHashableScriptData rawBytes
+        Nothing ->
+          case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
+            Left err -> fail $ "Error parsing TxOut JSON: " <> displayError err
+            Right sData -> pure sData
+      if hashScriptDataBytes hashableData /= h
+        then
+          fail $ "Inline datum not equivalent to inline datum hash. " <> unpack (Aeson.encodeToLazyText o)
+        else return $ Just hashableData
+    (Nothing, Nothing) -> return Nothing
+    (_, _) ->
+      fail
+        "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+
 instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
   parseJSON = withObject "TxOut" $ \o -> do
     case shelleyBasedEra :: ShelleyBasedEra era of
@@ -456,47 +488,16 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
       ShelleyBasedEraBabbage -> do
         alonzoTxOutInBabbage <- alonzoTxOutParser AlonzoEraOnwardsBabbage o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) -> do
-              case scriptDataJsonToHashable ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right hashableData -> do
-                  if hashScriptDataBytes hashableData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
-
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsBabbage) <$> parseInlineDatum o
         mReferenceScript <- o .:? "referenceScript"
 
         reconcileBabbage alonzoTxOutInBabbage mInlineDatum mReferenceScript
       ShelleyBasedEraConway -> do
         alonzoTxOutInConway <- alonzoTxOutParser AlonzoEraOnwardsConway o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsConway sData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsConway) <$> parseInlineDatum o
 
         mReferenceScript <- o .:? "referenceScript"
 
@@ -504,23 +505,8 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxTx era) where
       ShelleyBasedEraDijkstra -> do
         alonzoTxOutInConway <- alonzoTxOutParser AlonzoEraOnwardsDijkstra o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsDijkstra sData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsDijkstra) <$> parseInlineDatum o
 
         mReferenceScript <- o .:? "referenceScript"
 
@@ -639,23 +625,8 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
       ShelleyBasedEraBabbage -> do
         alonzoTxOutInBabbage <- alonzoTxOutParser AlonzoEraOnwardsBabbage o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) -> do
-              case scriptDataJsonToHashable ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right hashableData -> do
-                  if hashScriptDataBytes hashableData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsBabbage hashableData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsBabbage) <$> parseInlineDatum o
 
         -- We check for a reference script
         mReferenceScript <- o .:? "referenceScript"
@@ -664,23 +635,8 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
       ShelleyBasedEraConway -> do
         alonzoTxOutInConway <- alonzoTxOutParser AlonzoEraOnwardsConway o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsConway sData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsConway) <$> parseInlineDatum o
 
         -- We check for a reference script
         mReferenceScript <- o .:? "referenceScript"
@@ -689,23 +645,8 @@ instance IsShelleyBasedEra era => FromJSON (TxOut CtxUTxO era) where
       ShelleyBasedEraDijkstra -> do
         alonzoTxOutInConway <- alonzoTxOutParser AlonzoEraOnwardsDijkstra o
 
-        -- We check for the existence of inline datums
-        inlineDatumHash <- o .:? "inlineDatumhash"
-        inlineDatum <- o .:? "inlineDatum"
         mInlineDatum <-
-          case (inlineDatum, inlineDatumHash) of
-            (Just dVal, Just h) ->
-              case scriptDataFromJson ScriptDataJsonDetailedSchema dVal of
-                Left err ->
-                  fail $ "Error parsing TxOut JSON: " <> displayError err
-                Right sData ->
-                  if hashScriptDataBytes sData /= h
-                    then fail "Inline datum not equivalent to inline datum hash"
-                    else return $ TxOutDatumInline BabbageEraOnwardsDijkstra sData
-            (Nothing, Nothing) -> return TxOutDatumNone
-            (_, _) ->
-              fail
-                "Should not be possible to create a tx output with either an inline datum hash or an inline datum"
+          maybe TxOutDatumNone (TxOutDatumInline BabbageEraOnwardsDijkstra) <$> parseInlineDatum o
 
         -- We check for a reference script
         mReferenceScript <- o .:? "referenceScript"

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -61,10 +61,14 @@ prop_json_roundtrip_txout_noncanonical_inline_datum = H.property $ do
   hsd <- forAll genNonCanonicalHashableScriptData
   addr <- forAll $ genAddressInEra ShelleyBasedEraConway
   val <- forAll $ genTxOutValue ShelleyBasedEraConway
-  let txOut =
+  let txOutUTxO =
         TxOut addr val (TxOutDatumInline BabbageEraOnwardsConway hsd) ReferenceScriptNone
           :: TxOut CtxUTxO ConwayEra
-  tripping txOut encode eitherDecode
+      txOutTx =
+        TxOut addr val (TxOutDatumInline BabbageEraOnwardsConway hsd) ReferenceScriptNone
+          :: TxOut CtxTx ConwayEra
+  tripping txOutUTxO encode eitherDecode
+  tripping txOutTx encode eitherDecode
 
 prop_json_roundtrip_scriptdata_detailed_json :: Property
 prop_json_roundtrip_scriptdata_detailed_json = H.property $ do

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -54,6 +54,22 @@ prop_json_roundtrip_txout_utxo_context = H.property $ do
   txOut <- forAll $ genTxOutUTxOContext ShelleyBasedEraBabbage
   tripping txOut encode eitherDecode
 
+-- | Round-trips a 'TxOut' whose inline datum uses non-canonical CBOR bytes
+-- (definite-length array instead of the canonical indefinite-length form).
+prop_json_roundtrip_txout_noncanonical_inline_datum :: Property
+prop_json_roundtrip_txout_noncanonical_inline_datum = H.property $ do
+  hsd <- forAll genNonCanonicalHashableScriptData
+  addr <- forAll $ genAddressInEra ShelleyBasedEraConway
+  val <- forAll $ genTxOutValue ShelleyBasedEraConway
+  let txOutUTxO =
+        TxOut addr val (TxOutDatumInline BabbageEraOnwardsConway hsd) ReferenceScriptNone
+          :: TxOut CtxUTxO ConwayEra
+      txOutTx =
+        TxOut addr val (TxOutDatumInline BabbageEraOnwardsConway hsd) ReferenceScriptNone
+          :: TxOut CtxTx ConwayEra
+  tripping txOutUTxO encode eitherDecode
+  tripping txOutTx encode eitherDecode
+
 prop_json_roundtrip_scriptdata_detailed_json :: Property
 prop_json_roundtrip_scriptdata_detailed_json = H.property $ do
   sData <- forAll genHashableScriptData
@@ -131,6 +147,9 @@ tests =
     , testProperty "json roundtrip txoutvalue" prop_json_roundtrip_txoutvalue
     , testProperty "json roundtrip txout tx context" prop_json_roundtrip_txout_tx_context
     , testProperty "json roundtrip txout utxo context" prop_json_roundtrip_txout_utxo_context
+    , testProperty
+        "json roundtrip txout noncanonical inline datum"
+        prop_json_roundtrip_txout_noncanonical_inline_datum
     , testProperty "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
     , testProperty "json roundtrip praos nonce" prop_roundtrip_praos_nonce_JSON
     , testProperty "new TxOut ToJSON matches legacy" prop_new_txout_json_matches_legacy

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -54,6 +54,18 @@ prop_json_roundtrip_txout_utxo_context = H.property $ do
   txOut <- forAll $ genTxOutUTxOContext ShelleyBasedEraBabbage
   tripping txOut encode eitherDecode
 
+-- | Round-trips a 'TxOut' whose inline datum uses non-canonical CBOR bytes
+-- (definite-length array instead of the canonical indefinite-length form).
+prop_json_roundtrip_txout_noncanonical_inline_datum :: Property
+prop_json_roundtrip_txout_noncanonical_inline_datum = H.property $ do
+  hsd <- forAll genNonCanonicalHashableScriptData
+  addr <- forAll $ genAddressInEra ShelleyBasedEraConway
+  val <- forAll $ genTxOutValue ShelleyBasedEraConway
+  let txOut =
+        TxOut addr val (TxOutDatumInline BabbageEraOnwardsConway hsd) ReferenceScriptNone
+          :: TxOut CtxUTxO ConwayEra
+  tripping txOut encode eitherDecode
+
 prop_json_roundtrip_scriptdata_detailed_json :: Property
 prop_json_roundtrip_scriptdata_detailed_json = H.property $ do
   sData <- forAll genHashableScriptData
@@ -131,6 +143,7 @@ tests =
     , testProperty "json roundtrip txoutvalue" prop_json_roundtrip_txoutvalue
     , testProperty "json roundtrip txout tx context" prop_json_roundtrip_txout_tx_context
     , testProperty "json roundtrip txout utxo context" prop_json_roundtrip_txout_utxo_context
+    , testProperty "json roundtrip txout noncanonical inline datum" prop_json_roundtrip_txout_noncanonical_inline_datum
     , testProperty "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
     , testProperty "json roundtrip praos nonce" prop_roundtrip_praos_nonce_JSON
     , testProperty "new TxOut ToJSON matches legacy" prop_new_txout_json_matches_legacy

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Json.hs
@@ -147,7 +147,9 @@ tests =
     , testProperty "json roundtrip txoutvalue" prop_json_roundtrip_txoutvalue
     , testProperty "json roundtrip txout tx context" prop_json_roundtrip_txout_tx_context
     , testProperty "json roundtrip txout utxo context" prop_json_roundtrip_txout_utxo_context
-    , testProperty "json roundtrip txout noncanonical inline datum" prop_json_roundtrip_txout_noncanonical_inline_datum
+    , testProperty
+        "json roundtrip txout noncanonical inline datum"
+        prop_json_roundtrip_txout_noncanonical_inline_datum
     , testProperty "json roundtrip scriptdata detailed json" prop_json_roundtrip_scriptdata_detailed_json
     , testProperty "json roundtrip praos nonce" prop_roundtrip_praos_nonce_JSON
     , testProperty "new TxOut ToJSON matches legacy" prop_new_txout_json_matches_legacy


### PR DESCRIPTION
● Fix non-canonical inline datum JSON round-trip

  Problem

  FromJSON (TxOut) crashes when parsing a TxOut whose inline datum was encoded with non-canonical CBOR bytes (e.g. definite-length arrays instead of the indefinite-length form Plutus normally emits).

  The error:
  "Inline datum not equivalent to inline datum hash"

  This happens because ToJSON and FromJSON disagree on how to reconstruct HashableScriptData:

  - ToJSON serialises the inline datum as three fields:
    - inlineDatum — the human-readable JSON representation
    - inlineDatumhash — blake2b_256(originalCborBytes)
    - inlineDatumRaw — the original CBOR bytes as hex
  - FromJSON ignored inlineDatumRaw entirely and reconstructed HashableScriptData via scriptDataFromJson, which always re-serialises to canonical CBOR. For non-canonical original bytes:
    - H(canonical) ≠ H(original) = inlineDatumhash
    - → parse fails with the above error

  Non-canonical Plutus CBOR is valid and accepted by the ledger. It arises when scripts use definite-length array encoding for constructor fields instead of the canonical indefinite-length form. Any node that stores such a UTxO entry and later replays it from a JSON snapshot (e.g. from a SQLite event log) would crash on
  deserialisation.

  Fix

  inlineDatumRaw is always present in JSON produced by ToJSON (as null for non-inline outputs, as hex for inline ones). FromJSON now reads this field first and uses deserialiseFromCBOR AsHashableScriptData to reconstruct HashableScriptData with the original bytes preserved. The scriptDataFromJson path is kept as a fallback for JSON
  produced by external tools or older versions that may not include inlineDatumRaw.

  The fix is applied to all six affected sites: Babbage, Conway, and Dijkstra eras in both FromJSON (TxOut CtxTx era) and FromJSON (TxOut CtxUTxO era). The repeated logic is extracted into a parseInlineDatum helper.

  Testing

  Added prop_json_roundtrip_txout_noncanonical_inline_datum — a property test that generates a TxOut with a non-canonical inline datum (definite-length CBOR constructor) and asserts the JSON round-trip is identity. The test fails without the fix and passes with it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
