### PR TITLE
Create secret files with owner-only permissions in writeSecrets

### DIFF
--- a/.changes/20260708_140000_cardano-api_pablo.lamela_write_secrets_owner_permissions.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_write_secrets_owner_permissions.yml
@@ -1,4 +1,4 @@
-description: Fixed `writeSecrets` creating secret files with the process-default permissions and only restricting them afterwards, leaving a window during which the secrets could be readable by other users. Secret files are now created with owner-only permissions from the start.
+description: Fixed `writeSecrets` creating secret files with the process-default permissions and only restricting them afterwards, leaving a window during which the secrets could be readable by other users. Secret files are now created with owner-only permissions from the start. Write failures are now thrown as `ErrorAsException` carrying the file path and a call stack, instead of a bare `IOException`.
 kind:
 - bugfix
 pr: 1250

--- a/.changes/20260708_140000_cardano-api_pablo.lamela_write_secrets_owner_permissions.yml
+++ b/.changes/20260708_140000_cardano-api_pablo.lamela_write_secrets_owner_permissions.yml
@@ -1,0 +1,5 @@
+description: Fixed `writeSecrets` creating secret files with the process-default permissions and only restricting them afterwards, leaving a window during which the secrets could be readable by other users. Secret files are now created with owner-only permissions from the start.
+kind:
+- bugfix
+pr: 1250
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
@@ -16,6 +16,7 @@ import Cardano.Api.IO.Internal.Compat.Win32
 
 import Control.Monad.Except (ExceptT)
 import Data.ByteString (ByteString)
+import GHC.Stack (HasCallStack)
 import System.IO
 
 handleFileForWritingWithOwnerPermission
@@ -24,7 +25,8 @@ handleFileForWritingWithOwnerPermission
   -> IO (Either (FileError e) ())
 handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissionImpl
 
-writeSecrets :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+writeSecrets
+  :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
 writeSecrets = writeSecretsImpl
 
 checkVrfFilePermissions :: File content direction -> ExceptT VRFPrivateKeyFilePermissionError IO ()

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -21,12 +21,13 @@ where
 import           Cardano.Api.Error (FileError (..), throwErrorM)
 import           Cardano.Api.IO.Internal.Base
 
-import           Control.Exception (IOException, bracket, bracketOnError, throwIO, try)
+import           Control.Exception (IOException, bracket, bracketOnError, try)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT, runExceptT)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
 import qualified Data.ByteString as BS
+import           GHC.Stack (HasCallStack)
 import           System.Directory ()
 import           System.FilePath ((</>))
 import qualified System.IO as IO
@@ -71,7 +72,8 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
         IO.hClose
         (runExceptT . handleIOExceptT (FileIOError path) . f)
 
-writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
+writeSecretsImpl
+  :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
 writeSecretsImpl outDir prefix suffix secretOp xs =
   forM_ (zip xs [0 :: Int ..]) $
     \(secret, nr) -> do
@@ -79,7 +81,6 @@ writeSecretsImpl outDir prefix suffix secretOp xs =
       result <- handleFileForWritingWithOwnerPermissionImpl filename $ \h ->
         BS.hPut h $ secretOp secret
       case result of
-        Left (FileIOError _ ioe) -> throwIO ioe
         Left err -> throwErrorM (err :: FileError ())
         Right () -> setFileMode filename ownerReadMode
 

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -18,10 +18,10 @@ where
 
 #ifdef UNIX
 
-import           Cardano.Api.Error (FileError (..))
+import           Cardano.Api.Error (FileError (..), throwErrorM)
 import           Cardano.Api.IO.Internal.Base
 
-import           Control.Exception (IOException, bracket, bracketOnError, try)
+import           Control.Exception (IOException, bracket, bracketOnError, throwIO, try)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT, runExceptT)
 import           Control.Monad.IO.Class
@@ -76,8 +76,12 @@ writeSecretsImpl outDir prefix suffix secretOp xs =
   forM_ (zip xs [0 :: Int ..]) $
     \(secret, nr) -> do
       let filename = outDir </> prefix <> "." <> printf "%03d" nr <> "." <> suffix
-      BS.writeFile filename $ secretOp secret
-      setFileMode filename ownerReadMode
+      result <- handleFileForWritingWithOwnerPermissionImpl filename $ \h ->
+        BS.hPut h $ secretOp secret
+      case result of
+        Left (FileIOError _ ioe) -> throwIO ioe
+        Left err -> throwErrorM (err :: FileError ())
+        Right () -> setFileMode filename ownerReadMode
 
 -- | Make sure the VRF private key file is readable only
 -- by the current process owner the node is running under.

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Wasm.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Wasm.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+-- HasCallStack is unused in these dummy implementations, but keeps the
+-- signatures identical to the Posix and Win32 variants.
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 #if defined(wasm32_HOST_ARCH)
 #define WASM
@@ -20,6 +23,7 @@ import           Cardano.Api.Error (FileError (..))
 import           Cardano.Api.IO.Internal.Base
 import           Control.Monad.Except (ExceptT)
 import           Data.ByteString (ByteString)
+import           GHC.Stack (HasCallStack)
 import           System.IO (Handle)
 
 handleFileForWritingWithOwnerPermissionImpl
@@ -28,7 +32,8 @@ handleFileForWritingWithOwnerPermissionImpl
   -> IO (Either (FileError e) ())
 handleFileForWritingWithOwnerPermissionImpl _path _f = return $ Right () -- Dummy implementation for WASM
 
-writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+writeSecretsImpl
+  :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
 writeSecretsImpl _outDir _prefix _suffix _secretOp _xs = return () -- Dummy implementation for WASM
 
 -- | Make sure the VRF private key file is readable only

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Win32.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Win32.hs
@@ -16,10 +16,10 @@ where
 
 #ifndef UNIX
 
-import           Cardano.Api.Error (FileError (..))
+import           Cardano.Api.Error (FileError (..), throwErrorM)
 import           Cardano.Api.IO.Internal.Base
 
-import           Control.Exception (bracketOnError)
+import           Control.Exception (bracketOnError, throwIO)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT)
 import           Control.Monad.IO.Class (liftIO)
@@ -63,8 +63,12 @@ writeSecretsImpl outDir prefix suffix secretOp xs =
   forM_ (zip xs [0 :: Int ..]) $
     \(secret, nr) -> do
       let filename = outDir </> prefix <> "." <> printf "%03d" nr <> "." <> suffix
-      BS.writeFile filename $ secretOp secret
-      setPermissions filename (emptyPermissions{readable = True})
+      result <- handleFileForWritingWithOwnerPermissionImpl filename $ \h ->
+        BS.hPut h $ secretOp secret
+      case result of
+        Left (FileIOError _ ioe) -> throwIO ioe
+        Left err -> throwErrorM (err :: FileError ())
+        Right () -> setPermissions filename (emptyPermissions{readable = True})
 
 -- | Make sure the VRF private key file is readable only
 -- by the current process owner the node is running under.

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Win32.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Win32.hs
@@ -19,7 +19,7 @@ where
 import           Cardano.Api.Error (FileError (..), throwErrorM)
 import           Cardano.Api.IO.Internal.Base
 
-import           Control.Exception (bracketOnError, throwIO)
+import           Control.Exception (bracketOnError)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT)
 import           Control.Monad.IO.Class (liftIO)
@@ -27,6 +27,7 @@ import           Control.Monad.Trans.Except.Extra (left)
 import           Data.Bits
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import           GHC.Stack (HasCallStack)
 import qualified System.Directory as IO
 import           System.Directory (emptyPermissions, readable, setPermissions)
 import           System.FilePath (splitFileName, (<.>), (</>))
@@ -58,7 +59,8 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
  where
   (targetDir, targetFile) = splitFileName path
 
-writeSecretsImpl :: FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+writeSecretsImpl
+  :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
 writeSecretsImpl outDir prefix suffix secretOp xs =
   forM_ (zip xs [0 :: Int ..]) $
     \(secret, nr) -> do
@@ -66,7 +68,6 @@ writeSecretsImpl outDir prefix suffix secretOp xs =
       result <- handleFileForWritingWithOwnerPermissionImpl filename $ \h ->
         BS.hPut h $ secretOp secret
       case result of
-        Left (FileIOError _ ioe) -> throwIO ioe
         Left err -> throwErrorM (err :: FileError ())
         Right () -> setPermissions filename (emptyPermissions{readable = True})
 


### PR DESCRIPTION
# Context

`writeSecrets` created secret files with the process-default permissions and only restricted them afterwards with `setFileMode`, leaving a window during which the secrets could be readable by other users.

This PR creates the files with owner-only permissions from the start.

# How to trust this PR

- The write now goes through the existing `handleFileForWritingWithOwnerPermissionImpl`, the same mechanism `writeLazyByteStringFileWithOwnerPermissions` already uses.
- The same change is applied to both the POSIX and Win32 implementations.
- Error behaviour is preserved: IO errors are rethrown as exceptions, as `BS.writeFile` did before.
- The final permission tightening (owner read-only) still runs, so the end state of the files is unchanged.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
