### PR TITLE
cardano-wasm: add address validation and network detection (inspectAddress)

### DIFF
--- a/.changes/20260708_130000_cardano-wasm_pablo.lamela_inspect_address.yml
+++ b/.changes/20260708_130000_cardano-wasm_pablo.lamela_inspect_address.yml
@@ -1,0 +1,5 @@
+description: Added `inspectAddress` to the `cardano-wasm` API, which checks whether a string is a valid Shelley-era address. It resolves to an object with the `network` the address belongs to ("mainnet" or "testnet"), or to `null` if the address is invalid, and it never throws. This lets consumers reject mistyped recipients and mainnet/testnet mismatches at entry time, instead of failing at node submission. Note that an address cannot distinguish between different testnets (like preprod and preview), as they only differ in the network magic, which is not part of the address.
+kind:
+- feature
+pr: 1244
+project: cardano-wasm

--- a/cardano-wasm/cardano-wasm.cabal
+++ b/cardano-wasm/cardano-wasm.cabal
@@ -30,6 +30,7 @@ library cardano-wasi-lib
     src-lib
 
   exposed-modules:
+    Cardano.Wasm.Api.Address
     Cardano.Wasm.Api.Certificate.StakeCertificate
     Cardano.Wasm.Api.GRPC
     Cardano.Wasm.Api.Info
@@ -80,8 +81,9 @@ executable cardano-wasi
   if arch(wasm32)
     ghc-options:
       -no-hs-main
-      "-optl-Wl,--strip-all,--export=hs_init,--export=newTx,--export=newUpcomingEraTx,--export=addTxInput,--export=addSimpleTxOut,--export=appendCertificateToTx,--export=setFee,--export=estimateMinFee,--export=signWithPaymentKey,--export=signWithStakeKey,--export=getUnsignedTxId,--export=alsoSignWithPaymentKey,--export=alsoSignWithStakeKey,--export=toCbor,--export=getSignedTxId,--export=makeStakeAddressStakeDelegationCertificate,--export=makeStakeAddressStakeDelegationCertificateUpcomingEra,--export=makeStakeAddressRegistrationCertificate,--export=makeStakeAddressRegistrationCertificateUpcomingEra,--export=makeStakeAddressUnregistrationCertificate,--export=makeStakeAddressUnregistrationCertificateUpcomingEra,--export=generatePaymentWallet,--export=generateStakeWallet,--export=restorePaymentWalletFromSigningKeyBech32,--export=restoreStakeWalletFromSigningKeyBech32,--export=generateTestnetPaymentWallet,--export=generateTestnetStakeWallet,--export=restoreTestnetPaymentWalletFromSigningKeyBech32,--export=restoreTestnetStakeWalletFromSigningKeyBech32,--export=getAddressBech32,--export=getBech32ForPaymentVerificationKey,--export=getBech32ForPaymentSigningKey,--export=getBech32ForStakeVerificationKey,--export=getBech32ForStakeSigningKey,--export=getBase16ForPaymentVerificationKeyHash,--export=getBase16ForStakeVerificationKeyHash,--export=mallocNBytes,--export=getStrLen,--export=freeMemory"
+      "-optl-Wl,--strip-all,--export=hs_init,--export=newTx,--export=newUpcomingEraTx,--export=addTxInput,--export=addSimpleTxOut,--export=appendCertificateToTx,--export=setFee,--export=estimateMinFee,--export=signWithPaymentKey,--export=signWithStakeKey,--export=getUnsignedTxId,--export=alsoSignWithPaymentKey,--export=alsoSignWithStakeKey,--export=toCbor,--export=getSignedTxId,--export=inspectAddress,--export=makeStakeAddressStakeDelegationCertificate,--export=makeStakeAddressStakeDelegationCertificateUpcomingEra,--export=makeStakeAddressRegistrationCertificate,--export=makeStakeAddressRegistrationCertificateUpcomingEra,--export=makeStakeAddressUnregistrationCertificate,--export=makeStakeAddressUnregistrationCertificateUpcomingEra,--export=generatePaymentWallet,--export=generateStakeWallet,--export=restorePaymentWalletFromSigningKeyBech32,--export=restoreStakeWalletFromSigningKeyBech32,--export=generateTestnetPaymentWallet,--export=generateTestnetStakeWallet,--export=restoreTestnetPaymentWalletFromSigningKeyBech32,--export=restoreTestnetStakeWalletFromSigningKeyBech32,--export=getAddressBech32,--export=getBech32ForPaymentVerificationKey,--export=getBech32ForPaymentSigningKey,--export=getBech32ForStakeVerificationKey,--export=getBech32ForStakeSigningKey,--export=getBase16ForPaymentVerificationKeyHash,--export=getBase16ForStakeVerificationKeyHash,--export=mallocNBytes,--export=getStrLen,--export=freeMemory"
   other-modules:
+    Cardano.Wasi.Internal.Api.Address
     Cardano.Wasi.Internal.Api.Certificate.StakeCertificate
     Cardano.Wasi.Internal.Api.GRPC
     Cardano.Wasi.Internal.Api.Memory

--- a/cardano-wasm/js-test/basic-test.golden
+++ b/cardano-wasm/js-test/basic-test.golden
@@ -2,6 +2,7 @@
 > [object] {
     objectType: cardano-api
     tx: [object Object]
+    inspectAddress: async function (...args) 
     newGrpcConnection: async function (...args) 
     certificate: [object Object]
     wallet: [object Object]

--- a/cardano-wasm/lib-wrapper/cardano-api.d.ts
+++ b/cardano-wasm/lib-wrapper/cardano-api.d.ts
@@ -41,6 +41,13 @@ declare interface CardanoApi {
     }
 
     /**
+     * Check whether a string is a valid Shelley-era address (like "addr..." or "addr_test...") and, if it is, get which network it belongs to. It never throws: for invalid addresses it resolves to `null`. Note that an address only encodes whether it belongs to mainnet or a testnet: it is not possible to tell different testnets (like preprod and preview) apart from an address alone, because they only differ in the network magic, which is not part of the address.
+     * @param address The address to inspect.
+     * @returns A promise that resolves to an object with the `network` the address belongs to ("mainnet" or "testnet"), or to `null` if the string is not a valid address.
+     */
+    inspectAddress(address: string): Promise<{ network: "mainnet" | "testnet" } | null>;
+
+    /**
      * Create a new client connection for communicating with a Cardano node through gRPC-web.
      * @param webGrpcUrl The URL of the gRPC-web server.
      * @returns A promise that resolves to a new `GrpcConnection`.

--- a/cardano-wasm/npm-wrapper/api.test.js
+++ b/cardano-wasm/npm-wrapper/api.test.js
@@ -154,4 +154,32 @@ describe('Cardano API', () => {
         expect(txCbor).toBe("84a400d9010281825820be6efd42a3d7b9a00d09d77a5d41e55ceaf0bd093a8aa8a893ce70d9caafd97800018182581d6082935e44937e8b530f32ce672b5d600d0a286b4e8a52c6555f659b871a004c4b400219271004d901028183028200581ca9461e687627cddc5f54ffc988bc44321189538c601f1ad1b7979d9b581cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbba100d9010282825820adfc1c30385916da87db1ba3328f0690a57ebb2a6ac9f6f86b2d97f943adae005840b5df44de4b1302d1b031363cfb9636be2f395561dcf083d1192656677506bfa401d988d745f2ee2d11ed9e563f35cc2dfbb605c7cd58a613e42377e5e2a8da01825820ee31f83c88a71219a6fcf9bee0da9bc22620588f5a15a6145553504df9649e5c58402a2a37f2391bdf3a1ff52a7ed2103473f35b43022ed101bddcb18a557f7e9f9eac75c3562b142cc15dc9ebd006da34f4076ff413914ec90e4359d757d73bfc06f5f6");
     });
 
+    // An address only encodes mainnet vs testnet (network id 1 vs 0). Different
+    // testnets (like preprod and preview) only differ by network magic, which is
+    // not part of the address, so they cannot be told apart here.
+    it('should validate addresses and detect their network', async () => {
+        // Payment-only (enterprise) and base (payment + stake) addresses, built
+        // from the payment and stake key hashes used in the other tests
+        const testnetAddress = "addr_test1vzpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpcue4v2v";
+        const mainnetAddress = "addr1vxpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpc83ps9f";
+        const testnetBaseAddress = "addr_test1qzpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpafgc0xsa38ehw9748lexytc3pjzxy48rrqruddrduhnkdssekpmc";
+        const mainnetBaseAddress = "addr1qxpfxhjyjdlgk5c0xt8xw26avqxs52rtf69993j4tajehpafgc0xsa38ehw9748lexytc3pjzxy48rrqruddrduhnkdsn0tph8";
+
+        expect(await api.inspectAddress(testnetAddress)).toEqual({ network: "testnet" });
+        expect(await api.inspectAddress(testnetBaseAddress)).toEqual({ network: "testnet" });
+        expect(await api.inspectAddress(mainnetAddress)).toEqual({ network: "mainnet" });
+        expect(await api.inspectAddress(mainnetBaseAddress)).toEqual({ network: "mainnet" });
+
+        // Invalid inputs do not throw, they resolve to null instead
+        const invalidAddresses = [
+            "",                                // empty
+            testnetAddress.slice(0, -1),       // truncated
+            testnetAddress.slice(0, -1) + "w", // bad checksum
+            "this is not an address",          // not an address at all
+        ];
+        for (const address of invalidAddresses) {
+            expect(await api.inspectAddress(address)).toBeNull();
+        }
+    });
+
 });

--- a/cardano-wasm/src-lib/Cardano/Wasm/Api/Address.hs
+++ b/cardano-wasm/src-lib/Cardano/Wasm/Api/Address.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MonoLocalBinds #-}
+
+module Cardano.Wasm.Api.Address
+  ( AddressInfo (..)
+  , inspectAddressImpl
+  )
+where
+
+import Cardano.Api qualified as Api
+import Cardano.Api.Ledger qualified as Ledger
+
+import Data.Aeson (ToJSON (toJSON), (.=))
+import Data.Aeson qualified as Aeson
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+-- | Information about a valid address, as returned by 'inspectAddressImpl'.
+newtype AddressInfo = AddressInfo
+  { addressNetwork :: Ledger.Network
+  -- ^ The network the address belongs to.
+  }
+  deriving (Show, Eq)
+
+instance ToJSON AddressInfo where
+  toJSON :: AddressInfo -> Aeson.Value
+  toJSON (AddressInfo network) =
+    Aeson.object
+      [ "network"
+          .= case network of
+            Ledger.Mainnet -> "mainnet" :: Text
+            Ledger.Testnet -> "testnet"
+      ]
+
+-- | Inspect an address given as a string. If the address is a well-formed
+-- Shelley-era address (bech32, like @addr...@ or @addr_test...@), it returns
+-- information about the address: currently, the network it belongs to.
+-- Otherwise it returns 'Nothing' (serialised as @null@ in the JavaScript
+-- API). It never throws.
+--
+-- Note that an address only encodes whether it belongs to mainnet or a
+-- testnet: it is not possible to distinguish between different testnets
+-- (like preprod and preview) from an address alone, because they only differ
+-- in the network magic, which is not part of the address.
+inspectAddressImpl :: String -> Maybe AddressInfo
+inspectAddressImpl addrStr =
+  case Api.deserialiseAddress (Api.AsAddress Api.AsShelleyAddr) (Text.pack addrStr) of
+    Just (Api.ShelleyAddress network _ _) -> Just (AddressInfo network)
+    Nothing -> Nothing

--- a/cardano-wasm/src-lib/Cardano/Wasm/Api/Info.hs
+++ b/cardano-wasm/src-lib/Cardano/Wasm/Api/Info.hs
@@ -34,6 +34,7 @@ data TSType
   | TSAny
   | TSUtxoList
   | TSUtxosForAddressList
+  | TSAddressInfo
   deriving (Show, Eq)
 
 tsTypeAsString :: TSType -> String
@@ -45,6 +46,7 @@ tsTypeAsString TSUtxoList =
   "{ address: string, txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
 tsTypeAsString TSUtxosForAddressList =
   "{ txId: string, txIndex: number, lovelace: bigint, assets: any[], datum?: any, script?: any }[]"
+tsTypeAsString TSAddressInfo = "{ network: \"mainnet\" | \"testnet\" } | null"
 
 instance Aeson.ToJSON TSType where
   toJSON :: TSType -> Aeson.Value
@@ -536,6 +538,17 @@ apiInfo =
                                   , methodReturnDoc = "A promise that resolves to a new `UnsignedTx` object."
                                   }
                             ]
+                        }
+                  , MethodInfoEntry $
+                      MethodInfo
+                        { methodName = "inspectAddress"
+                        , methodSimpleName = Nothing
+                        , methodDoc =
+                            "Check whether a string is a valid Shelley-era address (like \"addr...\" or \"addr_test...\") and, if it is, get which network it belongs to. It never throws: for invalid addresses it resolves to `null`. Note that an address only encodes whether it belongs to mainnet or a testnet: it is not possible to tell different testnets (like preprod and preview) apart from an address alone, because they only differ in the network magic, which is not part of the address."
+                        , methodParams = [ParamInfo "address" TSString "The address to inspect."]
+                        , methodReturnType = OtherType TSAddressInfo
+                        , methodReturnDoc =
+                            "A promise that resolves to an object with the `network` the address belongs to (\"mainnet\" or \"testnet\"), or to `null` if the string is not a valid address."
                         }
                   , MethodInfoEntry $
                       MethodInfo

--- a/cardano-wasm/src-wasi/Cardano/Wasi/Internal/Api/Address.hs
+++ b/cardano-wasm/src-wasi/Cardano/Wasi/Internal/Api/Address.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+
+module Cardano.Wasi.Internal.Api.Address
+  ( inspectAddress
+  )
+where
+
+import Cardano.Wasi.Internal.Conversion (toCJSON)
+import Cardano.Wasm.Api.Address qualified as Address
+
+import Foreign.C (CString)
+import Foreign.C.String (peekCString)
+
+-- * Address inspection
+
+#if defined(wasm32_HOST_ARCH)
+
+foreign export ccall "inspectAddress"
+  inspectAddress :: CString -> IO AddressInfoJSON
+
+#endif
+
+type AddressInfoJSON = CString
+
+inspectAddress :: CString -> IO AddressInfoJSON
+inspectAddress address =
+  toCJSON . Address.inspectAddressImpl
+    =<< peekCString address

--- a/cardano-wasm/src-wasm/Cardano/Wasm/Internal/JavaScript/Bridge.hs
+++ b/cardano-wasm/src-wasm/Cardano/Wasm/Internal/JavaScript/Bridge.hs
@@ -16,6 +16,7 @@ module Cardano.Wasm.Internal.JavaScript.Bridge where
 import Cardano.Api qualified as Api
 import Cardano.Api.Ledger qualified as Ledger
 
+import Cardano.Wasm.Api.Address qualified as Wasm
 import Cardano.Wasm.Api.Certificate.StakeCertificate qualified as Wasm
 import Cardano.Wasm.Api.GRPC qualified as Wasm
 import Cardano.Wasm.Api.Info (apiInfo)
@@ -129,6 +130,8 @@ type JSCoin = JSVal
 type JSSigningKey = JSString
 
 type JSProtocolParams = JSVal
+
+type JSAddressInfo = JSVal
 
 type JSGrpc = JSGRPCClient
 
@@ -623,6 +626,16 @@ getUtxosForAddress grpcObject address =
 -- | Submit a transaction to the Cardano Node using GRPC-web.
 submitTx :: HasCallStack => JSGrpc -> JSString -> IO JSString
 submitTx grpcObject tx = toJSVal =<< join (Wasm.submitTxImpl js_submitTx <$> fromJSVal grpcObject <*> fromJSVal tx)
+
+-- * Address inspection
+
+foreign export javascript "inspectAddress"
+  inspectAddress :: JSString -> IO JSAddressInfo
+
+-- | Check whether a string is a valid Shelley-era address and which network it belongs to.
+inspectAddress :: HasCallStack => JSString -> IO JSAddressInfo
+inspectAddress jsAddress =
+  toJSVal . Wasm.inspectAddressImpl =<< fromJSVal jsAddress
 
 -- * API Information
 


### PR DESCRIPTION
# Context

Adds an `inspectAddress(address)` method to the main `CardanoApi` object. For a valid Shelley-era address it resolves to an object with the network the address belongs to (`{ network: "mainnet" | "testnet" }`); for invalid input it resolves to `null`. It never throws.

Motivation: `addSimpleTxOut` accepts any string, so a typo or a mainnet/testnet mix-up currently only fails at node submission, with an opaque error far from where the user entered the address. This lets apps validate addresses at entry time.

Note that an address only encodes mainnet vs testnet: different testnets (like preprod and preview) only differ by network magic, which is not part of the address, so they cannot be told apart.

# How to trust this PR

- The core logic is `inspectAddressImpl` in the new `cardano-wasm/src-lib/Cardano/Wasm/Api/Address.hs`: a thin wrapper over `deserialiseAddress` for Shelley-era addresses, reading the network from the address header. Everything else is the usual plumbing (WASI and JS bridge exports, API metadata in `Info.hs`, TypeScript typings, golden file).
- The new test in `cardano-wasm/npm-wrapper/api.test.js` covers mainnet and testnet, enterprise and base addresses, and invalid inputs (empty, truncated, bad checksum, garbage). It runs in the WASM CI job, or locally with `npm test` in `cardano-wasm/npm-wrapper`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`