### PR TITLE
Return an error instead of throwing on invalid UTF-8 in deserialisation helpers

### DIFF
--- a/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
@@ -1,5 +1,5 @@
 description: |
-  Fixed `deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) to return an error instead of throwing an impure exception when the input is not valid UTF-8.
+  Fixed `deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) to return an error instead of throwing an impure exception when the input is not valid UTF-8. Added a `Bech32InvalidUtf8` constructor to `Bech32DecodeError`, which carries the rendered UTF-8 decoding error.
 kind:
 - bugfix
 pr: 1249

--- a/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
@@ -1,5 +1,5 @@
 description: |
-  Fixed `deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) to return an error instead of throwing an impure exception when the input is not valid UTF-8. Added a `Bech32InvalidUtf8` constructor to `Bech32DecodeError`, which carries the rendered UTF-8 decoding error.
+  Fixed `deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) to return an error instead of throwing an impure exception when the input is not valid UTF-8. Added a `Bech32InvalidUtf8` constructor to `Bech32DecodeError`, which carries the UTF-8 decoding error.
 kind:
 - bugfix
 pr: 1249

--- a/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_nonthrowing_utf8_decode.yml
@@ -1,0 +1,6 @@
+description: |
+  Fixed `deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) to return an error instead of throwing an impure exception when the input is not valid UTF-8.
+kind:
+- bugfix
+pr: 1249
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Internal/Orphans/Misc.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Orphans/Misc.hs
@@ -63,6 +63,8 @@ deriving instance Data Bech32.DecodingError
 
 deriving instance Data Bech32.CharPosition
 
+deriving instance Data T.UnicodeException
+
 -- | These instances originally existed on the Lovelace type.
 -- As the Lovelace type is deleted and we use L.Coin instead,
 -- these instances are added to L.Coin.  The instances are

--- a/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
+++ b/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
@@ -28,11 +28,12 @@ import Cardano.Api.Serialise.TextEnvelope.Internal
 import Cardano.Chain.Common qualified as Common
 import Cardano.Crypto.Signing qualified as Crypto
 
-import Codec.Binary.Bech32 qualified as Bech32
+import Control.Exception (displayException)
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Formatting (build, sformat, (%))
 
@@ -146,7 +147,7 @@ deserialiseAnyVerificationKeyBech32
 deserialiseAnyVerificationKeyBech32 bs =
   case Text.decodeUtf8' bs of
     -- The input is not valid UTF-8, so it cannot be valid Bech32.
-    Left _ -> Left $ Bech32DecodingError $ Bech32.StringToDecodeContainsInvalidChars []
+    Left err -> Left $ Bech32InvalidUtf8 $ Text.pack $ displayException err
     Right text -> deserialiseAnyOfFromBech32 allBech32VerKey text
  where
   allBech32VerKey

--- a/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
+++ b/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
@@ -28,12 +28,10 @@ import Cardano.Api.Serialise.TextEnvelope.Internal
 import Cardano.Chain.Common qualified as Common
 import Cardano.Crypto.Signing qualified as Crypto
 
-import Control.Exception (displayException)
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
-import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Formatting (build, sformat, (%))
 
@@ -147,7 +145,7 @@ deserialiseAnyVerificationKeyBech32
 deserialiseAnyVerificationKeyBech32 bs =
   case Text.decodeUtf8' bs of
     -- The input is not valid UTF-8, so it cannot be valid Bech32.
-    Left err -> Left $ Bech32InvalidUtf8 $ Text.pack $ displayException err
+    Left err -> Left $ Bech32InvalidUtf8 err
     Right text -> deserialiseAnyOfFromBech32 allBech32VerKey text
  where
   allBech32VerKey

--- a/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
+++ b/cardano-api/src/Cardano/Api/Key/Internal/SomeAddressVerificationKey.hs
@@ -28,6 +28,7 @@ import Cardano.Api.Serialise.TextEnvelope.Internal
 import Cardano.Chain.Common qualified as Common
 import Cardano.Crypto.Signing qualified as Crypto
 
+import Codec.Binary.Bech32 qualified as Bech32
 import Data.Aeson qualified as Aeson
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
@@ -142,8 +143,11 @@ deserialiseAnyVerificationKey bs =
 
 deserialiseAnyVerificationKeyBech32
   :: ByteString -> Either Bech32DecodeError SomeAddressVerificationKey
-deserialiseAnyVerificationKeyBech32 =
-  deserialiseAnyOfFromBech32 allBech32VerKey . Text.decodeUtf8
+deserialiseAnyVerificationKeyBech32 bs =
+  case Text.decodeUtf8' bs of
+    -- The input is not valid UTF-8, so it cannot be valid Bech32.
+    Left _ -> Left $ Bech32DecodingError $ Bech32.StringToDecodeContainsInvalidChars []
+    Right text -> deserialiseAnyOfFromBech32 allBech32VerKey text
  where
   allBech32VerKey
     :: [FromSomeType SerialiseAsBech32 SomeAddressVerificationKey]

--- a/cardano-api/src/Cardano/Api/Serialise/Bech32.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/Bech32.hs
@@ -149,6 +149,9 @@ data Bech32DecodeError
       -- ^ Expected header
       !Text
       -- ^ Unexpected header
+  | -- | The input is not valid UTF-8, so it cannot be a Bech32-encoded
+    -- string. The field contains the rendered UTF-8 decoding error.
+    Bech32InvalidUtf8 !Text
   deriving (Eq, Show, Data)
 
 instance Error Bech32DecodeError where
@@ -181,3 +184,5 @@ instance Error Bech32DecodeError where
         [ "Unexpected CIP-129 Bech32 header: the actual header is " <> pshow actual
         , ", but it was expected to be " <> pshow expected
         ]
+    Bech32InvalidUtf8 decodeErr ->
+      "The Bech32-encoded string is not valid UTF-8: " <> pretty decodeErr

--- a/cardano-api/src/Cardano/Api/Serialise/Bech32.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/Bech32.hs
@@ -28,6 +28,7 @@ import Data.ByteString (ByteString)
 import Data.Data (Data)
 import Data.List qualified as List
 import Data.Set (Set)
+import Data.Text.Encoding.Error (UnicodeException)
 import GHC.Exts (IsList (..))
 import GHC.Stack
 
@@ -150,8 +151,8 @@ data Bech32DecodeError
       !Text
       -- ^ Unexpected header
   | -- | The input is not valid UTF-8, so it cannot be a Bech32-encoded
-    -- string. The field contains the rendered UTF-8 decoding error.
-    Bech32InvalidUtf8 !Text
+    -- string. The field contains the UTF-8 decoding error.
+    Bech32InvalidUtf8 !UnicodeException
   deriving (Eq, Show, Data)
 
 instance Error Bech32DecodeError where
@@ -185,4 +186,4 @@ instance Error Bech32DecodeError where
         , ", but it was expected to be " <> pshow expected
         ]
     Bech32InvalidUtf8 decodeErr ->
-      "The Bech32-encoded string is not valid UTF-8: " <> pretty decodeErr
+      "The Bech32-encoded string is not valid UTF-8: " <> prettyError decodeErr

--- a/cardano-api/src/Cardano/Api/Serialise/DeserialiseAnyOf.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/DeserialiseAnyOf.hs
@@ -35,7 +35,6 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.Char (toLower)
 import Data.Data
 import Data.List.NonEmpty (NonEmpty)
-import Data.Text (Text)
 import Data.Text.Encoding qualified as Text
 import GHC.Exts (IsList (..))
 import Prettyprinter
@@ -107,9 +106,6 @@ deserialiseInput
 deserialiseInput acceptedFormats inputBs =
   go (toList acceptedFormats)
  where
-  inputText :: Text
-  inputText = Text.decodeUtf8 inputBs
-
   go :: [InputFormat a] -> Either InputDecodeError a
   go [] = Left InputInvalidError
   go (kf : kfs) =
@@ -140,12 +136,16 @@ deserialiseInput acceptedFormats inputBs =
 
   deserialiseBech32 :: SerialiseAsBech32 a => DeserialiseInputResult a
   deserialiseBech32 =
-    case deserialiseFromBech32 inputText of
-      Right res -> DeserialiseInputSuccess res
-      -- The input was not valid Bech32.
-      Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
-      -- The input was valid Bech32, but some other error occurred.
-      Left err -> DeserialiseInputError $ InputBech32DecodeError err
+    case Text.decodeUtf8' inputBs of
+      -- The input was not valid UTF-8, so it cannot be valid Bech32.
+      Left _ -> DeserialiseInputErrorFormatMismatch
+      Right inputText ->
+        case deserialiseFromBech32 inputText of
+          Right res -> DeserialiseInputSuccess res
+          -- The input was not valid Bech32.
+          Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+          -- The input was valid Bech32, but some other error occurred.
+          Left err -> DeserialiseInputError $ InputBech32DecodeError err
 
   deserialiseHex :: SerialiseAsRawBytes a => DeserialiseInputResult a
   deserialiseHex
@@ -179,9 +179,6 @@ deserialiseInputAnyOf bech32Types textEnvTypes inputBs =
     DeserialiseInputError err -> Left err
     DeserialiseInputErrorFormatMismatch -> Left InputInvalidError
  where
-  inputText :: Text
-  inputText = Text.decodeUtf8 inputBs
-
   orTry
     :: DeserialiseInputResult b
     -> DeserialiseInputResult b
@@ -209,12 +206,16 @@ deserialiseInputAnyOf bech32Types textEnvTypes inputBs =
 
   deserialiseBech32 :: DeserialiseInputResult b
   deserialiseBech32 =
-    case deserialiseAnyOfFromBech32 bech32Types inputText of
-      Right res -> DeserialiseInputSuccess res
-      -- The input was not valid Bech32.
-      Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
-      -- The input was valid Bech32, but some other error occurred.
-      Left err -> DeserialiseInputError $ InputBech32DecodeError err
+    case Text.decodeUtf8' inputBs of
+      -- The input was not valid UTF-8, so it cannot be valid Bech32.
+      Left _ -> DeserialiseInputErrorFormatMismatch
+      Right inputText ->
+        case deserialiseAnyOfFromBech32 bech32Types inputText of
+          Right res -> DeserialiseInputSuccess res
+          -- The input was not valid Bech32.
+          Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+          -- The input was valid Bech32, but some other error occurred.
+          Left err -> DeserialiseInputError $ InputBech32DecodeError err
 
 -- | Read formatted file
 readFormattedFile

--- a/cardano-api/src/Cardano/Api/Serialise/DeserialiseAnyOf.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/DeserialiseAnyOf.hs
@@ -135,17 +135,19 @@ deserialiseInput acceptedFormats inputBs =
       Left _ -> DeserialiseInputErrorFormatMismatch
 
   deserialiseBech32 :: SerialiseAsBech32 a => DeserialiseInputResult a
-  deserialiseBech32 =
-    case Text.decodeUtf8' inputBs of
-      -- The input was not valid UTF-8, so it cannot be valid Bech32.
-      Left _ -> DeserialiseInputErrorFormatMismatch
-      Right inputText ->
-        case deserialiseFromBech32 inputText of
-          Right res -> DeserialiseInputSuccess res
-          -- The input was not valid Bech32.
-          Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
-          -- The input was valid Bech32, but some other error occurred.
-          Left err -> DeserialiseInputError $ InputBech32DecodeError err
+  deserialiseBech32 = either id fromBech32 $ decodeText inputBs
+   where
+    -- The input was not valid UTF-8, so it cannot be valid Bech32.
+    decodeText =
+      first (const DeserialiseInputErrorFormatMismatch)
+        . Text.decodeUtf8'
+    fromBech32 text =
+      case deserialiseFromBech32 text of
+        Right res -> DeserialiseInputSuccess res
+        -- The input was not valid Bech32.
+        Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+        -- The input was valid Bech32, but some other error occurred.
+        Left err -> DeserialiseInputError $ InputBech32DecodeError err
 
   deserialiseHex :: SerialiseAsRawBytes a => DeserialiseInputResult a
   deserialiseHex
@@ -205,17 +207,19 @@ deserialiseInputAnyOf bech32Types textEnvTypes inputBs =
       Left _ -> DeserialiseInputErrorFormatMismatch
 
   deserialiseBech32 :: DeserialiseInputResult b
-  deserialiseBech32 =
-    case Text.decodeUtf8' inputBs of
-      -- The input was not valid UTF-8, so it cannot be valid Bech32.
-      Left _ -> DeserialiseInputErrorFormatMismatch
-      Right inputText ->
-        case deserialiseAnyOfFromBech32 bech32Types inputText of
-          Right res -> DeserialiseInputSuccess res
-          -- The input was not valid Bech32.
-          Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
-          -- The input was valid Bech32, but some other error occurred.
-          Left err -> DeserialiseInputError $ InputBech32DecodeError err
+  deserialiseBech32 = either id fromBech32 $ decodeText inputBs
+   where
+    -- The input was not valid UTF-8, so it cannot be valid Bech32.
+    decodeText =
+      first (const DeserialiseInputErrorFormatMismatch)
+        . Text.decodeUtf8'
+    fromBech32 text =
+      case deserialiseAnyOfFromBech32 bech32Types text of
+        Right res -> DeserialiseInputSuccess res
+        -- The input was not valid Bech32.
+        Left (Bech32DecodingError _) -> DeserialiseInputErrorFormatMismatch
+        -- The input was valid Bech32, but some other error occurred.
+        Left err -> DeserialiseInputError $ InputBech32DecodeError err
 
 -- | Read formatted file
 readFormattedFile

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -61,6 +61,7 @@ import Data.Maybe
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
+import Data.Text.Encoding.Error (UnicodeException (..))
 import Data.Word
 import GHC.Exts (IsList (..))
 import GHC.Stack (HasCallStack)
@@ -90,6 +91,9 @@ bytestring = "<bytestring>" :: ByteString
 
 lazyBytestring :: LBS.ByteString
 lazyBytestring = "<lazy-bytestring>" :: LBS.ByteString
+
+unicodeException :: UnicodeException
+unicodeException = DecodeError "<decode error>" (Just 0xc3)
 
 stakePoolVerKey1 :: VerificationKey StakePoolKey
 stakePoolVerKey1 = getVerificationKey $ deterministicSigningKey AsStakePoolKey (Crypto.mkSeedFromBytes seed1)
@@ -159,7 +163,7 @@ test_Bech32DecodeError =
     , Bech32DeserialiseFromBytesError bytestring
     , Bech32WrongPrefix text text
     , Bech32UnexpectedHeader text text
-    , Bech32InvalidUtf8 text
+    , Bech32InvalidUtf8 unicodeException
     ]
 
 test_InputDecodeError :: TestTree

--- a/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-api/test/cardano-api-golden/Test/Golden/ErrorsSpec.hs
@@ -159,6 +159,7 @@ test_Bech32DecodeError =
     , Bech32DeserialiseFromBytesError bytestring
     , Bech32WrongPrefix text text
     , Bech32UnexpectedHeader text text
+    , Bech32InvalidUtf8 text
     ]
 
 test_InputDecodeError :: TestTree

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Serialise.Bech32.Bech32DecodeError/Bech32InvalidUtf8.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Serialise.Bech32.Bech32DecodeError/Bech32InvalidUtf8.txt
@@ -1,0 +1,1 @@
+The Bech32-encoded string is not valid UTF-8: <text>

--- a/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Serialise.Bech32.Bech32DecodeError/Bech32InvalidUtf8.txt
+++ b/cardano-api/test/cardano-api-golden/files/errors/Cardano.Api.Serialise.Bech32.Bech32DecodeError/Bech32InvalidUtf8.txt
@@ -1,1 +1,1 @@
-The Bech32-encoded string is not valid UTF-8: <text>
+The Bech32-encoded string is not valid UTF-8: Cannot decode byte '\xc3': <decode error>


### PR DESCRIPTION
# Context

`deserialiseInput`, `deserialiseInputAnyOf` and `deserialiseAnyVerificationKeyBech32` (and thereby `deserialiseAnyVerificationKey`) used `Text.decodeUtf8`, which throws an impure exception when the input is not valid UTF-8. For example, `deserialiseInput` on the bytes `"\xc3\x28"` threw instead of returning `Left InputInvalidError`.

This PR switches them to `Text.decodeUtf8'` and treats invalid UTF-8 as a normal decoding failure.

# How to trust this PR

- Invalid UTF-8 can never be valid Bech32, so mapping the decode failure to the existing "not valid Bech32" path (`DeserialiseInputErrorFormatMismatch` / `Bech32DecodingError`) does not change behaviour for any valid input.
- The three changed sites are mechanical: wrap the old code in the `Right` case of `decodeUtf8'`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
