### PR TITLE
cardano-rpc: ReadTip

### DIFF
--- a/.changes/20260720_cardano_api_chaindb_tip_reexports.yml
+++ b/.changes/20260720_cardano_api_chaindb_tip_reexports.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1259
+kind:
+  - compatible
+description: |
+  Re-export getTipHeader, blockHash and blockSlot from Cardano.Api.Consensus.

--- a/.changes/20260720_cardano_rpc_read_tip.yml
+++ b/.changes/20260720_cardano_rpc_read_tip.yml
@@ -1,0 +1,6 @@
+project: cardano-rpc
+pr: 1259
+kind:
+  - feature
+description: |
+  Implement the ReadTip SyncService method: returns the current chain tip as slot, block hash, height and timestamp.

--- a/cardano-api/src/Cardano/Api/Consensus.hs
+++ b/cardano-api/src/Cardano/Api/Consensus.hs
@@ -54,6 +54,7 @@ module Cardano.Api.Consensus
   , ChainDB.ChainDB
   , ChainDB.getBlockComponent
   , ChainDB.getCurrentLedger
+  , ChainDB.getTipHeader
   , ConfigSupportsNode
   , ChainDepState
   , GenTx (..)
@@ -71,7 +72,9 @@ module Cardano.Api.Consensus
   , StandardCrypto
   , TopLevelConfig
   , ledgerState
+  , blockHash
   , blockNo
+  , blockSlot
   , byronBlockRaw
   , byronIdTx
   , configBlock

--- a/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
@@ -19,7 +19,9 @@ module Cardano.Api.Consensus.Internal.Reexport
   , StandardCrypto
   , TopLevelConfig
   , ledgerState
+  , blockHash
   , blockNo
+  , blockSlot
   , byronBlockRaw
   , byronIdTx
   , configBlock
@@ -34,7 +36,14 @@ module Cardano.Api.Consensus.Internal.Reexport
 where
 
 import Cardano.Protocol.Crypto (StandardCrypto)
-import Ouroboros.Consensus.Block (HasHeader, HeaderHash, RealPoint (..), blockNo)
+import Ouroboros.Consensus.Block
+  ( HasHeader
+  , HeaderHash
+  , RealPoint (..)
+  , blockHash
+  , blockNo
+  , blockSlot
+  )
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock (byronBlockRaw), GenTx (..), byronIdTx)
 import Ouroboros.Consensus.Cardano.Block (CardanoBlock, EraMismatch (..))
 import Ouroboros.Consensus.Config (TopLevelConfig, configBlock, configLedger)

--- a/cardano-rpc/README.md
+++ b/cardano-rpc/README.md
@@ -36,7 +36,7 @@ It implements [UTxO RPC](https://utxorpc.org/introduction) protobuf communicatio
 | [FetchBlock](https://utxorpc.org/sync/spec/#fetchblockrequest) | ✅ Supported |
 | [DumpHistory](https://utxorpc.org/sync/spec/#dumphistoryrequest) | ⬜ Not supported |
 | [FollowTip](https://utxorpc.org/sync/spec/#followtiprequest) | ⬜ Not supported |
-| [ReadTip](https://utxorpc.org/sync/spec/#readtiprequest) | ⬜ Not supported |
+| [ReadTip](https://utxorpc.org/sync/spec/#readtiprequest) | ✅ Supported |
 
 ### [WatchService](https://utxorpc.org/watch/spec/)
 

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -85,7 +85,7 @@ methodsSyncRpc =
   Method (mkNonStreaming $ const unimplemented) -- dumpHistory
     . Method (mkNonStreaming $ wrapInSpan TraceRpcFetchBlockSpan . fetchBlockMethod)
     . Method (mkServerStreaming $ \_ _ -> unimplemented) -- followTip
-    . Method (mkNonStreaming $ const unimplemented) -- readTip
+    . Method (mkNonStreaming $ wrapInSpan TraceRpcReadTipSpan . readTipMethod)
     $ NoMoreMethods
  where
   unimplemented =

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -95,10 +95,12 @@ instance Pretty TraceRpcSubmit where
 instance Error TraceRpcSubmit where
   prettyError = pretty
 
--- | Traces used in SyncService (FetchBlock, FollowTip)
+-- | Traces used in SyncService (FetchBlock, ReadTip, FollowTip)
 data TraceRpcSync
   = -- | FetchBlock span
     TraceRpcFetchBlockSpan TraceSpanEvent
+  | -- | ReadTip span
+    TraceRpcReadTipSpan TraceSpanEvent
   | -- | Requested block was not found
     TraceRpcFetchBlockNotFound SlotNo
   | -- | Node kernel access is not yet available
@@ -111,6 +113,8 @@ instance Pretty TraceRpcSync where
   pretty = \case
     TraceRpcFetchBlockSpan (SpanBegin _) -> "Started FetchBlock method"
     TraceRpcFetchBlockSpan (SpanEnd _) -> "Finished FetchBlock method"
+    TraceRpcReadTipSpan (SpanBegin _) -> "Started ReadTip method"
+    TraceRpcReadTipSpan (SpanEnd _) -> "Finished ReadTip method"
     TraceRpcFetchBlockNotFound slot -> "Block not found at slot " <> pshow slot
     TraceRpcNodeKernelAccessUnavailable -> "Node kernel access not yet initialised"
     TraceRpcForkerError e -> "Ledger forker error: " <> pretty e

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
@@ -8,10 +8,12 @@
 -- (fetching blocks, dumping history, following the tip).
 module Cardano.Rpc.Server.Internal.UtxoRpc.Sync
   ( fetchBlockMethod
+  , readTipMethod
   )
 where
 
 import Cardano.Api
+import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as U5c
 import Cardano.Rpc.Server.Internal.Error
 import Cardano.Rpc.Server.Internal.Monad
@@ -23,6 +25,7 @@ import Cardano.Rpc.Server.NodeKernelAccess
 import RIO
 
 import Data.ByteString qualified as BS
+import Data.ByteString.Short qualified as SBS
 import Data.ProtoLens (defMessage)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Network.GRPC.Spec (GrpcError (GrpcInternal, GrpcInvalidArgument, GrpcNotFound), Proto)
@@ -88,3 +91,35 @@ fetchBlockMethod request = do
                & U5c.cardano . U5c.body . U5c.tx .~ txs
                & U5c.cardano . U5c.timestamp .~ timestampMs
            )
+
+-- | Handle the @ReadTip@ SyncService RPC method.
+-- Reads the current chain tip from ChainDB and returns it as slot, block
+-- header hash, block height and slot timestamp.
+-- When the chain is at origin, the tip field is left unset.
+readTipMethod
+  :: MonadRpc e m
+  => Proto U5c.ReadTipRequest
+  -> m (Proto U5c.ReadTipResponse)
+readTipMethod _request = do
+  NodeKernelAccess{chainDb, systemStart, readEraHistory} <- grabNodeKernelAccess
+  tipHeader <- liftIO $ Consensus.getTipHeader chainDb
+  tip <- forM tipHeader $ \header -> do
+    let slot = Consensus.blockSlot header
+        Consensus.OneEraHash tipHash = Consensus.blockHash header
+        BlockNo height = Consensus.blockNo header
+        throwPastHorizon =
+          throwGrpcErrorWithMessage GrpcInternal $
+            "cannot convert tip slot "
+              <> tshow (unSlotNo slot)
+              <> " to timestamp: the slot is past the era history horizon"
+    eraHistory <- readEraHistory
+    timestampMs <-
+      slotToUTCTime systemStart eraHistory slot
+        & either (const throwPastHorizon) (pure . round . (* 1000) . utcTimeToPOSIXSeconds)
+    pure $
+      defMessage
+        & U5c.slot .~ unSlotNo slot
+        & U5c.hash .~ SBS.fromShort tipHash
+        & U5c.height .~ height
+        & U5c.timestamp .~ timestampMs
+  pure $ defMessage & U5c.maybe'tip .~ tip


### PR DESCRIPTION
# Context

Part of the node kernel access work (ADR-019) and the Kupo/Ogmios replacement effort (#1229): implements the `SyncService.ReadTip` method (#1218).

`ReadTip` returns the current chain tip as a fully populated `BlockRef`: slot, block header hash, block height and the slot timestamp in milliseconds. The handler reads the tip header straight from ChainDB through node kernel access (`getTipHeader` - no block body fetch), and derives the timestamp from era history the same way `FetchBlock` does. When the chain is at origin the `tip` field is left unset; when the node kernel has not initialised yet the call fails with `UNAVAILABLE`.

Implementation notes:

- `Cardano.Api.Consensus` gains `getTipHeader`, `blockHash` and `blockSlot` re-exports.
- A `TraceRpcReadTipSpan` trace is emitted around the handler; the node-side rendering and the `rpc.request.SyncService.ReadTip` prometheus counter land with the E2E test in IntersectMBO/cardano-node#6579.
- README coverage table: ReadTip flipped to supported.

Stacked on #1258; only the last commit is new here.

# How to trust this PR

The handler is a ChainDB read plus field projection, so there are no unit tests - it needs a live ChainDB. E2E coverage lives in IntersectMBO/cardano-node#6579's `Cardano.Testnet.Test.Rpc.FetchBlock`: it calls `ReadTip` over gRPC against a running testnet and asserts the tip's slot and height are bounded below by a CLI `query tip` snapshot, the hash is 32 bytes, and the timestamp agrees with the slot-derived time within 1s.

Run it with:

```
TASTY_PATTERN='/RPC FetchBlock/' cabal test cardano-testnet-test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`
