### PR TITLE
Document unpkg.com runtime dependency of the no-bundler wasm wrapper

### DIFF
--- a/.changes/20260708_cardano_wasm_document_wasi_shim_cdn_dependency.yml
+++ b/.changes/20260708_cardano_wasm_document_wasi_shim_cdn_dependency.yml
@@ -1,0 +1,6 @@
+project: cardano-wasm
+pr: 1251
+kind:
+  - documentation
+description: |
+  Document that the no-bundler browser wrapper (`cardano-api.js`) loads `@bjorn3/browser_wasi_shim` from the `unpkg.com` CDN at page load

--- a/cardano-wasm/README.md
+++ b/cardano-wasm/README.md
@@ -217,6 +217,9 @@ You can find more information in [this url](https://ghc.gitlab.haskell.org/ghc/d
 
 And you can find an example of how to use it in the `example` subfolder. This example assumes that the generated `.wasm` and `.js` files as well as the files from the `lib-wrapper` subfolder, all reside in the same folder as the code in `example` subfolder.
 
+>[!NOTE]
+>The no-bundler wrapper (`cardano-api.js` in the `lib-wrapper` folder) dynamically imports `@bjorn3/browser_wasi_shim@0.4.1` from the `unpkg.com` CDN at page load, so the browser needs network access to `unpkg.com` at runtime. In particular, it will not work offline (e.g. in air-gapped environments) or on pages whose Content Security Policy blocks `unpkg.com`. This only applies to the no-bundler wrapper: the NPM package instead depends on `@bjorn3/browser_wasi_shim` as a regular dependency.
+
 ### Troubleshooting guide
 
 #### `Failed to load dynamic interface file for ...` GHC-47808 error


### PR DESCRIPTION
# Context

The no-bundler browser wrapper (`lib-wrapper/cardano-api.js`) dynamically imports `@bjorn3/browser_wasi_shim@0.4.1` from the `unpkg.com` CDN at page load. This was undocumented: the wrapper needs network access to `unpkg.com` at runtime, so it will not work offline (e.g. air-gapped setups) or under a Content Security Policy that blocks `unpkg.com`.

This PR documents that in the `cardano-wasm` README.

# How to trust this PR

- Documentation only: one note added to `cardano-wasm/README.md`.
- The import being documented is at `cardano-wasm/lib-wrapper/cardano-api.js:13`.
- The NPM package is unaffected; it depends on `@bjorn3/browser_wasi_shim` as a regular dependency.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
