### PR TITLE
cardano-wasm: base16-decode certificate CBOR before deserialising

### DIFF
--- a/.changes/20260630_025611_cardano-wasm_pablo.lamela_fix_stake_certs_deserialisation_wasm.yml
+++ b/.changes/20260630_025611_cardano-wasm_pablo.lamela_fix_stake_certs_deserialisation_wasm.yml
@@ -1,0 +1,6 @@
+description: Fixed `appendCertificateTx` to decode base16 and not assume it gets CBOR
+  directly.
+kind:
+- bugfix
+pr: 1239
+project: cardano-wasm

--- a/cardano-wasm/src-lib/Cardano/Wasm/Api/Tx.hs
+++ b/cardano-wasm/src-lib/Cardano/Wasm/Api/Tx.hs
@@ -41,6 +41,7 @@ import Control.Monad.Catch (MonadThrow)
 import Data.Aeson (ToJSON (toJSON), (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Types qualified as Aeson
+import Data.ByteString.Base16 qualified as Base16
 import Data.Sequence.Strict qualified as StrictSeq
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -137,9 +138,9 @@ appendCertificateToTxImpl (UnsignedTxObject era (Exp.UnsignedTx tx)) certCbor = 
   deserialiseCertificate
     :: (HasCallStack, MonadThrow m) => Exp.Era era -> String -> m (Exp.Certificate (Exp.LedgerEra era))
   deserialiseCertificate era' certCbor' =
-    obtainCommonConstraints era' $
-      rightOrError $
-        Api.deserialiseFromCBOR Exp.AsCertificate (Text.encodeUtf8 $ Text.pack certCbor')
+    obtainCommonConstraints era' $ do
+      rawCbor <- rightOrError $ Base16.decode (Text.encodeUtf8 $ Text.pack certCbor')
+      rightOrError $ Api.deserialiseFromCBOR Exp.AsCertificate rawCbor
 
 -- | Set the fee for an unsigned transaction object.
 setFeeImpl :: UnsignedTxObject -> Ledger.Coin -> UnsignedTxObject


### PR DESCRIPTION
# Context

Stake certificates couldn't be attached to a transaction in `cardano-wasm`. The producer and consumer disagreed on the certificate string encoding:

- The makers (`makeStakeAddress{Registration,StakeDelegation,Unregistration}Certificate` return the cert as a **base16 CBOR hex string** — as documented in the `.d.ts`.
- `appendCertificateToTx` fed those **raw hex characters** straight into the CBOR decoder *without base16-decoding first*.

So certificates were unusable end-to-end, in both mainnet and upcoming eras.

# The fix

One line in `deserialiseCertificate` (`cardano-wasm/src-lib/Cardano/Wasm/Api/Tx.hs`): base16-decode the input before `deserialiseFromCBOR`.

- Matches the documented `"CBOR hex string"` contract that both the makers and `appendCertificateToTx` already advertise — so **no maker or `.d.ts` changes** needed.

# How to trust this PR

It is a pretty small change.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
