### PR TITLE
Add readAnyScriptBytes and readFileAnyScript to the experimental API

### DIFF
--- a/.changes/20260708_add_read_any_script.yml
+++ b/.changes/20260708_add_read_any_script.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1245
+kind:
+  - feature
+description: |
+  Add `readAnyScriptBytes` and `readFileAnyScript` to the experimental API, decoding an `AnyScript` from a text envelope (simple or Plutus script CBOR) with a fallback to the legacy JSON simple script encoding. Introduce `AnyScriptDecodeError` for the JSON and CBOR failure cases.

--- a/cardano-api/src/Cardano/Api/Experimental.hs
+++ b/cardano-api/src/Cardano/Api/Experimental.hs
@@ -61,9 +61,12 @@ module Cardano.Api.Experimental
 
     -- ** AnyScript related
   , AnyScript (..)
+  , AnyScriptDecodeError (..)
   , deserialiseAnyPlutusScriptOfLanguage
   , deserialiseAnySimpleScript
   , hashAnyScript
+  , readAnyScriptBytes
+  , readFileAnyScript
 
     -- ** Simple script related
   , SimpleScript (..)
@@ -72,6 +75,7 @@ module Cardano.Api.Experimental
   , hashSimpleScript
 
     -- ** Plutus related
+  , AnyPlutusScriptLanguage (..)
   , PlutusScriptInEra (..)
   , PlutusScriptOrReferenceInput (..)
   , serialiseAnyPlutusScriptToTextEnvelope

--- a/cardano-api/src/Cardano/Api/Experimental/AnyScript.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/AnyScript.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -10,26 +11,46 @@
 module Cardano.Api.Experimental.AnyScript
   ( AnyScript (..)
   , AsType (..)
+  , AnyScriptDecodeError (..)
   , deserialiseAnyPlutusScriptOfLanguage
   , deserialiseAnySimpleScript
   , hashAnyScript
+  , readAnyScriptBytes
+  , readFileAnyScript
   )
 where
 
+import Cardano.Api.Error (Error (..), FileError (..), fileIOExceptT)
 import Cardano.Api.Experimental.Era
 import Cardano.Api.Experimental.Plutus.Internal.Script hiding (AnyPlutusScript)
+import Cardano.Api.Experimental.Plutus.Internal.Script qualified as PlutusScript
 import Cardano.Api.Experimental.Simple.Script
 import Cardano.Api.HasTypeProxy
+import Cardano.Api.IO (File (..), FileDirection (In), readFileBlocking)
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
+import Cardano.Api.Plutus.Internal.Script (toAllegraTimelock)
+import Cardano.Api.Plutus.Internal.Script qualified as OldScript
+  ( AsType (AsScript, AsSimpleScript)
+  , SimpleScript
+  )
+import Cardano.Api.Pretty (pretty, vsep, (<+>))
 import Cardano.Api.Serialise.Cbor
+import Cardano.Api.Serialise.Json (JsonDecodeError (..), deserialiseFromJSON)
+import Cardano.Api.Serialise.TextEnvelope (TextEnvelope (..), TextEnvelopeType (..))
+import Cardano.Api.Serialise.TextEnvelope.Internal (textEnvelopeType)
 
 import Cardano.Ledger.Binary qualified as CBOR
 import Cardano.Ledger.Core qualified as L
 import Cardano.Ledger.Plutus.Language qualified as Plutus
 
+import Control.Monad.Trans.Except (runExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
+import Data.Bifunctor (bimap)
+import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Either.Combinators (maybeToRight, rightToMaybe)
 import Data.Foldable (asum)
+import Data.Text qualified as Text
 import Data.Type.Equality ((:~:) (..))
 import Data.Typeable (Typeable, eqT)
 
@@ -111,3 +132,92 @@ deserialiseAnyPlutusScriptOfLanguage bs lang = do
   s :: (PlutusScriptInEra lang (LedgerEra era)) <-
     obtainCommonConstraints (useEra @era) (deserialisePlutusScriptInEra lang bs)
   return $ AnyPlutusScript s
+
+data AnyScriptDecodeError
+  = -- | A text envelope was decoded, but its Plutus CBOR payload could not be.
+    AnyScriptPlutusCborError AnyPlutusScriptLanguage CBOR.DecoderError
+  | -- | A text envelope was decoded, but its simple-script CBOR payload could not be.
+    AnyScriptSimpleCborError CBOR.DecoderError
+  | -- | The input could not be decoded as a text envelope, nor as a simple
+    -- script. Both failures are retained so the caller can see why each format
+    -- was rejected.
+    AnyScriptJsonError
+      JsonDecodeError
+      -- ^ Why the input could not be decoded as a text envelope.
+      JsonDecodeError
+      -- ^ Why the input could not be decoded as a simple script.
+  | -- | The text envelope's type is not a recognised script type.
+    AnyScriptUnknownTextEnvelopeType TextEnvelopeType
+  deriving Show
+
+instance Error AnyScriptDecodeError where
+  prettyError (AnyScriptPlutusCborError lang e) =
+    "Failed to decode Plutus script ("
+      <> pretty (plutusLanguageToText lang)
+      <> ") CBOR:"
+        <+> prettyError e
+  prettyError (AnyScriptSimpleCborError e) =
+    "Failed to decode simple script CBOR:" <+> prettyError e
+  prettyError (AnyScriptJsonError teErr simpleErr) =
+    vsep
+      [ "Input could not be decoded as a text envelope, nor as a simple script."
+      , "As a text envelope:" <+> prettyError teErr
+      , "As a simple script:" <+> prettyError simpleErr
+      ]
+  prettyError (AnyScriptUnknownTextEnvelopeType (TextEnvelopeType t)) =
+    "Unrecognised script text envelope type:" <+> pretty t
+
+-- | The text envelope type used by simple scripts, read from the canonical
+-- 'HasTextEnvelope' instance so it stays in step with the type that producers
+-- emit rather than duplicating the string.
+simpleScriptTextEnvelopeType :: TextEnvelopeType
+simpleScriptTextEnvelopeType =
+  textEnvelopeType (OldScript.AsScript OldScript.AsSimpleScript)
+
+-- | Decode an 'AnyScript' from its serialised form: a text envelope wrapping
+-- the CBOR encoding of either a simple or a Plutus script, or (as a fallback)
+-- the legacy JSON-only encoding of a simple script.
+readAnyScriptBytes
+  :: forall era
+   . Era era
+  -> ByteString
+  -> Either AnyScriptDecodeError (AnyScript (LedgerEra era))
+readAnyScriptBytes era bs =
+  case deserialiseFromJSON bs :: Either JsonDecodeError TextEnvelope of
+    Right te ->
+      let scriptBs = teRawCBOR te
+          TextEnvelopeType anyScriptType = teType te
+       in case textToPlutusLanguage (Text.pack anyScriptType) of
+            Just lang ->
+              case obtainCommonConstraints era $
+                     decodeAnyPlutusScript @(LedgerEra era) scriptBs lang
+                     :: Either CBOR.DecoderError (PlutusScript.AnyPlutusScript (LedgerEra era)) of
+                Left e -> Left (AnyScriptPlutusCborError lang e)
+                Right (PlutusScript.AnyPlutusScript ps) -> Right (AnyPlutusScript ps)
+            Nothing
+              | teType te == simpleScriptTextEnvelopeType ->
+                  bimap AnyScriptSimpleCborError AnySimpleScript $
+                    obtainCommonConstraints era (deserialiseSimpleScript scriptBs)
+              | otherwise ->
+                  Left (AnyScriptUnknownTextEnvelopeType (teType te))
+    Left teErr ->
+      case deserialiseFromJSON bs :: Either JsonDecodeError OldScript.SimpleScript of
+        Left e -> Left (AnyScriptJsonError teErr e)
+        Right script ->
+          case era of
+            DijkstraEra -> error "TODO Dijkstra: Simple script not supported"
+            ConwayEra ->
+              obtainConwayConstraints era $
+                Right . AnySimpleScript . SimpleScript $
+                  toAllegraTimelock script
+
+readFileAnyScript
+  :: Era era
+  -> File content In
+  -> IO (Either (FileError AnyScriptDecodeError) (AnyScript (LedgerEra era)))
+readFileAnyScript era path =
+  runExceptT $ do
+    content <- fileIOExceptT (unFile path) readFileBlocking
+    firstExceptT (FileError (unFile path)) $
+      hoistEither $
+        readAnyScriptBytes era content

--- a/cardano-api/src/Cardano/Api/Experimental/AnyScript.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/AnyScript.hs
@@ -45,7 +45,7 @@ import Cardano.Ledger.Plutus.Language qualified as Plutus
 
 import Control.Monad.Trans.Except (runExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
-import Data.Bifunctor (bimap)
+import Data.Bifunctor (bimap, first)
 import Data.ByteString (ByteString)
 import Data.ByteString qualified as BS
 import Data.Either.Combinators (maybeToRight, rightToMaybe)
@@ -176,7 +176,7 @@ simpleScriptTextEnvelopeType =
 
 -- | Decode an 'AnyScript' from its serialised form: a text envelope wrapping
 -- the CBOR encoding of either a simple or a Plutus script, or (as a fallback)
--- the legacy JSON-only encoding of a simple script.
+-- the JSON-only encoding of a simple script.
 readAnyScriptBytes
   :: forall era
    . Era era
@@ -184,32 +184,48 @@ readAnyScriptBytes
   -> Either AnyScriptDecodeError (AnyScript (LedgerEra era))
 readAnyScriptBytes era bs =
   case deserialiseFromJSON bs :: Either JsonDecodeError TextEnvelope of
-    Right te ->
-      let scriptBs = teRawCBOR te
-          TextEnvelopeType anyScriptType = teType te
-       in case textToPlutusLanguage (Text.pack anyScriptType) of
-            Just lang ->
-              case obtainCommonConstraints era $
-                     decodeAnyPlutusScript @(LedgerEra era) scriptBs lang
-                     :: Either CBOR.DecoderError (PlutusScript.AnyPlutusScript (LedgerEra era)) of
-                Left e -> Left (AnyScriptPlutusCborError lang e)
-                Right (PlutusScript.AnyPlutusScript ps) -> Right (AnyPlutusScript ps)
-            Nothing
-              | teType te == simpleScriptTextEnvelopeType ->
-                  bimap AnyScriptSimpleCborError AnySimpleScript $
-                    obtainCommonConstraints era (deserialiseSimpleScript scriptBs)
-              | otherwise ->
-                  Left (AnyScriptUnknownTextEnvelopeType (teType te))
-    Left teErr ->
-      case deserialiseFromJSON bs :: Either JsonDecodeError OldScript.SimpleScript of
-        Left e -> Left (AnyScriptJsonError teErr e)
-        Right script ->
-          case era of
-            DijkstraEra -> error "TODO Dijkstra: Simple script not supported"
-            ConwayEra ->
-              obtainConwayConstraints era $
-                Right . AnySimpleScript . SimpleScript $
-                  toAllegraTimelock script
+    Right te -> readTextEnvelopeScript era te
+    Left teErr -> first (AnyScriptJsonError teErr) (readSimpleScriptFromJson era bs)
+
+-- | Decode an 'AnyScript' from a text envelope, selecting the Plutus or simple
+-- script CBOR decoder from the envelope type, and rejecting envelope types that
+-- are not scripts.
+readTextEnvelopeScript
+  :: forall era
+   . Era era
+  -> TextEnvelope
+  -> Either AnyScriptDecodeError (AnyScript (LedgerEra era))
+readTextEnvelopeScript era te =
+  let scriptBs = teRawCBOR te
+      TextEnvelopeType anyScriptType = teType te
+   in case textToPlutusLanguage (Text.pack anyScriptType) of
+        Just lang ->
+          case obtainCommonConstraints era $
+                 decodeAnyPlutusScript @(LedgerEra era) scriptBs lang
+                 :: Either CBOR.DecoderError (PlutusScript.AnyPlutusScript (LedgerEra era)) of
+            Left e -> Left (AnyScriptPlutusCborError lang e)
+            Right (PlutusScript.AnyPlutusScript ps) -> Right (AnyPlutusScript ps)
+        Nothing
+          | teType te == simpleScriptTextEnvelopeType ->
+              bimap AnyScriptSimpleCborError AnySimpleScript $
+                obtainCommonConstraints era (deserialiseSimpleScript scriptBs)
+          | otherwise ->
+              Left (AnyScriptUnknownTextEnvelopeType (teType te))
+
+-- | Decode an 'AnyScript' from the JSON-only simple script encoding.
+readSimpleScriptFromJson
+  :: forall era
+   . Era era
+  -> ByteString
+  -> Either JsonDecodeError (AnyScript (LedgerEra era))
+readSimpleScriptFromJson era bs = do
+  script <- deserialiseFromJSON bs :: Either JsonDecodeError OldScript.SimpleScript
+  case era of
+    DijkstraEra -> error "TODO Dijkstra: Simple script not supported"
+    ConwayEra ->
+      obtainConwayConstraints era $
+        Right . AnySimpleScript . SimpleScript $
+          toAllegraTimelock script
 
 readFileAnyScript
   :: Era era

--- a/cardano-api/src/Cardano/Api/Experimental/Plutus/Internal/Script.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Plutus/Internal/Script.hs
@@ -217,6 +217,9 @@ data AnyPlutusScriptLanguage where
     :: L.PlutusLanguage lang
     => L.SLanguage lang -> AnyPlutusScriptLanguage
 
+instance Show AnyPlutusScriptLanguage where
+  show = Text.unpack . plutusLanguageToText
+
 -- | Serialise an 'AnyPlutusScript' to a 'TextEnvelope'. The text envelope type
 -- is determined by the Plutus language version of the script.
 serialiseAnyPlutusScriptToTextEnvelope

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -44,6 +44,7 @@ import Cardano.Slotting.Time qualified as Slotting
 
 import Control.Monad.Identity (Identity)
 import Data.Bifunctor (first)
+import Data.ByteString qualified as BS
 import Data.Foldable (toList)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
@@ -55,7 +56,13 @@ import Data.Time.Clock.POSIX qualified as Time
 import Lens.Micro
 
 import Test.Gen.Cardano.Api.Experimental (genAnyScript)
-import Test.Gen.Cardano.Api.Typed (genAddressInEra, genTx, genTxIn)
+import Test.Gen.Cardano.Api.Typed
+  ( genAddressInEra
+  , genPlutusScriptInEra
+  , genSimpleScript
+  , genTx
+  , genTxIn
+  )
 
 import Hedgehog (Gen, Property)
 import Hedgehog qualified as H
@@ -96,6 +103,21 @@ tests =
             prop_roundtrip_cbor_any_script
         ]
     , testGroup
+        "readAnyScriptBytes"
+        [ testProperty
+            "Roundtrip Plutus script text envelope"
+            prop_roundtrip_plutus_script_text_envelope
+        , testProperty
+            "Read old API simple script text envelope"
+            prop_read_old_api_simple_script_text_envelope
+        , testProperty
+            "Read legacy JSON simple script"
+            prop_read_legacy_json_simple_script
+        , testProperty
+            "Roundtrip readFileAnyScript"
+            prop_roundtrip_read_file_any_script
+        ]
+    , testGroup
         "makeUnsignedTx"
         [ testProperty
             "Plutus scripts without protocol params returns MakeUnsignedTxMissingProtocolParams"
@@ -131,6 +153,42 @@ prop_roundtrip_cbor_any_script :: Property
 prop_roundtrip_cbor_any_script = H.property $ do
   script <- H.forAll genAnyScript
   H.tripping script Api.serialiseToCBOR (Api.deserialiseFromCBOR Exp.AsAnyScript)
+
+prop_roundtrip_plutus_script_text_envelope :: Property
+prop_roundtrip_plutus_script_text_envelope = H.property $ do
+  ps <- H.forAll genPlutusScriptInEra
+  let envelopeJson = Api.serialiseToJSON $ Api.serialiseToTextEnvelope Nothing ps
+  script <- H.evalEither $ Exp.readAnyScriptBytes Exp.ConwayEra envelopeJson
+  script H.=== Exp.AnyPlutusScript ps
+
+-- | The experimental API has no text envelope format for simple scripts, but
+-- the old API produces one via its 'Api.Script' instance (type
+-- \"SimpleScript\", Allegra-era 'Timelock' CBOR), so the simple script arm of
+-- 'Exp.readAnyScriptBytes' is tested against what the old API writes.
+prop_read_old_api_simple_script_text_envelope :: Property
+prop_read_old_api_simple_script_text_envelope = H.property $ do
+  oldScript <- H.forAll genSimpleScript
+  let envelopeJson =
+        Api.serialiseToJSON $ Api.serialiseToTextEnvelope Nothing (Api.SimpleScript oldScript)
+  script <- H.evalEither $ Exp.readAnyScriptBytes Exp.ConwayEra envelopeJson
+  script H.=== Exp.AnySimpleScript (Exp.SimpleScript (Api.toAllegraTimelock oldScript))
+
+prop_read_legacy_json_simple_script :: Property
+prop_read_legacy_json_simple_script = H.property $ do
+  oldScript <- H.forAll genSimpleScript
+  script <- H.evalEither $ Exp.readAnyScriptBytes Exp.ConwayEra (Api.serialiseToJSON oldScript)
+  script H.=== Exp.AnySimpleScript (Exp.SimpleScript (Api.toAllegraTimelock oldScript))
+
+prop_roundtrip_read_file_any_script :: Property
+prop_roundtrip_read_file_any_script = H.propertyOnce . H.moduleWorkspace "any-script" $ \ws -> do
+  oldScript <- H.forAll genSimpleScript
+  let envelopeJson =
+        Api.serialiseToJSON $ Api.serialiseToTextEnvelope Nothing (Api.SimpleScript oldScript)
+      path = ws <> "/simple-script.json"
+  H.evalIO $ BS.writeFile path envelopeJson
+  result <- H.evalIO $ Exp.readFileAnyScript Exp.ConwayEra (Api.File path)
+  script <- H.evalEither result
+  script H.=== Exp.AnySimpleScript (Exp.SimpleScript (Api.toAllegraTimelock oldScript))
 
 prop_created_transaction_with_both_apis_are_the_same :: Property
 prop_created_transaction_with_both_apis_are_the_same = H.propertyOnce $ do


### PR DESCRIPTION
# Context

Adds script reading to the experimental API, so downstream consumers (e.g. `cardano-cli`) can decode a script file without knowing its language or serialisation format up front:

- `readAnyScriptBytes` decodes an `AnyScript (LedgerEra era)` from bytes: it first tries a `TextEnvelope`, using the envelope type to select Plutus (`decodeAnyPlutusScript`) or simple script (`deserialiseSimpleScript`) CBOR decoding, and falls back to the legacy JSON-only simple script encoding for inputs that are not text envelopes.
- `readFileAnyScript` is the file-reading wrapper, returning `FileError AnyScriptDecodeError`.
- `AnyScriptDecodeError` is the new error type covering the JSON and CBOR failure cases, with an `Error` instance.

The legacy JSON fallback uses the established `TODO Dijkstra` placeholder for the Dijkstra era, consistent with the rest of the experimental API.

# How to trust this PR

```bash
cabal build cardano-api -j4
```

The change is additive: no existing functions are modified, only new exports from `Cardano.Api.Experimental`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`