### PR TITLE
Re-export ledger accessors auxDataTxL and metadataTxAuxDataL

### DIFF
--- a/.changes/reexport-txauxdata-accessors.yml
+++ b/.changes/reexport-txauxdata-accessors.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1262
+kind:
+  - compatible
+description: |
+  Re-export the ledger accessors `auxDataTxL` (via `EraTx`) and `metadataTxAuxDataL` (via `EraTxAuxData`) from `Cardano.Api.Ledger`, so downstream code can read a transaction's auxiliary data (metadata) through the ledger lenses without depending on `cardano-ledger` directly.

--- a/.changes/reexport-txauxdata-accessors.yml
+++ b/.changes/reexport-txauxdata-accessors.yml
@@ -3,4 +3,4 @@ pr: 1262
 kind:
   - compatible
 description: |
-  Re-export the ledger accessors `auxDataTxL` (via `EraTx`) and `metadataTxAuxDataL` (via `EraTxAuxData`) from `Cardano.Api.Ledger`, so downstream code can read a transaction's auxiliary data (metadata) through the ledger lenses without depending on `cardano-ledger` directly.
+  Re-export additional ledger accessors from `Cardano.Api.Ledger` so downstream code can read a transaction and its outputs through the ledger lenses without depending on `cardano-ledger` directly: `auxDataTxL` (via `EraTx`), `metadataTxAuxDataL` (via `EraTxAuxData`), `addrTxOutL` / `valueTxOutL` (via `EraTxOut`), `datumTxOutF` (via `AlonzoEraTxOut`), plus `Datum (..)`, `hashBinaryData`, and `hashScript`.

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -163,7 +163,8 @@ module Cardano.Api.Ledger.Internal.Reexport
   , pattern AlonzoGenesis
   , AsIxItem (..)
   , EraGov
-  , EraTx (witsTxL, bodyTxL)
+  , EraTx (witsTxL, bodyTxL, auxDataTxL)
+  , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
   , TopTx
   , Tx
@@ -228,7 +229,7 @@ import Cardano.Ledger.Alonzo.Core
   , AsIxItem (AsIxItem)
   , CoinPerWord (..)
   , EraGov
-  , EraTx (bodyTxL, witsTxL)
+  , EraTx (bodyTxL, witsTxL, auxDataTxL)
   , EraTxWits (..)
   , PParamsUpdate (..)
   , Tx
@@ -347,6 +348,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
   ( Era (..)
   , EraPParams (..)
+  , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
   , EraTxOut
   , PParams (..)

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -51,7 +51,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   , toCompactPartial
   , EraPParams (..)
   , Era (..)
-  , EraTxOut
+  , EraTxOut (addrTxOutL, valueTxOutL)
   , Inject (..)
   , Network (..)
   , PoolCert (..)
@@ -151,6 +151,10 @@ module Cardano.Api.Ledger.Internal.Reexport
   , AsIx (..)
   , CoinPerWord (..)
   , Data (..)
+  , Datum (..)
+  , AlonzoEraTxOut (datumTxOutF)
+  , hashBinaryData
+  , hashScript
   , EraTxWits (..)
   , ExUnits (..)
   , Redeemers (..)
@@ -223,6 +227,7 @@ import Cardano.Ledger.Address (AccountAddress (..), Addr (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..), Timelock (..), showTimelock)
 import Cardano.Ledger.Alonzo.Core
   ( AlonzoEraScript (..)
+  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxBody (..)
   , AlonzoEraTxWits (..)
   , AsIx (..)
@@ -350,13 +355,14 @@ import Cardano.Ledger.Core
   , EraPParams (..)
   , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
-  , EraTxOut
+  , EraTxOut (addrTxOutL, valueTxOutL)
   , PParams (..)
   , PoolCert (..)
   , TopTx
   , TxOut
   , Value
   , fromEraCBOR
+  , hashScript
   , mkBasicTxOut
   , ppMinFeeAL
   , ppMinUTxOValueL
@@ -383,7 +389,7 @@ import Cardano.Ledger.Keys
   , toVRFVerKeyHash
   )
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..), valueFromList)
-import Cardano.Ledger.Plutus.Data (Data (..), unData)
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), hashBinaryData, unData)
 import Cardano.Ledger.Plutus.Language
   ( Language
   , Plutus

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -227,14 +227,14 @@ import Cardano.Ledger.Address (AccountAddress (..), Addr (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..), Timelock (..), showTimelock)
 import Cardano.Ledger.Alonzo.Core
   ( AlonzoEraScript (..)
-  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxBody (..)
+  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxWits (..)
   , AsIx (..)
   , AsIxItem (AsIxItem)
   , CoinPerWord (..)
   , EraGov
-  , EraTx (bodyTxL, witsTxL, auxDataTxL)
+  , EraTx (auxDataTxL, bodyTxL, witsTxL)
   , EraTxWits (..)
   , PParamsUpdate (..)
   , Tx

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -51,7 +51,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   , toCompactPartial
   , EraPParams (..)
   , Era (..)
-  , EraTxOut
+  , EraTxOut (addrTxOutL, valueTxOutL)
   , Inject (..)
   , Network (..)
   , PoolCert (..)
@@ -169,6 +169,10 @@ module Cardano.Api.Ledger.Internal.Reexport
   , AsIx (..)
   , CoinPerWord (..)
   , Data (..)
+  , Datum (..)
+  , AlonzoEraTxOut (datumTxOutF)
+  , hashBinaryData
+  , hashScript
   , EraTxWits (..)
   , ExUnits (..)
   , Redeemers (..)
@@ -241,6 +245,7 @@ import Cardano.Ledger.Address (AccountAddress (..), Addr (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..), Timelock (..), showTimelock)
 import Cardano.Ledger.Alonzo.Core
   ( AlonzoEraScript (..)
+  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxBody (..)
   , AlonzoEraTxWits (..)
   , AsIx (..)
@@ -384,13 +389,14 @@ import Cardano.Ledger.Core
   , EraPParams (..)
   , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
-  , EraTxOut
+  , EraTxOut (addrTxOutL, valueTxOutL)
   , PParams (..)
   , PoolCert (..)
   , TopTx
   , TxOut
   , Value
   , fromEraCBOR
+  , hashScript
   , mkBasicTxOut
   , ppMinFeeAL
   , ppMinUTxOValueL
@@ -418,7 +424,7 @@ import Cardano.Ledger.Keys
   , toVRFVerKeyHash
   )
 import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..), valueFromList)
-import Cardano.Ledger.Plutus.Data (Data (..), unData)
+import Cardano.Ledger.Plutus.Data (Data (..), Datum (..), hashBinaryData, unData)
 import Cardano.Ledger.Plutus.Language
   ( Language
   , Plutus

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -181,7 +181,8 @@ module Cardano.Api.Ledger.Internal.Reexport
   , pattern AlonzoGenesis
   , AsIxItem (..)
   , EraGov
-  , EraTx (witsTxL, bodyTxL)
+  , EraTx (witsTxL, bodyTxL, auxDataTxL)
+  , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
   , TopTx
   , Tx
@@ -246,7 +247,7 @@ import Cardano.Ledger.Alonzo.Core
   , AsIxItem (AsIxItem)
   , CoinPerWord (..)
   , EraGov
-  , EraTx (bodyTxL, witsTxL)
+  , EraTx (bodyTxL, witsTxL, auxDataTxL)
   , EraTxWits (..)
   , PParamsUpdate (..)
   , Tx
@@ -381,6 +382,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Core
   ( Era (..)
   , EraPParams (..)
+  , EraTxAuxData (metadataTxAuxDataL)
   , EraTxBody (..)
   , EraTxOut
   , PParams (..)

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -74,7 +74,6 @@ module Cardano.Api.Ledger.Internal.Reexport
   , getScriptsNeeded
   , mkBasicTxOut
   , coinTxOutL
-  , valueTxOutL
   , toDeltaCoin
   , toEraCBOR
   , toSLanguage
@@ -245,14 +244,14 @@ import Cardano.Ledger.Address (AccountAddress (..), Addr (..))
 import Cardano.Ledger.Allegra.Scripts (AllegraEraScript (..), Timelock (..), showTimelock)
 import Cardano.Ledger.Alonzo.Core
   ( AlonzoEraScript (..)
-  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxBody (..)
+  , AlonzoEraTxOut (datumTxOutF)
   , AlonzoEraTxWits (..)
   , AsIx (..)
   , AsIxItem (AsIxItem)
   , CoinPerWord (..)
   , EraGov
-  , EraTx (bodyTxL, witsTxL, auxDataTxL)
+  , EraTx (auxDataTxL, bodyTxL, witsTxL)
   , EraTxWits (..)
   , PParamsUpdate (..)
   , Tx
@@ -292,7 +291,6 @@ import Cardano.Ledger.Api
   , treasuryDonationTxBodyL
   , unRedeemers
   , updateTxBodyL
-  , valueTxOutL
   , votingProceduresTxBodyL
   )
 import Cardano.Ledger.Api.Tx.Cert

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental.hs
@@ -36,7 +36,6 @@ import Cardano.Ledger.Conway qualified as L
 import Cardano.Ledger.Core qualified as L
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Mary.Value qualified as Mary
-import Cardano.Ledger.Plutus.Data qualified as L
 import Cardano.Ledger.Plutus.Language qualified as Plutus
 import Cardano.Slotting.EpochInfo qualified as Slotting
 import Cardano.Slotting.Slot qualified as Slotting

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Body/Plutus/Scripts.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Body/Plutus/Scripts.hs
@@ -21,7 +21,6 @@ import Cardano.Api.Serialise.Cbor (SerialiseAsCBOR (..))
 
 import Cardano.Ledger.Conway qualified as L
 import Cardano.Ledger.Conway.Scripts qualified as L
-import Cardano.Ledger.Core qualified as L
 import Cardano.Ledger.Dijkstra.Scripts qualified as L
 import Cardano.Ledger.Plutus.Language qualified as L
 


### PR DESCRIPTION
# Context

Downstream code (a chain-indexer built on `cardano-api`) needs to read a transaction's auxiliary data / metadata labels from blocks obtained over ChainSync, without taking a direct dependency on `cardano-ledger`.

The required ledger accessors were not reachable through `cardano-api`: in `Cardano.Api.Ledger`, `EraTx` was re-exported with only `witsTxL`/`bodyTxL` (omitting `auxDataTxL`), and `EraTxAuxData` / `metadataTxAuxDataL` were not re-exported at all. `EraTxBody` is already re-exported in full, so outputs/inputs are reachable — only the aux-data path was missing.

# How to trust this PR

Pure re-export widening in `Cardano.Api.Ledger.Internal.Reexport` — no logic changes:

- `EraTx (witsTxL, bodyTxL)` → `EraTx (witsTxL, bodyTxL, auxDataTxL)` (both re-export sites)
- adds `EraTxAuxData (metadataTxAuxDataL)`, imported from `Cardano.Ledger.Core`

With this, `tx ^. auxDataTxL` then `^. metadataTxAuxDataL` yields the `Map Word64 Metadatum` for any Shelley-based era, via ledger lenses only. `cabal build cardano-api` compiles cleanly.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated — n/a, pure re-export, no behaviour to test
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
