### PR TITLE
Add experimental era ranges: eon-like spans as type-level lists

### DIFF
--- a/.changes/20260716_cardano_api_experimental_era_ranges.yml
+++ b/.changes/20260716_cardano_api_experimental_era_ranges.yml
@@ -1,0 +1,7 @@
+project: cardano-api
+pr: 1256
+kind:
+  - feature
+  - bugfix
+description: |
+  Add experimental era ranges in `Cardano.Api.Experimental.Era.Range` and `Cardano.Api.Experimental.Era.Range.Some`: era spans as type-level lists (`Onwards`, `:-:`) with a generic membership witness `EraIn`, range constraints derived by GHC via `All`/`withRange`/`rangeDict`, total and nestable `splitRange` dispatch, and a `vary`-based existential `SomeEraIn`. Fix `TestEquality CardanoEra` missing the `DijkstraEra` case.

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -84,6 +84,8 @@ library
     Cardano.Api.Experimental.AnyScriptWitness
     Cardano.Api.Experimental.Certificate
     Cardano.Api.Experimental.Era
+    Cardano.Api.Experimental.Era.Range
+    Cardano.Api.Experimental.Era.Range.Some
     Cardano.Api.Experimental.Plutus
     Cardano.Api.Experimental.Serialise.TextEnvelope
     Cardano.Api.Experimental.Simple.Script
@@ -153,6 +155,7 @@ library
     cardano-slotting >=0.2.0.0,
     cardano-strict-containers >=0.1,
     cborg,
+    constraints,
     containers,
     contra-tracer,
     crypton,
@@ -198,6 +201,7 @@ library
     transformers-except ^>=0.1.3,
     typed-protocols ^>=1.2,
     validation,
+    vary,
     vector,
     yaml,
 
@@ -228,6 +232,7 @@ library
     Cardano.Api.Era.Internal.Eon.ShelleyToBabbageEra
     Cardano.Api.Era.Internal.Eon.ShelleyToMaryEra
     Cardano.Api.Era.Internal.Feature
+    Cardano.Api.Experimental.Era.Range.Internal
     Cardano.Api.Experimental.Plutus.Internal.IndexedPlutusScriptWitness
     Cardano.Api.Experimental.Plutus.Internal.Script
     Cardano.Api.Experimental.Plutus.Internal.ScriptWitness
@@ -407,6 +412,7 @@ test-suite cardano-api-test
     Test.Cardano.Api.EpochLeadership
     Test.Cardano.Api.Eras
     Test.Cardano.Api.Experimental
+    Test.Cardano.Api.Experimental.EraRange
     Test.Cardano.Api.Experimental.Fee
     Test.Cardano.Api.Genesis
     Test.Cardano.Api.GovAnchorValidation

--- a/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
@@ -304,6 +304,7 @@ instance TestEquality CardanoEra where
   testEquality AlonzoEra AlonzoEra = Just Refl
   testEquality BabbageEra BabbageEra = Just Refl
   testEquality ConwayEra ConwayEra = Just Refl
+  testEquality DijkstraEra DijkstraEra = Just Refl
   testEquality _ _ = Nothing
 
 instance Eon CardanoEra where

--- a/cardano-api/src/Cardano/Api/Experimental/Era/Range.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era/Range.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-- | Era ranges: eon-like spans of eras as type-level lists, with generic
+-- membership witnesses, constraint reification and dispatch.
+--
+-- An era range is a type-level list of eras, usually written as a slice of
+-- the timeline:
+--
+-- @
+-- Onwards AlonzoEra         -- Alonzo and everything after it
+-- ShelleyEra :-: BabbageEra -- the closed interval from Shelley to Babbage
+-- @
+--
+-- A value of type @'EraIn' range era@ witnesses that @era@ is in @range@,
+-- like an eon witness, but generic in the range. Constraints holding for
+-- every era of a range are brought into scope with 'withRange'. Bundles are
+-- written once, as a plain constraint alias, and made passable to
+-- 'withRange' with a two-line class\/instance eta-expansion:
+--
+-- @
+-- type MintConstraints era = (IsShelleyBasedEra era, L.MaryEraTxBody (ShelleyLedgerEra era))
+--
+-- class MintConstraints era => MintC era
+--
+-- instance MintConstraints era => MintC era
+--
+-- f :: EraIn (Onwards MaryEra) era -> ...
+-- f w = withRange \@MintC w $ ...
+-- @
+--
+-- Unlike the eon @*Constraints@ bundles, @'All' c range@ is discharged by
+-- GHC from the per-era instances, so an era lacking support is a compile
+-- error at the use site instead of a runtime error.
+module Cardano.Api.Experimental.Era.Range
+  ( -- * Timeline
+    ShelleyBasedEras
+  , SupportedEras
+
+    -- * Range constructors
+  , From
+  , UpTo
+  , Onwards
+  , type (:-:)
+  , type (++)
+
+    -- * Membership witness
+  , EraIn
+  , eraInToCardanoEra
+  , KnownEras (..)
+  , maybeEraIn
+  , HasEraIn (..)
+
+    -- * Constraints over a range
+  , All
+  , type (:&:)
+  , withRange
+  , rangeDict
+
+    -- * Splitting a range
+  , SplitEras
+  , splitRange
+  )
+where
+
+import Cardano.Api.Experimental.Era.Range.Internal

--- a/cardano-api/src/Cardano/Api/Experimental/Era/Range/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era/Range/Internal.hs
@@ -1,0 +1,345 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyCase #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- | Era ranges as type-level lists.
+--
+-- This module contains the implementation details of
+-- "Cardano.Api.Experimental.Era.Range". Import that module instead unless you
+-- need access to the internals.
+module Cardano.Api.Experimental.Era.Range.Internal
+  ( -- * Timeline
+    ShelleyBasedEras
+  , SupportedEras
+
+    -- * Range constructors
+  , From
+  , UpTo
+  , Onwards
+  , type (:-:)
+  , type (++)
+
+    -- * Membership witness
+  , EraIn (..)
+  , eraInToCardanoEra
+  , KnownEras (..)
+  , maybeEraIn
+  , HasEraIn (..)
+
+    -- * Constraints over a range
+  , All
+  , type (:&:)
+  , withRange
+  , rangeDict
+
+    -- * Splitting a range
+  , SplitEras (..)
+  , splitRange
+
+    -- * Compile-time consistency checks
+  , ErasDownFrom
+  , ToLedgerEras
+  , LedgerTimeline
+  , supportedErasAligned
+  , timelineMatchesLedger
+  )
+where
+
+import Cardano.Api.Era.Internal.Core
+  ( AllegraEra
+  , AlonzoEra
+  , BabbageEra
+  , CardanoEra
+  , ConwayEra
+  , DijkstraEra
+  , Eon (..)
+  , IsCardanoEra (..)
+  , MaryEra
+  , ShelleyEra
+  , ToCardanoEra (..)
+  )
+import Cardano.Api.Era.Internal.Eon.Convert (Convert (..))
+import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra (ShelleyLedgerEra)
+import Cardano.Api.Experimental.Era qualified as Exp
+
+import Cardano.Ledger.Api.Era qualified as L
+
+import Data.Constraint (Dict (..))
+import Data.Kind (Constraint, Type)
+import Data.Type.Equality (TestEquality (..), (:~:) (..))
+import Data.Typeable (Typeable)
+import GHC.TypeLits (ErrorMessage (..), TypeError)
+
+-- | All Shelley-based eras, in chronological order.
+--
+-- This is the single place where the era timeline is spelled out. Era ranges
+-- ('Onwards', ':-:') are computed slices of this list, so they pick up new
+-- eras automatically. 'timelineMatchesLedger' proves at compile time that
+-- this list stays in sync with the ledger's own era chain.
+--
+-- Byron is excluded, exactly as 'Cardano.Api.ShelleyBasedEra' excludes it.
+type ShelleyBasedEras =
+  '[ShelleyEra, AllegraEra, MaryEra, AlonzoEra, BabbageEra, ConwayEra, DijkstraEra]
+
+-- | The eras supported by the experimental API: the era currently on mainnet
+-- and the upcoming one. This tracks the 'Exp.Era' GADT; see
+-- 'supportedErasAligned' for the compile-time proof that it stays in sync
+-- with @'Onwards' 'ConwayEra'@.
+--
+-- Spelled out as a literal list (rather than via 'Onwards') so that it can
+-- appear in instance heads.
+type SupportedEras = '[ConwayEra, DijkstraEra]
+
+-- | The suffix of the timeline @eras@ starting at @era@.
+type family From (era :: Type) (eras :: [Type]) :: [Type] where
+  From era (era ': eras) = era ': eras
+  From era (_ ': eras) = From era eras
+  From era '[] =
+    TypeError ('Text "From: era " ':<>: 'ShowType era ':<>: 'Text " is not in the timeline")
+
+-- | The prefix of the timeline @eras@ ending at @era@ (inclusive).
+type family UpTo (era :: Type) (eras :: [Type]) :: [Type] where
+  UpTo era (era ': _) = '[era]
+  UpTo era (e ': eras) = e ': UpTo era eras
+  UpTo era '[] =
+    TypeError ('Text "UpTo: era " ':<>: 'ShowType era ':<>: 'Text " is not in the timeline")
+
+-- | All eras from @era@ onwards. A new era added to 'ShelleyBasedEras'
+-- automatically joins every range defined this way.
+--
+-- >>> -- Onwards AlonzoEra ~ '[AlonzoEra, BabbageEra, ConwayEra, DijkstraEra]
+type Onwards era = From era ShelleyBasedEras
+
+-- | The closed era interval from @era1@ to @era2@, both inclusive.
+--
+-- >>> -- ShelleyEra :-: MaryEra ~ '[ShelleyEra, AllegraEra, MaryEra]
+type era1 :-: era2 = UpTo era2 (From era1 ShelleyBasedEras)
+
+-- | Type-level list append. @xs '++' ys@ is the range that covers @xs@
+-- followed by @ys@; see 'splitRange' for the inverse.
+type family (eras1 :: [Type]) ++ (eras2 :: [Type]) :: [Type] where
+  '[] ++ eras = eras
+  (e ': eras1) ++ eras2 = e ': (eras1 ++ eras2)
+
+infixr 5 ++
+
+-- | A witness that @era@ is a member of the era range @eras@, carrying the
+-- 'CardanoEra' singleton for @era@.
+--
+-- This is the generic counterpart of the hand-written eon GADTs:
+-- @'EraIn' ('Onwards' 'AlonzoEra') era@ plays the role of
+-- @AlonzoEraOnwards era@, but works for any range without a dedicated type.
+--
+-- Obtain a witness with 'eraIn' (statically) or 'checkMember' (dynamically),
+-- constraints with 'withRange', and dispatch with 'splitRange'.
+data EraIn (eras :: [Type]) (era :: Type) where
+  EraHere :: CardanoEra era -> EraIn (era ': eras) era
+  EraThere :: EraIn eras era -> EraIn (e ': eras) era
+
+instance Show (EraIn eras era) where
+  showsPrec d = showsPrec d . eraInToCardanoEra
+
+-- | Extract the era singleton from a range membership witness.
+eraInToCardanoEra :: EraIn eras era -> CardanoEra era
+eraInToCardanoEra = \case
+  EraHere era -> era
+  EraThere w -> eraInToCardanoEra w
+
+instance ToCardanoEra (EraIn eras) where
+  toCardanoEra = eraInToCardanoEra
+
+instance Convert (EraIn eras) CardanoEra where
+  convert = eraInToCardanoEra
+
+-- | An era range whose members can be enumerated and tested against.
+-- Instances exist for every type-level list of eras; no per-range code is
+-- needed.
+class KnownEras (eras :: [Type]) where
+  -- | Check whether @era@ is in the range, returning the membership witness
+  -- if so.
+  checkMember :: CardanoEra era -> Maybe (EraIn eras era)
+
+  -- | All eras in the range, in chronological order.
+  knownEras :: [Exp.Some (EraIn eras)]
+
+instance KnownEras '[] where
+  checkMember _ = Nothing
+  knownEras = []
+
+instance (IsCardanoEra e, Typeable eras, KnownEras eras) => KnownEras (e ': eras) where
+  checkMember era =
+    case testEquality era (cardanoEra @e) of
+      Just Refl -> Just $ EraHere era
+      Nothing -> EraThere <$> checkMember era
+  knownEras =
+    Exp.Some (EraHere $ cardanoEra @e)
+      : map (\(Exp.Some w) -> Exp.Some $ EraThere w) (knownEras @eras)
+
+-- | Obtain a membership witness for a statically known era.
+maybeEraIn :: (KnownEras eras, IsCardanoEra era) => Maybe (EraIn eras era)
+maybeEraIn = checkMember cardanoEra
+
+-- | Every 'EraIn' range is an 'Eon', so the existing eon combinators
+-- ('Cardano.Api.forEraInEon', 'Cardano.Api.forEraMaybeEon',
+-- 'Cardano.Api.Featured', ...) work with era ranges unchanged.
+instance KnownEras eras => Eon (EraIn eras) where
+  inEonForEra no yes = maybe no yes . checkMember
+
+-- | Statically known membership of @era@ in the range @eras@: the generic
+-- counterpart of the @Is*BasedEra@ class ladder.
+class HasEraIn (eras :: [Type]) (era :: Type) where
+  -- | The membership witness for @era@.
+  eraIn :: EraIn eras era
+
+instance {-# OVERLAPPING #-} IsCardanoEra era => HasEraIn (era ': eras) era where
+  eraIn = EraHere cardanoEra
+
+instance HasEraIn eras era => HasEraIn (e ': eras) era where
+  eraIn = EraThere eraIn
+
+-- | @'All' c eras@ holds when the constraint @c@ holds for every era in the
+-- range. GHC discharges it instance by instance for a concrete range, so no
+-- hand-written constraint tables are needed - and an era lacking an instance
+-- is a compile error naming that era, not a runtime error.
+type family All (c :: Type -> Constraint) (eras :: [Type]) :: Constraint where
+  All _ '[] = ()
+  All c (era ': eras) = (c era, All c eras)
+
+-- | Constraint product: @(c ':&:' d) era@ holds when both @c era@ and
+-- @d era@ hold. Defined once so that use sites can combine constraints for
+-- 'withRange' without declaring an ad-hoc bundle class:
+--
+-- @
+-- withRange \@(SomeBundleC :&: OtherBundleC) w $ ...
+-- @
+--
+-- (A type synonym would not do here: 'withRange' takes its constraint
+-- parameter unapplied, and type synonyms cannot be passed unsaturated.)
+class (c era, d era) => (c :&: d) era
+
+instance (c era, d era) => (c :&: d) era
+
+infixr 7 :&:
+
+-- | Bring the constraint @c era@ into scope, given that @c@ holds for every
+-- era in the range. This is the generic replacement for the per-eon
+-- @*Constraints@ functions:
+--
+-- @
+-- shelleyBasedEraConstraints sbe f   -- old, per-eon
+-- withRange \@ShelleyBasedC w f      -- new, any range, any constraint
+-- @
+withRange
+  :: forall c eras era a
+   . All c eras
+  => EraIn eras era
+  -> (c era => a)
+  -> a
+withRange w f =
+  case w of
+    EraHere _ -> f
+    EraThere w' -> withRange @c w' f
+
+-- | Like 'withRange', but returning first-class evidence that can be stored
+-- in data structures and applied later with 'Data.Constraint.withDict'.
+rangeDict :: forall c eras era. All c eras => EraIn eras era -> Dict (c era)
+rangeDict w = withRange @c w Dict
+
+-- | Ranges that a wider range can be split at. Instances exist for every
+-- type-level list; no per-boundary code is needed.
+class SplitEras (eras1 :: [Type]) where
+  -- | See 'splitRange'.
+  splitEras
+    :: forall eras2 era
+     . EraIn (eras1 ++ eras2) era
+    -> Either (EraIn eras1 era) (EraIn eras2 era)
+
+instance SplitEras '[] where
+  splitEras = Right
+
+instance SplitEras eras1 => SplitEras (e ': eras1) where
+  splitEras
+    :: forall eras2 era
+     . EraIn ((e ': eras1) ++ eras2) era
+    -> Either (EraIn (e ': eras1) era) (EraIn eras2 era)
+  splitEras = \case
+    EraHere era -> Left $ EraHere era
+    EraThere w -> either (Left . EraThere) Right $ splitEras @eras1 @eras2 w
+
+-- | Split a range at a boundary: the total, generic replacement for the
+-- @caseShelleyToXOrYEraOnwards@ dispatchers.
+--
+-- @
+-- case splitRange \@(ShelleyEra :-: BabbageEra) \@(Onwards ConwayEra) w of
+--   Left shelleyToBabbage -> ...
+--   Right conwayOnwards -> ...
+-- @
+--
+-- Both range arguments must be given by type application, since @eras1 '++'
+-- eras2@ cannot be decomposed by inference.
+splitRange
+  :: forall eras1 eras2 era
+   . SplitEras eras1
+  => EraIn (eras1 ++ eras2) era
+  -> Either (EraIn eras1 era) (EraIn eras2 era)
+splitRange = splitEras @eras1 @eras2
+
+-- | Widen the experimental two-era window to its range form.
+instance Convert Exp.Era (EraIn SupportedEras) where
+  convert = \case
+    Exp.ConwayEra -> EraHere cardanoEra
+    Exp.DijkstraEra -> EraThere $ EraHere cardanoEra
+
+-- | Narrow the range form back to the experimental 'Exp.Era' GADT.
+instance Convert (EraIn SupportedEras) Exp.Era where
+  convert = \case
+    EraHere _ -> Exp.ConwayEra
+    EraThere (EraHere _) -> Exp.DijkstraEra
+    EraThere (EraThere w) -> case w of {}
+
+-- | The ledger's own era chain, derived by walking 'L.PreviousEra' downwards
+-- from an era. The walk stops at Shelley: @'L.PreviousEra' 'L.ShelleyEra'@ is
+-- Byron, whose own predecessor is not exported by the ledger.
+type family ErasDownFrom (era :: Type) :: [Type] where
+  ErasDownFrom L.ShelleyEra = '[L.ShelleyEra]
+  ErasDownFrom era = era ': ErasDownFrom (L.PreviousEra era)
+
+-- | Map a list of cardano-api eras to their ledger eras.
+type family ToLedgerEras (eras :: [Type]) :: [Type] where
+  ToLedgerEras '[] = '[]
+  ToLedgerEras (era ': eras) = ShelleyLedgerEra era ': ToLedgerEras eras
+
+type family Reverse' (acc :: [Type]) (eras :: [Type]) :: [Type] where
+  Reverse' acc '[] = acc
+  Reverse' acc (e ': eras) = Reverse' (e ': acc) eras
+
+-- | The ledger's era chain in chronological order, anchored on
+-- 'L.LatestKnownEra' so that a new ledger era extends it automatically.
+type LedgerTimeline = Reverse' '[] (ErasDownFrom L.LatestKnownEra)
+
+-- | Compile-time proof that 'SupportedEras' tracks
+-- @'Onwards' 'ConwayEra'@. When a new era is appended to 'ShelleyBasedEras',
+-- this stops compiling exactly until 'SupportedEras' (and the 'Exp.Era'
+-- GADT it mirrors) catches up.
+supportedErasAligned :: SupportedEras :~: Onwards ConwayEra
+supportedErasAligned = Refl
+
+-- | Compile-time proof that 'ShelleyBasedEras' matches the ledger's own era
+-- chain. When the ledger bumps 'L.LatestKnownEra', this stops compiling
+-- exactly where cardano-api era support must be added.
+timelineMatchesLedger :: ToLedgerEras ShelleyBasedEras :~: LedgerTimeline
+timelineMatchesLedger = Refl

--- a/cardano-api/src/Cardano/Api/Experimental/Era/Range/Some.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era/Range/Some.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- | \"Some era in a range\", as a 'Vary' of era singletons.
+--
+-- @'SomeEraIn' range@ is the existential counterpart of
+-- @'EraIn' range era@: it holds the singleton of one (statically unknown)
+-- era of the range. It replaces bespoke existentials like @AnyCardanoEra@
+-- and @AnyShelleyBasedEra@, one per range, and inherits 'Vary''s instances
+-- ('Show', 'Eq', 'Ord') and combinators: in particular 'Vary.morph' widens a
+-- @'SomeEraIn' range@ to any wider range in O(1).
+module Cardano.Api.Experimental.Era.Range.Some
+  ( Sings
+  , SomeEraIn
+  , SingIn
+  , someEra
+  , injectEra
+  , VaryEras (..)
+
+    -- * Pattern matching on single eras
+  , onEra
+  , noMoreEras
+  , isEra
+  )
+where
+
+import Cardano.Api.Era.Internal.Core (CardanoEra, IsCardanoEra (..))
+import Cardano.Api.Experimental.Era.Range.Internal
+
+import Data.Kind (Type)
+import Data.Maybe (isJust)
+import Data.Typeable (Typeable)
+
+import Vary (Vary, (:|))
+import Vary qualified
+
+-- | Map a list of eras to their 'CardanoEra' singleton types. The family is
+-- injective, so the range can be inferred back from the singleton list.
+type family Sings (eras :: [Type]) = (r :: [Type]) | r -> eras where
+  Sings '[] = '[]
+  Sings (era ': eras) = CardanoEra era ': Sings eras
+
+-- | The singleton of some era in the range @eras@.
+type SomeEraIn eras = Vary (Sings eras)
+
+-- | Membership of @era@'s singleton in the range's 'Vary', as a constraint.
+-- Holds for every era of a concrete range; used through
+-- @'All' ('SingIn' eras) eras@ by 'injectEra'.
+class CardanoEra era :| Sings eras => SingIn eras era
+
+instance CardanoEra era :| Sings eras => SingIn eras era
+
+-- | Forget which era a membership witness is for, keeping the range. Use
+-- this form when the era is statically known; 'injectEra' handles the
+-- general case.
+someEra :: CardanoEra era :| Sings eras => EraIn eras era -> SomeEraIn eras
+someEra = Vary.from . eraInToCardanoEra
+
+-- | Forget which era a membership witness is for, keeping the range. The
+-- @'All' ('SingIn' eras) eras@ constraint is discharged by GHC for any
+-- concrete range.
+injectEra :: forall eras era. All (SingIn eras) eras => EraIn eras era -> SomeEraIn eras
+injectEra w = withRange @(SingIn eras) w $ someEra w
+
+-- | Ranges whose existential form can be eliminated back into a membership
+-- witness. Instances exist for every type-level list of eras.
+class KnownEras eras => VaryEras (eras :: [Type]) where
+  -- | Bring the era of a @'SomeEraIn' eras@ back into scope, with its
+  -- membership witness and its 'IsCardanoEra' instance.
+  withSomeEra :: SomeEraIn eras -> (forall era. IsCardanoEra era => EraIn eras era -> r) -> r
+
+instance VaryEras '[] where
+  withSomeEra v _ = Vary.exhaustiveCase v
+
+instance (IsCardanoEra e, Typeable eras, VaryEras eras) => VaryEras (e ': eras) where
+  withSomeEra v f =
+    case Vary.pop v of
+      Right era -> f $ EraHere era
+      Left rest -> withSomeEra rest $ \w -> f $ EraThere w
+
+-- | Handle one specific era of a range, chosen by type application, passing
+-- the remaining range on. The 'CardanoEra' wrapper is implicit. Chains of
+-- 'onEra' terminated by 'noMoreEras' are exhaustive for exactly the range -
+-- adding an era to the range is a compile error until a handler is added:
+--
+-- @
+-- v & (onEra \@ConwayEra "mainnet" . onEra \@DijkstraEra "upcoming" $ noMoreEras)
+-- @
+onEra
+  :: forall era eras r
+   . r
+  -> (SomeEraIn eras -> r)
+  -> SomeEraIn (era ': eras)
+  -> r
+onEra matched continue v =
+  case Vary.pop v of
+    Right _ -> matched
+    Left rest -> continue rest
+
+-- | Terminate an 'onEra' chain: an empty range holds no era. Analogous to
+-- 'Vary.exhaustiveCase'.
+noMoreEras :: SomeEraIn '[] -> r
+noMoreEras = Vary.exhaustiveCase
+
+-- | Check whether the era held by a 'SomeEraIn' is @era@, chosen by type
+-- application. The 'CardanoEra' wrapper is implicit.
+isEra :: forall era eras. CardanoEra era :| Sings eras => SomeEraIn eras -> Bool
+isEra = isJust . Vary.into @(CardanoEra era)

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/EraRange.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/EraRange.hs
@@ -1,0 +1,321 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- | Showcase for era ranges ("Cardano.Api.Experimental.Era.Range"): a lower
+-- bounded range, an upper bounded range, narrowing a wider range to a
+-- subset, and nested splits. Certificates make good examples because
+-- certificate support genuinely fragments across eras.
+module Test.Cardano.Api.Experimental.EraRange
+  ( tests
+  )
+where
+
+import Cardano.Api
+  ( AlonzoEra
+  , AnyCardanoEra (..)
+  , BabbageEra
+  , CardanoEra (..)
+  , ConwayEra
+  , DijkstraEra
+  , IsShelleyBasedEra (..)
+  , MaryEra
+  , ShelleyEra
+  , ShelleyLedgerEra
+  )
+import Cardano.Api.Experimental (Some (..))
+import Cardano.Api.Experimental.Era.Range
+import Cardano.Api.Experimental.Era.Range.Some
+
+import Cardano.Crypto.Hash.Class qualified as Hash
+import Cardano.Ledger.Address qualified as L (Addr (..))
+import Cardano.Ledger.Api.Tx.Cert qualified as L
+import Cardano.Ledger.BaseTypes qualified as L (Network (..))
+import Cardano.Ledger.Coin qualified as L (Coin (..))
+import Cardano.Ledger.Conway.TxCert qualified as L (ConwayEraTxCert (..))
+import Cardano.Ledger.Core qualified as L (EraTxOut, mkCoinTxOut)
+import Cardano.Ledger.Credential qualified as L
+import Cardano.Ledger.Hashes qualified as L
+import Cardano.Ledger.Shelley.TxCert qualified as L (ShelleyEraTxCert (..))
+
+import Control.Monad (forM_)
+import Data.ByteString qualified as BS
+import Data.Function ((&))
+import Data.List (isPrefixOf, partition)
+import Data.Maybe (isJust, isNothing)
+
+import Hedgehog (MonadTest, Property, (===))
+import Hedgehog.Extras qualified as H
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+-- * Constraint bundles
+
+--
+-- A bundle is written exactly once, as a plain constraint alias with the
+-- constraints in their natural applied form - the single source of truth,
+-- usable applied in signatures. The class and its universal instance are a
+-- two-line eta-expansion that only REFERENCE the alias: they exist because
+-- 'withRange' takes its constraint parameter unapplied, and type synonyms
+-- cannot be passed unsaturated, while a class name can.
+
+-- Note: @Show (L.TxCert (ShelleyLedgerEra era))@ and friends are deliberately
+-- absent from the bundles - ledger classes carry 'Show'\/'Eq'\/CBOR
+-- superclasses on their associated types, so listing them explicitly would
+-- trigger @-Wredundant-constraints@ in the leaf signatures below.
+
+type ConwayCertConstraints era =
+  ( IsShelleyBasedEra era
+  , L.ConwayEraTxCert (ShelleyLedgerEra era)
+  , L.EraTxOut (ShelleyLedgerEra era)
+  )
+
+class ConwayCertConstraints era => ConwayCertsC era
+
+instance ConwayCertConstraints era => ConwayCertsC era
+
+type LegacyCertConstraints era =
+  ( IsShelleyBasedEra era
+  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  )
+
+class LegacyCertConstraints era => LegacyCertsC era
+
+instance LegacyCertConstraints era => LegacyCertsC era
+
+-- * Showcase functions
+
+--
+-- Functions that do not dispatch state their requirements once, in the
+-- signature; 'withRange' appears only at the boundary (in the properties
+-- below, where enumerated witnesses meet these signatures). Functions that
+-- DO dispatch ('describeCert', 'eraGeneration') need 'withRange' inside the
+-- branches: each branch's constraints do not hold for the whole input
+-- range, so no signature could carry them.
+--
+-- The type applications on the ledger functions are required: @TxCert@ and
+-- @ShelleyLedgerEra@ are type families, so the ledger era cannot be
+-- inferred from the context. Call sites pin @era@ the same way.
+
+-- | Era lower bound: 'L.ConwayEraTxCert' holds for every era from Conway
+-- onwards. Dijkstra has its own concrete certificate type (@DijkstraTxCert@),
+-- but still supports the class, so this function covers it too. The bundle
+-- combines an api-level constraint with two independent ledger hierarchies
+-- (certificates and outputs); @Show@ for the results needs no separate
+-- constraint, as it is a superclass of both.
+conwayDelegationCert
+  :: forall era
+   . ConwayCertConstraints era
+  => L.Addr
+  -> L.Credential L.Staking
+  -> L.Delegatee
+  -> String
+conwayDelegationCert changeAddress credential delegatee =
+  show (shelleyBasedEra @era)
+    <> ": "
+    <> show (L.mkDelegTxCert @(ShelleyLedgerEra era) credential delegatee)
+    <> " paying to "
+    <> show (L.mkCoinTxOut @(ShelleyLedgerEra era) changeAddress (L.Coin 0))
+
+-- | Era upper bound: 'L.ShelleyEraTxCert' stops at Conway (the class itself
+-- carries @AtMostEra \"Conway\"@), so it is only derivable for ranges bounded
+-- above by Conway.
+legacyRegistrationCert
+  :: forall era
+   . LegacyCertConstraints era
+  => L.Credential L.Staking
+  -> String
+legacyRegistrationCert credential =
+  show (shelleyBasedEra @era)
+    <> ": "
+    <> show (L.mkRegTxCert @(ShelleyLedgerEra era) credential)
+
+-- | Era range subset: narrow the full timeline at the Babbage\/Conway
+-- boundary with 'splitRange', gaining the Conway certificate constraints
+-- only on the narrowed side. This is the total replacement for
+-- @caseShelleyToBabbageOrConwayEraOnwards@. Here 'withRange' must sit inside
+-- the branches: neither branch's constraints hold for the whole input range.
+describeCert
+  :: forall era
+   . EraIn ShelleyBasedEras era
+  -> L.Credential L.Staking
+  -> L.Delegatee
+  -> String
+describeCert w credential delegatee =
+  case splitRange @(ShelleyEra :-: BabbageEra) @(Onwards ConwayEra) w of
+    Left shelleyToBabbage ->
+      withRange @LegacyCertsC shelleyToBabbage $
+        "legacy: " <> show (L.mkRegTxCert @(ShelleyLedgerEra era) credential)
+    Right conwayOnwards ->
+      withRange @ConwayCertsC conwayOnwards $
+        "conway: " <> show (L.mkDelegTxCert @(ShelleyLedgerEra era) credential delegatee)
+
+-- | Nested 'splitRange': the piece of one split is a range like any other,
+-- so it can be split again, giving a total n-way dispatch. (The old
+-- @caseShelleyToXOrYEraOnwards@ dispatchers could not be nested safely.)
+eraGeneration :: EraIn ShelleyBasedEras era -> String
+eraGeneration w =
+  case splitRange @(ShelleyEra :-: MaryEra) @(Onwards AlonzoEra) w of
+    Left _preAlonzo -> "pre-Plutus"
+    Right alonzoOnwards ->
+      case splitRange @(AlonzoEra :-: BabbageEra) @(Onwards ConwayEra) alonzoOnwards of
+        Left _alonzoToBabbage -> "Plutus"
+        Right _conwayOnwards -> "governance"
+
+-- | Pattern matching a single era out of a range, idiom 1: case on the
+-- 'CardanoEra' singleton. Each arm refines @era@ to the concrete era (so
+-- every ledger instance resolves there), but the match cannot be exhaustive
+-- for the range - the singleton type admits all eras, so a wildcard arm is
+-- required for the eras the witness rules out.
+nameEra :: EraIn (Onwards ConwayEra) era -> String
+nameEra w =
+  case eraInToCardanoEra w of
+    ConwayEra -> "mainnet"
+    DijkstraEra -> "upcoming"
+    -- Not reliable, avoid: the checker cannot see that the witness rules
+    -- these eras out, and the wildcard silently swallows any era later
+    -- added to the range, losing the compile-time tripwire. Prefer the
+    -- exhaustive 'onEra' chain ('nameEraExhaustive' below).
+    _ -> "unreachable: not in Onwards ConwayEra"
+
+-- | Pattern matching a single era out of a range, idiom 2: an exhaustive
+-- 'onEra' chain over the existential form. This is total for exactly the
+-- range - adding an era to the range makes this a compile error until a
+-- handler is added - at the cost of erasing the type-level @era@.
+nameEraExhaustive :: EraIn (Onwards ConwayEra) era -> String
+nameEraExhaustive w =
+  injectEra w
+    & ( onEra @ConwayEra "mainnet"
+          . onEra @DijkstraEra "upcoming"
+          $ noMoreEras
+      )
+
+-- The negative space matters as much: these must NOT compile.
+--
+-- ShelleyEraTxCert has no Dijkstra instance, so requesting it for an
+-- unbounded range fails with "No instance for ShelleyEraTxCert DijkstraEra":
+--
+-- > bad w = withRange @LegacyCertsC
+-- >           (w :: EraIn (Onwards ConwayEra) era)
+--
+-- And an era outside the timeline is rejected by the range constructors:
+--
+-- > type Bad = Onwards Int   -- "From: era Int is not in the timeline"
+
+-- * Properties
+
+prop_era_range_lower_bound :: Property
+prop_era_range_lower_bound = H.propertyOnce $ do
+  changeAddress <- mkDummyAddress
+  credential <- mkDummyStakeCredential
+  delegatee <- L.DelegStake <$> mkDummyKeyHash
+  -- The explicit signature is needed by GHC 9.6/9.10: GADTs implies
+  -- MonoLocalBinds, so the let binding is not generalised, and the
+  -- Foldable-generic consumers below leave the type ambiguous otherwise.
+  let labels :: [String]
+      labels =
+        [ withRange @ConwayCertsC w $ conwayDelegationCert @era changeAddress credential delegatee
+        | Some (w :: EraIn (Onwards ConwayEra) era) <- knownEras @(Onwards ConwayEra)
+        ]
+  length labels === 2 -- Conway and Dijkstra
+  H.assertWith labels $ not . any null
+
+prop_era_range_upper_bound :: Property
+prop_era_range_upper_bound = H.propertyOnce $ do
+  credential <- mkDummyStakeCredential
+  let labels :: [String]
+      labels =
+        [ withRange @LegacyCertsC w $ legacyRegistrationCert @era credential
+        | Some (w :: EraIn (ShelleyEra :-: ConwayEra) era) <- knownEras @(ShelleyEra :-: ConwayEra)
+        ]
+  length labels === 6 -- Shelley up to and including Conway
+  H.assertWith labels $ not . any null
+
+prop_era_range_subset :: Property
+prop_era_range_subset = H.propertyOnce $ do
+  credential <- mkDummyStakeCredential
+  delegatee <- L.DelegStake <$> mkDummyKeyHash
+  let labels =
+        [ describeCert w credential delegatee
+        | Some w <- knownEras @ShelleyBasedEras
+        ]
+      (legacy, conway) = partition ("legacy: " `isPrefixOf`) labels
+  length legacy === 5 -- Shelley to Babbage
+  length conway === 2 -- Conway and Dijkstra
+  H.assertWith conway $ all ("conway: " `isPrefixOf`)
+
+prop_era_range_nested_split :: Property
+prop_era_range_nested_split = H.propertyOnce $ do
+  let generations = [eraGeneration w | Some w <- knownEras @ShelleyBasedEras]
+  generations
+    === [ "pre-Plutus" -- Shelley
+        , "pre-Plutus" -- Allegra
+        , "pre-Plutus" -- Mary
+        , "Plutus" -- Alonzo
+        , "Plutus" -- Babbage
+        , "governance" -- Conway
+        , "governance" -- Dijkstra
+        ]
+
+prop_era_range_single_era_match :: Property
+prop_era_range_single_era_match = H.propertyOnce $ do
+  let names = [nameEra w | Some w <- knownEras @(Onwards ConwayEra)]
+      namesExhaustive = [nameEraExhaustive w | Some w <- knownEras @(Onwards ConwayEra)]
+      someEras = [injectEra w | Some w <- knownEras @(Onwards ConwayEra)]
+  names === ["mainnet", "upcoming"]
+  namesExhaustive === names
+  map (isEra @ConwayEra) someEras === [True, False]
+  map (isEra @DijkstraEra) someEras === [False, True]
+
+prop_era_range_membership :: Property
+prop_era_range_membership = H.propertyOnce $ do
+  -- Babbage predates the Conway-onwards range.
+  H.assertWith (checkMember @(Onwards ConwayEra) BabbageEra) isNothing
+  -- Dijkstra is in every Onwards range (regression test for the missing
+  -- Dijkstra arm in TestEquality CardanoEra).
+  H.assertWith (checkMember @(Onwards ConwayEra) DijkstraEra) isJust
+  H.assertWith (checkMember @ShelleyBasedEras DijkstraEra) isJust
+  -- Dijkstra is beyond an upper bounded range.
+  H.assertWith (checkMember @(ShelleyEra :-: ConwayEra) DijkstraEra) isNothing
+
+prop_era_range_vary_roundtrip :: Property
+prop_era_range_vary_roundtrip = H.propertyOnce $
+  forM_ (knownEras @ShelleyBasedEras) $ \(Some w) ->
+    withSomeEra (injectEra w) $ \w' ->
+      AnyCardanoEra (eraInToCardanoEra w') === AnyCardanoEra (eraInToCardanoEra w)
+
+-- * Dummy values
+
+mkDummyKeyHash :: MonadTest m => m (L.KeyHash r)
+mkDummyKeyHash = do
+  hash <- H.nothingFail $ Hash.hashFromBytes $ BS.replicate 28 0
+  pure $ L.KeyHash hash
+
+mkDummyStakeCredential :: MonadTest m => m (L.Credential L.Staking)
+mkDummyStakeCredential = L.KeyHashObj <$> mkDummyKeyHash
+
+mkDummyAddress :: MonadTest m => m L.Addr
+mkDummyAddress = do
+  paymentKeyHash <- mkDummyKeyHash
+  pure $ L.Addr L.Testnet (L.KeyHashObj paymentKeyHash) L.StakeRefNull
+
+tests :: TestTree
+tests =
+  testGroup
+    "Test.Cardano.Api.Experimental.EraRange"
+    [ testProperty "era range lower bound" prop_era_range_lower_bound
+    , testProperty "era range upper bound" prop_era_range_upper_bound
+    , testProperty "era range subset via splitRange" prop_era_range_subset
+    , testProperty "era range nested splitRange" prop_era_range_nested_split
+    , testProperty "era range single era match" prop_era_range_single_era_match
+    , testProperty "era range membership" prop_era_range_membership
+    , testProperty "era range vary roundtrip" prop_era_range_vary_roundtrip
+    ]

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -15,6 +15,7 @@ import Test.Cardano.Api.Envelope qualified
 import Test.Cardano.Api.EpochLeadership qualified
 import Test.Cardano.Api.Eras qualified
 import Test.Cardano.Api.Experimental qualified
+import Test.Cardano.Api.Experimental.EraRange qualified
 import Test.Cardano.Api.Experimental.Fee qualified
 import Test.Cardano.Api.Genesis qualified
 import Test.Cardano.Api.GovAnchorValidation qualified
@@ -56,6 +57,7 @@ tests =
     , Test.Cardano.Api.EpochLeadership.tests
     , Test.Cardano.Api.Eras.tests
     , Test.Cardano.Api.Experimental.tests
+    , Test.Cardano.Api.Experimental.EraRange.tests
     , Test.Cardano.Api.Experimental.Fee.tests
     , Test.Cardano.Api.Genesis.tests
     , Test.Cardano.Api.IO.tests

--- a/era-ranges-with-vary-design.md
+++ b/era-ranges-with-vary-design.md
@@ -1,0 +1,373 @@
+# Era ranges with `vary`: a design to replace eon boilerplate
+
+Status: draft proposal.
+Branch: `mgalazyn/support-era-ranges-with-vary`.
+
+## Problem
+
+The current eon machinery costs ~2,500 lines across `Cardano/Api/Era/Internal/` and scales badly:
+
+- 12 hand-written era-range GADTs (`ShelleyBasedEra`, `AlonzoEraOnwards`, `ShelleyToBabbageEra`, ...), each a ~110-150 line module of identical shape: GADT, `Eon`/`ToCardanoEra`/`Convert` instances, a `<Name>Constraints` synonym that re-lists a ~33-item constraint preamble, a CPS reifier, and an `Is*BasedEra` class.
+- Adding a new era touches every eon module, all six `Case.hs` dispatchers, the existentials, and the `Is*` ladder.
+- Adding a new range costs a whole new module.
+- The scheme fails open at runtime: every constraint bundle except `alonzoEraOnwardsConstraints` is an `error "TODO Dijkstra"` stub, all six `caseXOrY` dispatchers error on Dijkstra, and `AnyCardanoEra` cannot even represent Dijkstra.
+
+The experimental API (ADR-004) sidesteps eons by fixing a two-era window (`Era` = Conway | Dijkstra) with one constraint bundle, but it cannot express historical eras, and ADR-016 notes that any back-port "would need to be revisited".
+
+## Design principles
+
+- **Simplicity first: the API must be easy to grok by newcomers.**
+  The public vocabulary is deliberately tiny: a range alias (`Onwards ConwayEra`, `ShelleyEra :-: BabbageEra`), a witness (`EraIn range era`), one way to get constraints (`withRange`), one way to dispatch (`split`, `Vary.on`).
+  A newcomer should be able to read a signature like `f :: EraIn (Onwards AlonzoEra) era -> Tx era -> X` and understand it without knowing any of the machinery.
+- **Focus on reducing boilerplate.**
+  Every layer below exists to delete hand-maintained code: no per-range modules, no per-range instances, no hand-copied constraint tables, no per-boundary dispatchers.
+  If a proposed feature requires per-range or per-era code, it fails this principle.
+- **Proper abstractions hiding the gory details.**
+  Type families (`From`/`UpTo`/`All`), structural induction (`Here`/`There`), overlapping instances and any positional `unsafeCoerce` tricks live in an `Internal` module and never leak into user-facing signatures or error messages.
+  User-facing failures must read as domain errors ("`ShelleyEraTxCert` has no `DijkstraEra` instance", "era not in range `Onwards AlonzoEra`" via custom `TypeError`s), not as exposed type-level plumbing.
+
+## Core idea
+
+An era range is not a datatype, it is a **type-level list of era tags**, sliced from a single master timeline.
+Membership, subset and widening then come from `vary`'s vocabulary (`(:|)`, `Subset`, `morph`), constraints come from a generic `All` family selected through a structural membership witness, and existential dispatch is a `Vary` of era singletons.
+
+Everything below is written once, generically.
+No per-range modules, no per-range constraint tables, no per-range instances.
+
+### Layer 0: one master timeline, grounded in the ledger
+
+The ledger already encodes the era chain.
+`Cardano.Ledger.Internal.Definition.Era` (cardano-ledger-core) defines every era as an empty data type, and the `Era` class carries an injective associated family encoding the predecessor relation:
+
+```haskell
+type PreviousEra era = (r :: Type) | r -> era
+-- PreviousEra DijkstraEra = ConwayEra, ..., PreviousEra ShelleyEra = ByronEra
+type LatestKnownEra = DijkstraEra
+```
+
+All of it imports cleanly from `Cardano.Ledger.Api.Era` (cardano-api already depends on cardano-ledger-api); never import the warning-tagged `Cardano.Ledger.Internal.Era`.
+The chain is walkable with a closed family - injectivity is not needed for the backward walk, only concrete reduction:
+
+```haskell
+type family ErasDownFrom (era :: Type) :: [Type] where
+  ErasDownFrom L.ShelleyEra = '[L.ShelleyEra]                        -- stop before Byron/VoidEra
+  ErasDownFrom era          = era ': ErasDownFrom (L.PreviousEra era)
+```
+
+(The base case must be an exported era: `PreviousEra ByronEra` is the deliberately unexported `VoidEra`.)
+
+Two ways to define the cardano-api timeline:
+
+- **Derive it**: `type LedgerEras = Reverse (ErasDownFrom L.LatestKnownEra)`, over ledger era types.
+  This matches ADR-016's direction ("index the type by the ledger era, not the cardano-api era"), and a new ledger era extends the timeline without touching this module.
+- **Verify it**: keep a hand-written list over cardano-api tags, with a compile-time canary asserting it maps (through the injective `ShelleyLedgerEra` family) onto the derived ledger chain.
+  When the ledger bumps `LatestKnownEra`, the canary breaks at compile time, exactly where era support must be added.
+
+```haskell
+type ShelleyBasedEras =
+  '[ShelleyEra, AllegraEra, MaryEra, AlonzoEra, BabbageEra, ConwayEra, DijkstraEra]
+```
+
+Recommendation: start with the verified hand-written list over cardano-api tags, because layers 2-4 speak `CardanoEra` singletons; revisit deriving over ledger eras once the ledger-indexed experimental `TxBodyContent` becomes the main consumer.
+Byron stays outside, exactly as `ShelleyBasedEra` excludes it today; the ledger's usable upgrade chain also starts at Shelley (the `ByronEra` instances of `TranslateEra`/`EraApi` are error stubs).
+(`ByronToAlonzoEra` is nearly dead: `caseByronOrShelleyBasedEra` is already slated for deletion.)
+
+### Layer 1: ranges are computed slices
+
+```haskell
+type family From (e :: Type) (es :: [Type]) :: [Type] where
+  From e (e ': rest) = e ': rest
+  From e (_ ': rest) = From e rest
+
+type family UpTo (e :: Type) (es :: [Type]) :: [Type] where
+  UpTo e (e ': _)    = '[e]
+  UpTo e (x ': rest) = x ': UpTo e rest
+
+type Onwards e  = From e ShelleyBasedEras
+type e1 :-: e2  = UpTo e2 (From e1 ShelleyBasedEras)
+
+-- Every existing eon becomes a one-line alias:
+type AlonzoOnwards    = Onwards AlonzoEra          -- '[AlonzoEra, BabbageEra, ConwayEra, DijkstraEra]
+type ShelleyToBabbage = ShelleyEra :-: BabbageEra
+type SupportedEras = Onwards ConwayEra          -- ADR-004's window is just another range
+```
+
+A new era appended to `ShelleyBasedEras` automatically joins every `Onwards`-defined range.
+A new range is one line.
+
+### Aside: the ledger's own ordering machinery, and when to use it instead
+
+The ledger encodes era order a second way: Nat-valued protocol-version bounds per era (`ProtVerLow`/`ProtVerHigh`: Shelley 2, ..., Conway 9-11, Dijkstra 12), with constraint aliases built on them in `Cardano.Ledger.Core.Era` (re-exported by `Cardano.Ledger.Api.Era`):
+
+```haskell
+type AtLeastEra (n :: Symbol) era = ProtVerAtLeast era (ProtVerLow (EraFromName n))
+type AtMostEra  (n :: Symbol) era = ProtVerAtMost  era (ProtVerHigh (EraFromName n))
+type ExactEra inEra era           = ProtVerInBounds era (ProtVerLow inEra) (ProtVerHigh inEra)
+```
+
+For a signature that merely constrains a single ledger era to a bound, with no dispatch and no witness, these already suffice at zero cost - e.g. `hkdProtocolVersionL` requires `AtMostEra "Babbage" era` today.
+The list-based ranges complement rather than replace them: lists add what bounds alone cannot - the `EraIn` runtime witness, `All`-derived constraint reification, total `split`, and enumeration (`SomeEraIn`, generic `Bounded`/`Enum`).
+Where both work, prefer the ledger alias in ledger-era-indexed signatures and the range machinery where cardano-api needs witnesses or dispatch.
+
+Adjacent and worth knowing: `TranslateEra` and `EraApi`'s `upgradeTx`/`upgradeTxOut`/... are keyed on `PreviousEra` (`X (PreviousEra era) -> X era`), a ready-made per-step upgrade to build range-crossing conversions on later.
+
+### Layer 2: one witness type replaces twelve GADTs
+
+```haskell
+-- Structural proof that era is in the list es, carrying the singleton.
+data EraIn (es :: [Type]) (era :: Type) where
+  Here  :: CardanoEra era -> EraIn (era ': es) era
+  There :: EraIn es era -> EraIn (e ': es) era
+
+eraInToCardanoEra :: EraIn es era -> CardanoEra era
+```
+
+`EraIn AlonzoOnwards era` is isomorphic to today's `AlonzoEraOnwards era`, but the type is generic in the range.
+Conjuring a witness from a `CardanoEra` singleton is one inductive class, which simultaneously provides the `Eon` instance for **every** range at once:
+
+```haskell
+class KnownEras (es :: [Type]) where
+  checkMember :: CardanoEra era -> Maybe (EraIn es era)
+
+instance KnownEras '[] where
+  checkMember _ = Nothing
+
+instance (IsCardanoEra e, KnownEras es) => KnownEras (e ': es) where
+  checkMember era = case testEquality era (cardanoEra @e) of
+    Just Refl -> Just $ Here era
+    Nothing   -> There <$> checkMember era
+
+instance KnownEras es => Eon (EraIn es) where
+  inEonForEra no yes era = maybe no yes $ checkMember era
+```
+
+That single `Eon` instance means the entire existing combinator zoo (`forEraInEon`, `forEraMaybeEon`, `maybeEon`, `monoidForEraInEon`, `Featured`, `EraInEon`) works unchanged for every range: `Featured (EraIn ConwayOnwards) era a` type-checks today because `Featured` abstracts over `eon :: Type -> Type`.
+
+The seven-class `Is*BasedEra` ladder collapses into constraints of the form `HasEraIn es era` (one overlapping-instance class that produces `EraIn es era` the way `Is*BasedEra` produces eon witnesses), or simply `IsCardanoEra era` plus a runtime `checkMember`.
+
+### Honest overlap: what is and is not reimplemented from vary
+
+`EraIn`'s `Here`/`There` induction replicates the *technique* vary uses internally for its own instances, not vary's *function*.
+The distinction:
+
+- `Vary (Sings range)` is existential: "some era in the range", with the era's type-level identity erased.
+- `EraIn range era` is indexed: a proof about the specific type variable `era` that other values in scope (`Tx era`, `TxBody era`) share.
+  Vary's public API has no indexed witness, and eons are exactly indexed witnesses, so this half cannot be delegated to vary.
+- Constraint dispatch (`All`/`withRange`) does not exist in vary at all; vary's own `Eq`/`Show`/`Hashable` instances hand-roll the same head/tail induction privately, and `Vary.Core` is an unexposed other-module.
+
+So the parts that look like vary internals are precisely the parts vary does not export; the parts vary does export (the existential value, O(1) `morph`, `(:|)`, `Subset`) are used rather than rebuilt, in `Range.Some`.
+
+If less duplication is wanted there are two routes:
+
+- Represent membership positionally with vary's `(:|)` (type-level index + `KnownNat`) and select dictionaries from a table at that index with `unsafeCoerce` - exactly `Vary.Core`'s discipline.
+  O(1) instead of O(range length), but it imports unsafe coercion into cardano-api and loses the GADT refinement that makes `withRange` and `splitRange` total by construction.
+  With ranges capped at 7 eras, safety wins over the constant factor.
+- Upstream: propose an indexed membership witness (a `Vary.Elem`) and an `All`-style constraint fold to vary itself; if accepted, `EraIn` and `withRange` shrink to thin wrappers.
+
+### Layer 3: constraints for a range, derived instead of hand-listed
+
+```haskell
+type family All (c :: Type -> Constraint) (es :: [Type]) :: Constraint where
+  All _ '[]       = ()
+  All c (e ': es) = (c e, All c es)
+
+-- The one generic reifier replacing all twelve *Constraints CPS functions:
+withRange :: forall c es era r. All c es => EraIn es era -> (c era => r) -> r
+withRange (Here _)  k = k
+withRange (There m) k = withRange @c m k
+
+-- First-class evidence when it needs to be stored (in a Vary arm, a record, a Map):
+rangeDict :: forall c es era. All c es => EraIn es era -> Dict (c era)
+rangeDict (Here _)  = Dict
+rangeDict (There m) = rangeDict @c m
+```
+
+The decisive property: `All c es` for a concrete range is discharged by GHC **from the real ledger instances, era by era**.
+Nobody writes the 33-constraint tables any more.
+And Dijkstra failure mode inverts: where today `conwayEraOnwardsConstraints` compiles and then explodes at runtime, `withRange @c` on a range containing `DijkstraEra` simply fails to compile with "no instance `c DijkstraEra`" until the ledger support lands.
+That is precisely the compile-time tripwire AGENTS.md already recommends for concrete-era dispatch.
+
+Constraints are requested through named bundles, and the agreed idiom keeps each constraint list written exactly once: a plain constraint alias, with the constraints in their natural applied form, is the single source of truth (used applied in signatures); a two-line class+instance eta-expansion references the alias and makes it passable to `withRange` unapplied (a synonym alone cannot serve there - synonyms cannot be passed unsaturated, and no GHC 9.6-compatible extension lifts that):
+
+```haskell
+type ConwayCertConstraints era =
+  ( IsShelleyBasedEra era
+  , L.ConwayEraTxCert (ShelleyLedgerEra era)
+  )
+
+class ConwayCertConstraints era => ConwayCertsC era
+
+instance ConwayCertConstraints era => ConwayCertsC era
+
+-- signatures use the alias, applied; boundaries use the class, unapplied:
+f :: ConwayCertConstraints era => Tx era -> X
+g w = withRange @ConwayCertsC w $ f ...
+```
+
+Named bundle classes also dodge GHC's constraint-tuple arity cap and keep error messages readable.
+Note that ledger classes already carry `Show`/`Eq`/CBOR superclasses on their associated types (e.g. `Show (TxCert era)` is a superclass of `EraTxCert`), so bundles stay small - and listing such implied constraints in an alias used in signatures would trip `-Wredundant-constraints`.
+The fixed cost of each eta-expansion site is the pragma trio `FlexibleInstances`, `UndecidableInstances`, `UndecidableSuperClasses` (the superclass chain reaches ledger's `ProtVerLow <= ProtVerHigh` family constraint, and the universal instance fails the Paterson condition by design).
+
+This also scales to the eon-sized bundles: the existing `type XConstraints era = (...)` synonyms stay as-is and gain the two-line eta-expansion, with the 30-odd constraints never repeated.
+`(:&:)` remains for combining two bundle classes at a boundary without naming the combination.
+A one-line canary `_ok :: Dict (All AlonzoOnwardsC AlonzoOnwards); _ok = Dict` verifies a bundle for the whole range at library-compile time.
+
+### Layer 4: `Vary` for the existential side
+
+```haskell
+type family Sings (es :: [Type]) :: [Type] where
+  Sings '[]       = '[]
+  Sings (e ': es) = CardanoEra e ': Sings es
+
+-- "some era in the range" - replaces AnyCardanoEra, AnyShelleyBasedEra, EraInEon, Some Era
+type SomeEraIn es = Vary (Sings es)
+
+someEra     :: EraIn es era -> SomeEraIn es
+withSomeEra :: KnownEras es => SomeEraIn es -> (forall era. EraIn es era -> r) -> r
+```
+
+What `vary` buys here:
+
+- `Vary.morph` widens `SomeEraIn AlonzoOnwards` to `SomeEraIn ShelleyBasedEras` in O(1) (a retag), replacing the hand-written `Convert`/`AnyX -> AnyY` conversion swarm.
+- `Vary.on @(CardanoEra ConwayEra) ... $ Vary.exhaustiveCase` gives total per-era dispatch where adding an era to the master list breaks every dispatch site at compile time - the tripwire again, now enforced by types instead of by convention.
+- `Show`/`Eq`/`Ord`/`ToJSON` for `SomeEraIn es` come free from vary's own inductive instances over `CardanoEra e`'s instances.
+- vary's `(:|)` and `Subset` provide the membership/subset constraint vocabulary for signatures (`era :| AlonzoOnwards =>`), with custom `TypeError`s already built in.
+
+`vary` has no constraint-dispatch facility of its own; that is exactly what Layers 2-3 add, using the same head/tail induction vary uses internally for its instances.
+
+### Case.hs replacement
+
+`ShelleyBasedEras = ShelleyToBabbage ++ ConwayOnwards` holds by construction, so the six boundary dispatchers become one generic total function:
+
+```haskell
+split :: KnownLength xs => EraIn (xs ++ ys) era -> Either (EraIn xs era) (EraIn ys era)
+```
+
+`caseShelleyToBabbageOrConwayEraOnwards f g sbe` becomes `either f g (split w)`, with constraints recovered inside `f`/`g` via `withRange`.
+No Dijkstra error arms are possible: `split` is total for whatever the master list contains.
+Splits also nest: the piece of one split is a range like any other, so n-way dispatch is nested two-way splits - something the old dispatchers could not do (nesting `forShelleyBasedEraInEon` is explicitly forbidden today).
+
+## Module layout and compatibility with `Cardano.Api.Experimental.Era`
+
+The new code lives under `Cardano.Api.Experimental.Era.*`, next to the API it must interoperate with:
+
+```
+Cardano.Api.Experimental.Era.Range        -- From/UpTo/Onwards/(:-:), EraIn, KnownEras, All, withRange, rangeDict, split
+Cardano.Api.Experimental.Era.Range.Some   -- Sings, SomeEraIn, someEra, withSomeEra (the vary dependency is isolated here)
+```
+
+Compatibility with the existing experimental `Era` GADT is total and mechanical, because the experimental window is itself a range:
+
+```haskell
+type SupportedEras = Onwards ConwayEra   -- '[ConwayEra, DijkstraEra], tracks the Era GADT by construction
+
+instance Convert Era (EraIn SupportedEras) where
+  convert = \case
+    ConwayEra   -> Here (cardanoEra @ConwayEra)
+    DijkstraEra -> There (Here (cardanoEra @DijkstraEra))
+
+instance Convert (EraIn SupportedEras) Era where
+  convert = \case
+    Here _         -> ConwayEra
+    There (Here _) -> DijkstraEra
+```
+
+- `obtainCommonConstraints` interop: wrap `EraCommonConstraints` in a class synonym `CommonC`, then `withRange @CommonC w k` on an `EraIn SupportedEras era` is exactly `obtainCommonConstraints (convert w) k`.
+- `IsEra era` gives `HasEraIn SupportedEras era` (witness conjuring), so experimental call sites need no new constraints.
+- `sbeToEra`'s narrowing role is subsumed by `checkMember`/`split`: `split @(ShelleyEra :-: BabbageEra)` on the full timeline returns the deprecated eras on the `Left` and `EraIn SupportedEras era` on the `Right`, replacing the `DeprecatedEra` throw with a total `Either`.
+
+This placement follows ADR-009 (experimental modules are the sandbox for not-yet-stabilised APIs) and keeps the old `Cardano.Api.Era.Internal.Eon.*` tree untouched until migration starts.
+
+## Showcase tests
+
+A new test module `Test.Cardano.Api.Experimental.EraRange` demonstrates the three range shapes with real ledger constraints.
+The cert classes make ideal examples because certificate support genuinely fragments across eras: `L.ConwayEraTxCert` holds from Conway onwards (Dijkstra keeps the class even though its concrete `TxCert` type is the separate `DijkstraTxCert`), while `L.ShelleyEraTxCert` stops before Dijkstra.
+
+```haskell
+-- 1. Lower bound (Onwards range): ConwayEraTxCert holds for every era in Onwards ConwayEra.
+--    Compiles because GHC discharges All ConwayCertsC '[ConwayEra, DijkstraEra]
+--    from the real ledger instances, including Dijkstra's.
+prop_lower_bound :: Property
+prop_lower_bound = ... $ \(w :: EraIn (Onwards ConwayEra) era) ->
+  withRange @ConwayCertsC w $
+    -- e.g. build a delegation certificate via mkDelegTxCert and inspect it
+    ...
+
+-- 2. Upper bound (:-: range): ShelleyEraTxCert has NO Dijkstra instance,
+--    so it is only derivable for ranges bounded above by Conway.
+prop_upper_bound :: Property
+prop_upper_bound = ... $ \(w :: EraIn (ShelleyEra :-: ConwayEra) era) ->
+  withRange @LegacyCertsC w $
+    -- e.g. build a legacy RegTxCert and inspect it
+    ...
+
+-- 3. Subset: start from the full timeline, split at the Babbage/Conway boundary,
+--    and gain ConwayEraTxCert only on the narrowed side.
+prop_subset :: Property
+prop_subset = ... $ \(w :: EraIn ShelleyBasedEras era) ->
+  case split @(ShelleyEra :-: BabbageEra) w of
+    Left _preConway ->
+      -- no Conway cert machinery here, and requesting it would not compile
+      ...
+    Right (conwayOnwards :: EraIn (Onwards ConwayEra) era) ->
+      withRange @ConwayCertsC conwayOnwards $ ...
+```
+
+The negative space is as important as the tests: `withRange @LegacyCertsC` over `Onwards ConwayEra` must NOT compile (Dijkstra lacks the `ShelleyEraTxCert` instance), and neither must a `TxCert era ~ L.ConwayTxCert era` equality outside the singleton range `'[ConwayEra]` - the exact equality whose unsatisfiability makes today's `conwayEraOnwardsConstraints` crash at runtime for Dijkstra.
+These are documented as commented-out must-not-compile examples next to the tests (a deliberate-compile-failure test target can follow later).
+
+## What dies, what replaces it
+
+| Today | LOC | Replacement | LOC |
+|---|---|---|---|
+| 12 eon GADT modules | ~1,770 | `EraIn` + `KnownEras` + range aliases | ~60 + 1 line/range |
+| 12 `*Constraints` synonyms + reifiers | (incl. above) | `All` + `withRange`/`rangeDict` | ~20 |
+| 13 `Eon` instances | (incl. above) | 1 `Eon (EraIn es)` instance | ~5 |
+| ~30 `Convert` instances | (incl. above) | `checkMember`/`morph`/one `widen` | ~15 |
+| `Case.hs` (6 dispatchers, all Dijkstra bombs) | 134 | generic `split` | ~25 |
+| `Is*BasedEra` 7-class ladder | (spread) | `HasEraIn` class | ~10 |
+| `AnyCardanoEra`/`AnyShelleyBasedEra`/`EraInEon`/`Some Era` | ~250 | `SomeEraIn es` + generic Bounded/Enum | ~40 |
+| Per-new-era cost: every module above | | extend master list + tag/singleton/`IsCardanoEra`; ranges update automatically | |
+
+Rough total: ~2,500 lines of manually-maintained machinery becomes a ~250-line generic core plus one alias per range.
+Runtime `error "TODO Dijkstra"` stubs in the era machinery become compile errors at exactly the call sites that need missing instances.
+
+## Migration story
+
+- `EraIn es` is an `Eon`, so all generic combinators and `Featured` keep working immediately.
+- Bidirectional pattern synonyms on `EraIn` named after the old constructors (`pattern AlonzoEraOnwardsAlonzo :: () => era ~ AlonzoEra => EraIn AlonzoOnwards era`) make migration mostly mechanical: change the type name, keep the pattern matches.
+- Shims keep the 328 `shelleyBasedEraConstraints` call sites compiling during transition: `shelleyBasedEraConstraints w k = withRange @ShelleyBasedC (fromOldEon w) k`.
+- The experimental API slots in rather than competes: `Era era ≅ EraIn SupportedEras era` and `EraCommonConstraints era ≅` a class synonym used with `All`.
+  ADR-016's "back-porting would need to be revisited" becomes cheap: back-porting is choosing a wider range alias.
+
+## Dependencies
+
+- `vary` (0.1.1.3): on Hackage inside the pinned index-state, GHC 8.10+, core deps only `base` + `deepseq`.
+  Needs adding to `cardano-api.cabal` `build-depends` (not yet in the cardano-api build plan).
+- `constraints` (0.14.4): already `pre-existing` in the build-plan closure (via ouroboros-consensus, servant, sop-extras), so a direct dependency costs nothing.
+  Only needed for the first-class `Dict` form (`rangeDict`); the CPS `withRange` is dependency-free.
+- `cardano-ledger-api`: already a direct dependency; `Cardano.Ledger.Api.Era` is the sanctioned import for `PreviousEra`, `LatestKnownEra`, the era types, and the `AtLeastEra`/`AtMostEra` machinery (never the warning-tagged `Cardano.Ledger.Internal.Era`).
+
+## Risks and gotchas
+
+- **`TestEquality CardanoEra` has no Dijkstra arm** (`Era/Internal/Core.hs:299-307` falls through to `Nothing`).
+  `checkMember` routes through it, so Dijkstra would silently read as "not a member".
+  This is a pre-existing latent bug and must be fixed first (Boy Scout rule).
+- GHC 9.6/9.10/9.12 must all be happy without CPP.
+  Everything used (closed type families, GADT recursion over lists, class synonyms, overlapping instances for `HasEraIn`) is old, stable tech; vary itself supports 8.10+.
+  The known MonoLocalBinds tuple-binding gotcha (AGENTS.md) applies to dict-heavy call sites: keep explicit signatures.
+- Overlap/incoherence: vary's `Subset` uses `INCOHERENT` instances internally; our own core needs at most standard `OVERLAPPING` for `HasEraIn`, kept out of the public API surface.
+- Error-message quality: `All c es` failures name the exact missing per-era instance, which is better than today; membership failures via vary's `(:|)` produce its custom `TypeError`.
+  Custom `TypeError`s on `From`/`UpTo` misuse (era not in timeline, inverted bounds) are worth adding.
+- Compile-time cost: `All` expands to at most 7 constraints per request, versus today's 33-item bundles re-listed at every reifier; expect neutral or better.
+- `EraIn` selection is O(range length) at runtime, bounded by 7, called where today a `\case` sits; irrelevant.
+  The `Vary` existential is a single `Word` tag; `morph` is O(1).
+
+## Suggested next steps
+
+1. Fix the `TestEquality CardanoEra` Dijkstra arm.
+2. Prototype the core module `Cardano.Api.Experimental.Era.Range` (gory details in `Cardano.Api.Experimental.Era.Range.Internal`): `From`/`UpTo`/aliases, `EraIn`, `KnownEras`, `Eon` instance, `All`, `withRange`, `rangeDict`, `split`, plus `Cardano.Api.Experimental.Era.Range.Some` for the vary existential (`SomeEraIn`, `someEra`, `withSomeEra`).
+3. Add compile-time canaries: the ranges that must hold today (`All ShelleyBasedC ShelleyBasedEras` minus the constraints Dijkstra genuinely lacks, documenting the residue as the true "TODO Dijkstra" list), and the timeline-vs-ledger check against `ErasDownFrom L.LatestKnownEra`.
+4. Add the showcase tests (`Test.Cardano.Api.Experimental.EraRange`): lower bound, upper bound, and subset, per the section above.
+5. Migrate one real consumer end-to-end as proof (candidate: a `caseShelleyToBabbageOrConwayEraOnwards` call site in cardano-api, since those are pure boilerplate today).
+6. Verify with `cabal build cardano-api` from the metarepo root.


### PR DESCRIPTION
# Context

This PR prototypes **era ranges**: a generic replacement for the hand-written eon machinery, where an era span is a type-level list sliced from a single timeline instead of a bespoke GADT.

```haskell
Onwards AlonzoEra         -- Alonzo and everything after it
ShelleyEra :-: BabbageEra -- the closed interval from Shelley to Babbage
```

The motivation: each eon costs a ~110-150 line module (GADT, `Eon`/`Convert` instances, a ~33-item constraint synonym, a CPS reifier, an `Is*BasedEra` class), adding an era touches all of them, and every constraint bundle except `alonzoEraOnwardsConstraints` currently ends in a runtime `error "TODO Dijkstra"`.

What this adds, under `Cardano.Api.Experimental.Era.Range*` (purely additive - no existing eon code is changed):

- `EraIn range era` - one generic membership witness replacing per-range GADTs, with an `Eon` instance so existing combinators (`forEraInEon`, `Featured`, ...) work with any range.
- `All`/`withRange`/`rangeDict` - range constraints are derived by GHC from the per-era instances instead of hand-listed; an era lacking support becomes a **compile error at the use site** instead of a runtime error.
- `splitRange` - total, nestable boundary dispatch replacing the `caseShelleyToXOrYEraOnwards` family (which errors on Dijkstra and cannot be nested).
- `SomeEraIn range` - a [`vary`](https://hackage.haskell.org/package/vary)-based existential (`Vary` of `CardanoEra` singletons) with O(1) `morph` widening between ranges.
- Compile-time canaries proving the timeline matches the ledger's `PreviousEra` chain (`timelineMatchesLedger`) and that `SupportedEras` tracks the experimental `Era` GADT (`supportedErasAligned`).
- A fix for `TestEquality CardanoEra`, which was missing the `DijkstraEra` case (Dijkstra silently tested unequal to itself).

Constraint bundles follow one idiom, with the constraint list written exactly once: a plain alias as the single source of truth (used applied in signatures) plus a two-line class/instance eta-expansion making it passable to `withRange` unapplied.

Full rationale, trade-offs (including the honest overlap with `vary`'s internals) and migration story are in `era-ranges-with-vary-design.md` at the repo root.

New dependencies: `vary` (Hackage, within the pinned index-state) and `constraints` (already in the build-plan closure).

# How to trust this PR

- The change is additive: apart from the one-line `TestEquality` fix and cabal wiring, no existing module is touched.
- `Test.Cardano.Api.Experimental.EraRange` doubles as the usage showcase: lower bound (`ConwayEraTxCert` incl. Dijkstra), upper bound (`ShelleyEraTxCert`, capped at Conway by the class itself), subset narrowing and nested three-way dispatch via `splitRange`, membership checks (including the `TestEquality` regression), and a vary round-trip. Run them with:

  ```
  cabal run cardano-api:test:cardano-api-test -- -p "EraRange"
  ```

- The two canaries make the central claims compile-time checked: if the timeline drifted from the ledger's era chain, or `SupportedEras` from the experimental `Era` GADT, the library would not build.
- Must-NOT-compile counterexamples (requesting `ShelleyEraTxCert` for a Dijkstra-containing range; an era outside the timeline) are documented next to the tests.
- Library and tests build warning-free under `-Wall -Wredundant-constraints -Wunused-packages`; hlint reports no hints.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
