### PR TITLE
Remove deprecated `pattern Block` synonym from `Cardano.Api.Block`

### DIFF
--- a/.changes/20260709_cardano_api_remove_deprecated_pattern_block.yml
+++ b/.changes/20260709_cardano_api_remove_deprecated_pattern_block.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1252
+kind:
+  - breaking
+description: |
+  Remove the deprecated 'pattern Block :: BlockHeader -> [Tx era] -> Block era' pattern synonym from 'Cardano.Api.Block'. Use 'getBlockHeader' and 'getBlockTxs' instead. The 'Block' data type and its constructors ('ByronBlock', 'ShelleyBlock') are unchanged.

--- a/cardano-api/src/Cardano/Api/Block.hs
+++ b/cardano-api/src/Cardano/Api/Block.hs
@@ -4,21 +4,16 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ViewPatterns #-}
--- TODO Delete me when the patterns of this file are removed (they are the ones using deprecated - other - patterns)
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 -- | Blocks in the blockchain
 module Cardano.Api.Block
   ( -- * Blocks in the context of an era
     Block (..)
-  , pattern Block
   , BlockHeader (..)
   , getBlockHeader
   , getBlockTxs
@@ -95,16 +90,6 @@ data Block era where
     :: ShelleyBasedEra era
     -> Consensus.ShelleyBlock (ConsensusProtocol era) (ShelleyLedgerEra era)
     -> Block era
-
--- | A block consists of a header and a body containing transactions.
-{-# DEPRECATED Block "Use getBlockHeader instead " #-}
-pattern Block :: BlockHeader -> [Tx era] -> Block era
-pattern Block header txs <- (getBlockHeaderAndTxs -> (header, txs))
-
-{-# COMPLETE Block #-}
-
-getBlockHeaderAndTxs :: Block era -> (BlockHeader, [Tx era])
-getBlockHeaderAndTxs block = (getBlockHeader block, getBlockTxs block)
 
 -- The GADT in the ShelleyBlock case requires a custom instance
 instance Show (Block era) where


### PR DESCRIPTION
## Context

Remove the deprecated `pattern Block :: BlockHeader -> [Tx era] -> Block era` pattern synonym from `Cardano.Api.Block`.

The pattern was deprecated in January 2025 (commit 7f8d417071) in favour of `getBlockHeader` and `getBlockTxs`.
After 17 months of deprecation with zero consumers in the codebase, it is safe to remove.

## Changes

- Remove `pattern Block`, `{-# COMPLETE Block #-}` pragma, and the `getBlockHeaderAndTxs` helper
- Remove `PatternSynonyms`, `ViewPatterns` extensions and `{-# OPTIONS_GHC -Wno-deprecations #-}` that were only needed for the pattern
- The `Block` data type and its constructors (`ByronBlock`, `ShelleyBlock`) are unchanged

## How to trust this PR

This is a small, self-contained removal.
The deprecated pattern had no consumers anywhere in the cardano-api, cardano-cli, cardano-node, or cardano-rpc codebases.

## Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`