### PR TITLE
Add writeFileTextEnvelopeWithOwnerPermissions

### DIFF
--- a/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
@@ -1,4 +1,4 @@
-description: Added `writeFileTextEnvelopeWithOwnerPermissions`, a variant of `writeFileTextEnvelope` that creates the output file with owner-only permissions. Use it when writing sensitive data such as signing keys, since `writeFileTextEnvelope` creates files with the default permissions. Additionally, on POSIX systems, files created by the `WithOwnerPermissions` family of functions now get `0600` permissions instead of `0700` (the owner-execute bit is no longer set).
+description: Added `writeFileTextEnvelopeWithOwnerPermissions`, a variant of `writeFileTextEnvelope` that creates the output file with owner-only permissions. Use it when writing sensitive data such as signing keys, since `writeFileTextEnvelope` creates files with the default permissions. Additionally, on POSIX systems, files created by the `WithOwnerPermissions` family of functions now get `0600` permissions instead of `0700` (the owner-execute bit is no longer set), and pre-existing files are now truncated on open, so overwriting a file with shorter content no longer leaves stale trailing bytes.
 kind:
 - feature
 pr: 1248

--- a/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
@@ -1,0 +1,5 @@
+description: Added `writeFileTextEnvelopeWithOwnerPermissions`, a variant of `writeFileTextEnvelope` that creates the output file with owner-only permissions. Use it when writing sensitive data such as signing keys, since `writeFileTextEnvelope` creates files with the default permissions.
+kind:
+- feature
+pr: 1248
+project: cardano-api

--- a/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_write_text_envelope_owner_permissions.yml
@@ -1,4 +1,4 @@
-description: Added `writeFileTextEnvelopeWithOwnerPermissions`, a variant of `writeFileTextEnvelope` that creates the output file with owner-only permissions. Use it when writing sensitive data such as signing keys, since `writeFileTextEnvelope` creates files with the default permissions.
+description: Added `writeFileTextEnvelopeWithOwnerPermissions`, a variant of `writeFileTextEnvelope` that creates the output file with owner-only permissions. Use it when writing sensitive data such as signing keys, since `writeFileTextEnvelope` creates files with the default permissions. Additionally, on POSIX systems, files created by the `WithOwnerPermissions` family of functions now get `0600` permissions instead of `0700` (the owner-execute bit is no longer set).
 kind:
 - feature
 pr: 1248

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -34,12 +34,8 @@ import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
                    nullFileMode, otherModes, ownerReadMode, ownerWriteMode, setFdOwnerAndGroup,
                    setFileMode, stdFileMode, unionFileModes)
-#if MIN_VERSION_unix(2,8,0)
 import           System.Posix.IO (OpenFileFlags (..), OpenMode (..), closeFd, defaultFileFlags,
                    fdToHandle, openFd)
-#else
-import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, fdToHandle, openFd)
-#endif
 import           System.Posix.Types (Fd, FileMode)
 import           System.Posix.User (getRealUserID)
 import           Text.Printf (printf)
@@ -109,7 +105,8 @@ checkVrfFilePermissionsImpl (File vrfPrivKey) = do
 ownerReadWriteMode :: FileMode
 ownerReadWriteMode = ownerReadMode `unionFileModes` ownerWriteMode
 
--- | Opens a file from disk.
+-- | Opens a file from disk. In 'WriteOnly' mode, the file is truncated if
+-- it already exists.
 openFileDescriptor :: FilePath -> OpenMode -> IO Fd
 # if MIN_VERSION_unix(2,8,0)
 openFileDescriptor fp openMode =
@@ -122,7 +119,7 @@ openFileDescriptor fp openMode =
       ReadWrite ->
         defaultFileFlags{creat = Just stdFileMode}
       WriteOnly ->
-        defaultFileFlags{creat = Just ownerReadWriteMode}
+        defaultFileFlags{creat = Just ownerReadWriteMode, trunc = True}
 
 # else
 openFileDescriptor fp openMode =
@@ -140,7 +137,7 @@ openFileDescriptor fp openMode =
         )
       WriteOnly ->
         ( Just ownerReadWriteMode
-        , defaultFileFlags
+        , defaultFileFlags{trunc = True}
         )
 
 # endif

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -32,8 +32,8 @@ import           System.FilePath ((</>))
 import qualified System.IO as IO
 import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
-                   nullFileMode, otherModes, ownerModes, ownerReadMode, setFdOwnerAndGroup,
-                   setFileMode, stdFileMode)
+                   nullFileMode, otherModes, ownerReadMode, ownerWriteMode, setFdOwnerAndGroup,
+                   setFileMode, stdFileMode, unionFileModes)
 #if MIN_VERSION_unix(2,8,0)
 import           System.Posix.IO (OpenFileFlags (..), OpenMode (..), closeFd, defaultFileFlags,
                    fdToHandle, openFd)
@@ -104,6 +104,11 @@ checkVrfFilePermissionsImpl (File vrfPrivKey) = do
   hasGroupPermissions :: FileMode -> Bool
   hasGroupPermissions fm' = fm' `hasPermission` groupModes
 
+-- | Read and write permissions for the file owner only (@0600@). Files
+-- created for writing are data files, so the execute bit is not set.
+ownerReadWriteMode :: FileMode
+ownerReadWriteMode = ownerReadMode `unionFileModes` ownerWriteMode
+
 -- | Opens a file from disk.
 openFileDescriptor :: FilePath -> OpenMode -> IO Fd
 # if MIN_VERSION_unix(2,8,0)
@@ -117,7 +122,7 @@ openFileDescriptor fp openMode =
       ReadWrite ->
         defaultFileFlags{creat = Just stdFileMode}
       WriteOnly ->
-        defaultFileFlags{creat = Just ownerModes}
+        defaultFileFlags{creat = Just ownerReadWriteMode}
 
 # else
 openFileDescriptor fp openMode =
@@ -134,7 +139,7 @@ openFileDescriptor fp openMode =
         , defaultFileFlags
         )
       WriteOnly ->
-        ( Just ownerModes
+        ( Just ownerReadWriteMode
         , defaultFileFlags
         )
 

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope.hs
@@ -11,6 +11,7 @@ module Cardano.Api.Serialise.TextEnvelope
   , deserialiseFromTextEnvelope
   , readFileTextEnvelope
   , writeFileTextEnvelope
+  , writeFileTextEnvelopeWithOwnerPermissions
   , readTextEnvelopeFromFile
   , readTextEnvelopeOfTypeFromFile
   , textEnvelopeToJSON

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -284,7 +284,7 @@ deserialiseFromTextEnvelopeJSONAnyOf types bs =
 -- | Write a value to a file in the text envelope format.
 --
 -- Note that this does /not/ set conservative file permissions: the file is
--- created with the default permissions. When writing sensitive data such as
+-- created with the default permissions which should be restricted with `umask`. When writing sensitive data such as
 -- signing keys, use 'writeFileTextEnvelopeWithOwnerPermissions' instead,
 -- which tries to restrict access to the file owner where the platform
 -- supports it (see its documentation for the exact guarantees).

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -303,7 +303,8 @@ writeFileTextEnvelope outputFile mbDescr a =
 -- * On POSIX systems, the file is created with @0600@ permissions (read
 --   and write for the file owner only, further filtered by the process's
 --   @umask@), and its ownership is set to the current (real) user. If the
---   file already exists, its permission bits are left unchanged.
+--   file already exists, it is truncated, but its permission bits are
+--   left unchanged.
 --
 -- * On Windows, the contents are written to a freshly created temporary
 --   file which is then renamed to the target path. This guarantees the

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -286,7 +286,8 @@ deserialiseFromTextEnvelopeJSONAnyOf types bs =
 -- Note that this does /not/ set conservative file permissions: the file is
 -- created with the default permissions. When writing sensitive data such as
 -- signing keys, use 'writeFileTextEnvelopeWithOwnerPermissions' instead,
--- which tries to restricts access to the file owner (depending on the platform).
+-- which tries to restrict access to the file owner where the platform
+-- supports it (see its documentation for the exact guarantees).
 writeFileTextEnvelope
   :: HasTextEnvelope a
   => File content Out
@@ -296,9 +297,21 @@ writeFileTextEnvelope
 writeFileTextEnvelope outputFile mbDescr a =
   writeLazyByteStringFile outputFile (textEnvelopeToJSON mbDescr a)
 
--- | Like 'writeFileTextEnvelope', but the file is created with owner-only
--- permissions, i.e. it is readable and writable by the file owner only
--- (depending on the platform).
+-- | Like 'writeFileTextEnvelope', but the file is created so that only its
+-- owner has access to it, to the extent the platform allows it:
+--
+-- * On POSIX systems, the file is created with @0700@ permissions
+--   (@ownerModes@, further filtered by the process's @umask@), so no group
+--   or other access, and its ownership is set to the current (real) user.
+--   If the file already exists, its permission bits are left unchanged.
+--
+-- * On Windows, the contents are written to a freshly created temporary
+--   file which is then renamed to the target path. This guarantees the
+--   file is owned by the current user, but no explicit ACL is set: the
+--   file inherits the access control list of the target directory.
+--
+-- * On WASM, this is currently a no-op: no file is written at all.
+--
 -- Use this when writing sensitive data such as signing keys.
 writeFileTextEnvelopeWithOwnerPermissions
   :: HasTextEnvelope a

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -300,10 +300,10 @@ writeFileTextEnvelope outputFile mbDescr a =
 -- | Like 'writeFileTextEnvelope', but the file is created so that only its
 -- owner has access to it, to the extent the platform allows it:
 --
--- * On POSIX systems, the file is created with @0700@ permissions
---   (@ownerModes@, further filtered by the process's @umask@), so no group
---   or other access, and its ownership is set to the current (real) user.
---   If the file already exists, its permission bits are left unchanged.
+-- * On POSIX systems, the file is created with @0600@ permissions (read
+--   and write for the file owner only, further filtered by the process's
+--   @umask@), and its ownership is set to the current (real) user. If the
+--   file already exists, its permission bits are left unchanged.
 --
 -- * On Windows, the contents are written to a freshly created temporary
 --   file which is then renamed to the target path. This guarantees the

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -22,6 +22,7 @@ module Cardano.Api.Serialise.TextEnvelope.Internal
   , deserialiseFromTextEnvelope
   , readFileTextEnvelope
   , writeFileTextEnvelope
+  , writeFileTextEnvelopeWithOwnerPermissions
   , readTextEnvelopeFromFile
   , readTextEnvelopeOfTypeFromFile
   , textEnvelopeToJSON
@@ -280,6 +281,12 @@ deserialiseFromTextEnvelopeJSONAnyOf
 deserialiseFromTextEnvelopeJSONAnyOf types bs =
   decodeTextEnvelopeJSON bs >>= deserialiseFromTextEnvelopeAnyOf types
 
+-- | Write a value to a file in the text envelope format.
+--
+-- Note that this does /not/ set conservative file permissions: the file is
+-- created with the default permissions. When writing sensitive data such as
+-- signing keys, use 'writeFileTextEnvelopeWithOwnerPermissions' instead,
+-- which tries to restricts access to the file owner (depending on the platform).
 writeFileTextEnvelope
   :: HasTextEnvelope a
   => File content Out
@@ -288,6 +295,19 @@ writeFileTextEnvelope
   -> IO (Either (FileError ()) ())
 writeFileTextEnvelope outputFile mbDescr a =
   writeLazyByteStringFile outputFile (textEnvelopeToJSON mbDescr a)
+
+-- | Like 'writeFileTextEnvelope', but the file is created with owner-only
+-- permissions, i.e. it is readable and writable by the file owner only
+-- (depending on the platform).
+-- Use this when writing sensitive data such as signing keys.
+writeFileTextEnvelopeWithOwnerPermissions
+  :: HasTextEnvelope a
+  => File content Out
+  -> Maybe TextEnvelopeDescr
+  -> a
+  -> IO (Either (FileError ()) ())
+writeFileTextEnvelopeWithOwnerPermissions outputFile mbDescr a =
+  writeLazyByteStringFileWithOwnerPermissions outputFile (textEnvelopeToJSON mbDescr a)
 
 textEnvelopeToJSON :: HasTextEnvelope a => Maybe TextEnvelopeDescr -> a -> LBS.ByteString
 textEnvelopeToJSON mbDescr a =


### PR DESCRIPTION
# Context

`writeFileTextEnvelope` creates files with the default permissions, which is not appropriate for sensitive data such as signing keys.

This PR adds `writeFileTextEnvelopeWithOwnerPermissions`, a variant that creates the file with owner-only permissions. It also adds a haddock note to `writeFileTextEnvelope` pointing users to the new function for sensitive data.

# How to trust this PR

- The new function is a one-line wrapper around the existing `writeLazyByteStringFileWithOwnerPermissions`, which is already used elsewhere for this exact purpose.
- The rest of the diff is re-exports and haddocks.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
