### PR TITLE
cardano-rpc: Fix TxOutput.address and Datum.hash wire encoding

### DIFF
--- a/.changes/20260720_cardano_rpc_txoutput_raw_bytes.yml
+++ b/.changes/20260720_cardano_rpc_txoutput_raw_bytes.yml
@@ -1,0 +1,6 @@
+project: cardano-rpc
+pr: 1258
+kind:
+  - bugfix
+description: |
+  Fix wire encoding of two TxOutput fields: address now carries raw ledger address bytes instead of bech32/base58 text, and Datum.hash now carries the 32-byte datum hash instead of the datum CBOR for inline datums, matching other UTxO RPC implementations.

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -90,6 +90,7 @@ library
   build-depends:
     aeson,
     base,
+    base16-bytestring,
     bytestring,
     cardano-api >=11.2,
     cardano-binary,

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/TxOutput.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/TxOutput.hs
@@ -14,7 +14,6 @@ module Cardano.Rpc.Server.Internal.UtxoRpc.Type.TxOutput
   )
 where
 
-import Cardano.Api.Address
 import Cardano.Api.Era
 import Cardano.Api.Error
 import Cardano.Api.Experimental.Era
@@ -36,9 +35,9 @@ import Cardano.Binary qualified as CBOR
 
 import RIO hiding (toList)
 
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BSC
 import Data.ProtoLens (defMessage)
-import Data.Text qualified as T
-import Data.Text.Encoding qualified as T
 import GHC.IsList
 import Network.GRPC.Spec
 
@@ -123,12 +122,12 @@ txOutToUtxoRpcTxOutput sbe (TxOut addressInEra txOutValue datum script) = do
         TxOutDatumInline _ hashableScriptData ->
           Just $
             defMessage
-              & U5c.hash .~ serialiseToCBOR hashableScriptData
+              & U5c.hash .~ serialiseToRawBytes (hashScriptDataBytes hashableScriptData)
               & U5c.payload .~ scriptDataToUtxoRpcPlutusData (getScriptData hashableScriptData)
               & U5c.originalCbor .~ getOriginalScriptDataBytes hashableScriptData
 
   defMessage
-    & U5c.address .~ T.encodeUtf8 (shelleyBasedEraConstraints sbe $ serialiseAddress addressInEra)
+    & U5c.address .~ shelleyBasedEraConstraints sbe (serialiseToRawBytes addressInEra)
     & U5c.coin .~ inject (L.unCoin (txOutValueToLovelace txOutValue))
     & U5c.assets .~ multiAsset
     & U5c.maybe'datum .~ datumRpc
@@ -143,11 +142,15 @@ utxoRpcTxOutputToTxOut
   -> m (TxOut CtxUTxO era)
 utxoRpcTxOutputToTxOut txOutput = do
   let era = useEra @era
-  addrUtf8 <- liftEitherError $ T.decodeUtf8' (txOutput ^. U5c.address)
+  let addressBytes = txOutput ^. U5c.address
+      annotateError (SerialiseAsRawBytesError msg) =
+        SerialiseAsRawBytesError $
+          msg <> ", address (hex): " <> BSC.unpack (Base16.encode addressBytes)
   address <-
-    maybe (throwM . stringException $ "Cannot decode address: " <> T.unpack addrUtf8) pure $
-      obtainCommonConstraints era $
-        deserialiseAddress asType addrUtf8
+    obtainCommonConstraints era $
+      liftEitherError $
+        first annotateError $
+          deserialiseFromRawBytes asType addressBytes
   datum <-
     case txOutput ^. U5c.maybe'datum of
       Just datumRpc ->

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FetchBlockTx.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FetchBlockTx.hs
@@ -8,8 +8,7 @@ module Test.Cardano.Rpc.FetchBlockTx where
 
 import Cardano.Api (SlotNo (..))
 import Cardano.Api.Address
-  ( serialiseAddress
-  , toShelleyAddr
+  ( toShelleyAddr
   , toShelleyStakeAddr
   , toShelleyStakeCredential
   )
@@ -32,7 +31,6 @@ import RIO hiding (toList)
 
 import Data.Map.Strict qualified as M
 import Data.ProtoLens (decodeMessage, encodeMessage)
-import Data.Text.Encoding qualified as T
 import GHC.IsList (fromList, toList)
 import GHC.Stack (withFrozenCallStack)
 import Network.GRPC.Spec (Proto (..))
@@ -97,7 +95,7 @@ txToUtxoRpcTxProjections sbe = H.withTests 40 . H.property $ anyEraTxConstraints
       expectedAddress ledgerOutput =
         case fromShelleyTxOut sbe ledgerOutput of
           TxOut addressInEra _ _ _ ->
-            shelleyBasedEraConstraints sbe $ T.encodeUtf8 (serialiseAddress addressInEra)
+            shelleyBasedEraConstraints sbe $ serialiseToRawBytes addressInEra
   map (\o -> (o ^. U5c.address, o ^. U5c.coin)) protoOutputs
     === map
       (\o -> (expectedAddress o, inject $ o ^. L.coinTxOutL))
@@ -331,7 +329,7 @@ hprop_tx_to_utxorpc_tx_injected_optional_fields = H.withTests 10 . H.property $ 
   totalCollateral === inject (L.Coin totalCollateralCoin)
   collateralReturn <- H.nothingFail $ collateral ^. U5c.maybe'collateralReturn
   collateralReturn ^. U5c.address
-    === shelleyBasedEraConstraints sbe (T.encodeUtf8 (serialiseAddress returnAddress))
+    === shelleyBasedEraConstraints sbe (serialiseToRawBytes returnAddress)
   collateralReturn ^. U5c.coin === inject (L.Coin returnCoin)
 
   H.note_ "The proposal carries the injected deposit, return account, anchor and action"

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/TxOutput.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/TxOutput.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -5,6 +6,10 @@
 module Test.Cardano.Rpc.TxOutput where
 
 import Cardano.Api.Experimental.Era
+import Cardano.Api.Plutus (hashScriptDataBytes)
+import Cardano.Api.Serialise.Raw
+import Cardano.Api.Tx
+import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as U5c
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type
 
 import RIO
@@ -15,15 +20,37 @@ import Test.Gen.Cardano.Api.Typed
 
 import Hedgehog
 import Hedgehog qualified as H
+import Hedgehog.Extras qualified as H
+
+era :: Era ConwayEra
+era = ConwayEra
 
 -- | Test if TxOut in UTXO context does roundtrip
 hprop_roundtrip_tx_output :: Property
 hprop_roundtrip_tx_output = H.property $ do
-  let era = ConwayEra
-
   txOut <- forAll $ genTxOutUTxOContext (convert era)
 
   H.tripping
     txOut
     (txOutToUtxoRpcTxOutput (convert era))
     (first @Either displayException . utxoRpcTxOutputToTxOut)
+
+-- | Test that TxOutput fields carry raw bytes on the wire
+hprop_tx_output_wire_format :: Property
+hprop_tx_output_wire_format = H.property $ do
+  txOut@(TxOut addressInEra _ datum _) <- forAll $ genTxOutUTxOContext (convert era)
+
+  let protoTxOutput = txOutToUtxoRpcTxOutput (convert era) txOut
+
+  H.note_ "Address field carries raw ledger address bytes"
+  protoTxOutput ^. U5c.address === serialiseToRawBytes addressInEra
+
+  case datum of
+    TxOutDatumNone -> pure ()
+    TxOutDatumHash _ scriptDataHash -> do
+      H.note_ "Datum hash field carries the raw script data hash"
+      protoTxOutput ^. U5c.datum . U5c.hash === serialiseToRawBytes scriptDataHash
+    TxOutDatumInline _ hashableScriptData -> do
+      H.note_ "Inline datum hash field carries the datum hash, not the datum CBOR"
+      protoTxOutput ^. U5c.datum . U5c.hash
+        === serialiseToRawBytes (hashScriptDataBytes hashableScriptData)


### PR DESCRIPTION
# Context

An audit of the proto `bytes` fields populated by the UTxO RPC server found two fields carrying the wrong encoding.
`TxOutput.address` was populated with human-readable address text (bech32 for Shelley, base58 for Byron) instead of raw ledger address bytes.
`Datum.hash` was populated with the datum's CBOR instead of its blake2b-256 hash when the datum was inline.
Both diverged from the other UTxO RPC implementations (Dolos via pallas-utxorpc, Blink Labs cardano-node-api) and, for the address, from our own predicate and reward-account encoding.
The server is unreleased, so the wire format can still change without breaking clients.

Fixes #1246

Stacked on #1222 - only the last two commits belong to this PR.

# How to trust this PR

`txOutToUtxoRpcTxOutput` now uses `serialiseToRawBytes` for the address (raw header plus payload bytes, Byron included) and `hashScriptDataBytes` for the inline datum hash, and `utxoRpcTxOutputToTxOut` decodes the address with `deserialiseFromRawBytes` in lockstep.
Address serialisation is now uniform across cardano-rpc: transaction outputs, `exact_address` predicates and reward accounts all use raw on-chain bytes in both directions, so a client can echo `TxOutput.address` into a `SearchUtxos` predicate and get matches.
The new `hprop_tx_output_wire_format` property pins the wire format directly; the existing round-trip property cannot catch the inline datum bug because decoding never reads `Datum.hash` when `original_cbor` is present.
Run `cabal test cardano-rpc:cardano-rpc-test` to verify; all 78 tests pass.
The cardano-node E2E test `Cardano.Testnet.Test.Rpc.FetchBlock` asserts the same encoding and changes in lockstep (branch `mgalazyn/fix-grpc-bytes-fields` in cardano-node).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
