### PR TITLE
Remove collateral from transactions without Plutus scripts

### DIFF
--- a/.changes/20260723_cardano_api_collateral_without_plutus.yml
+++ b/.changes/20260723_cardano_api_collateral_without_plutus.yml
@@ -1,0 +1,7 @@
+project: cardano-api
+pr: 1265
+kind:
+  - bugfix
+description: |
+  Issue: `makeTransactionBodyAutoBalance` and `estimateBalancedTxBody` (both the traditional and the experimental versions) keep the collateral inputs and set the collateral fields on transactions without Plutus scripts, even though the ledger requires no collateral for them. With a small collateral input, the computed return collateral output falls below the minimum UTxO value and the ledger rejects the transaction.
+  Solution: collateral inputs are now removed from transactions without Plutus scripts, and no collateral fields are set.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -298,7 +298,7 @@ estimateBalancedTxBody'
   -- ^ Total value of UTXOs being spent.
   -> Either (TxFeeEstimationError era) (TxBodyContent (LedgerEra era))
 estimateBalancedTxBody'
-  txbodycontent
+  providedTxbodycontent
   pparams
   poolids
   stakeDelegDeposits
@@ -310,6 +310,14 @@ estimateBalancedTxBody'
   sizeOfAllReferenceScripts
   changeaddr
   totalUTxOValue = do
+    -- The ledger requires collateral only for transactions that run Plutus
+    -- scripts. For transactions without them, remove the collateral inputs:
+    -- they cost fees and require the collateral UTxOs to stay unspent, but
+    -- the ledger ignores them, and no collateral fields are needed.
+    let txbodycontent
+          | hasPlutusScriptWitnesses providedTxbodycontent = providedTxbodycontent
+          | otherwise = providedTxbodycontent{txInsCollateral = []}
+
     -- Step 1. Substitute those execution units into the tx
 
     txbodycontent1 <-
@@ -671,6 +679,20 @@ createFakeUTxO txbodycontent totalAdaInUTxO =
    in -- Take one txin and one txout. Replace the out value with totalAdaInUTxO
       -- Return an empty UTxO if there are no txins or txouts
       L.UTxO $ fromList $ zip singleTxIn singleTxOut
+
+-- | Whether the transaction contains any Plutus script witness. The ledger
+-- requires collateral only for transactions that run Plutus scripts.
+hasPlutusScriptWitnesses
+  :: forall era
+   . IsEra era
+  => TxBodyContent (LedgerEra era)
+  -> Bool
+hasPlutusScriptWitnesses txbodycontent =
+  not $
+    null
+      [ ()
+      | (_, AnyScriptWitnessPlutus{}) <- collectTxBodyScriptWitnesses txbodycontent
+      ]
 
 -- Calculation taken from validateInsufficientCollateral:
 -- https://github.com/input-output-hk/cardano-ledger/blob/389b266d6226dedf3d2aec7af640b3ca4984c5ea/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs#L335
@@ -1498,9 +1520,19 @@ makeTransactionBodyAutoBalance
   stakeDelegDeposits
   drepDelegDeposits
   utxo
-  txbodycontent
+  providedTxbodycontent
   changeaddr
   mnkeys = do
+    -- The ledger requires collateral only for transactions that run Plutus
+    -- scripts. For transactions without them, remove the collateral inputs:
+    -- they cost fees and require the collateral UTxOs to stay unspent, but
+    -- the ledger ignores them, and no collateral fields are needed. This is
+    -- the only case where the balancing functions modify the transaction
+    -- inputs; a transaction that should become invalid when some UTxO is
+    -- spent can use a reference input for that purpose.
+    let txbodycontent
+          | hasPlutusScriptWitnesses providedTxbodycontent = providedTxbodycontent
+          | otherwise = providedTxbodycontent{txInsCollateral = []}
     -- Our strategy is to:
     -- 1. evaluate all the scripts to get the exec units, update with ex units
     -- 2. figure out the overall min fees

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -226,7 +226,7 @@ estimateBalancedTxBody
   -> Either (TxFeeEstimationError era) (BalancedTxBody era)
 estimateBalancedTxBody
   w
-  txbodycontent
+  providedTxbodycontent
   pparams
   poolids
   stakeDelegDeposits
@@ -238,9 +238,16 @@ estimateBalancedTxBody
   sizeOfAllReferenceScripts
   changeaddr
   totalUTxOValue = do
-    -- Step 1. Substitute those execution units into the tx
-
     let sbe = convert w
+    -- The ledger requires collateral only for transactions that run Plutus
+    -- scripts. For transactions without them, remove the collateral inputs:
+    -- they cost fees and require the collateral UTxOs to stay unspent, but
+    -- the ledger ignores them, and no collateral fields are needed.
+    let txbodycontent
+          | hasPlutusScriptWitnesses sbe providedTxbodycontent = providedTxbodycontent
+          | otherwise = providedTxbodycontent{txInsCollateral = TxInsCollateralNone}
+
+    -- Step 1. Substitute those execution units into the tx
     txbodycontent1 <-
       maryEraOnwardsConstraints w $
         first TxFeeEstimationScriptExecutionError $
@@ -992,10 +999,20 @@ makeTransactionBodyAutoBalance
   stakeDelegDeposits
   drepDelegDeposits
   utxo
-  txbodycontent
+  providedTxbodycontent
   changeaddr
   mnkeys =
     shelleyBasedEraConstraints sbe $ do
+      -- The ledger requires collateral only for transactions that run Plutus
+      -- scripts. For transactions without them, remove the collateral inputs:
+      -- they cost fees and require the collateral UTxOs to stay unspent, but
+      -- the ledger ignores them, and no collateral fields are needed. This is
+      -- the only case where the balancing functions modify the transaction
+      -- inputs; a transaction that should become invalid when some UTxO is
+      -- spent can use a reference input for that purpose.
+      let txbodycontent
+            | hasPlutusScriptWitnesses sbe providedTxbodycontent = providedTxbodycontent
+            | otherwise = providedTxbodycontent{txInsCollateral = TxInsCollateralNone}
       -- Our strategy is to:
       -- 1. evaluate all the scripts to get the exec units, update with ex units
       -- 2. figure out the overall min fees
@@ -1210,6 +1227,17 @@ checkNonNegative sbe bpparams txout@(TxOut _ balance _ _) = do
             coin
     | not isPositiveValue -> Left $ TxBodyErrorBalanceNegative coin multiAsset
     | otherwise -> pure NonEmpty
+
+-- | Whether the transaction contains any Plutus script witness. The ledger
+-- requires collateral only for transactions that run Plutus scripts.
+hasPlutusScriptWitnesses :: ShelleyBasedEra era -> TxBodyContent BuildTx era -> Bool
+hasPlutusScriptWitnesses sbe txbodycontent =
+  not $
+    null
+      [ ()
+      | (_, AnyScriptWitness PlutusScriptWitness{}) <-
+          collectTxBodyScriptWitnesses sbe txbodycontent
+      ]
 
 -- Calculation taken from validateInsufficientCollateral:
 -- https://github.com/input-output-hk/cardano-ledger/blob/389b266d6226dedf3d2aec7af640b3ca4984c5ea/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs#L335

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
@@ -16,6 +16,7 @@ import Cardano.Api.Experimental.Era (convert)
 import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Monad.Error (failEitherWith)
+import Cardano.Api.Parser.Text qualified as Api
 
 import Cardano.Ledger.Api qualified as UnexportedLedger
 import Cardano.Ledger.Core qualified as L
@@ -107,6 +108,15 @@ tests =
         [ testProperty
             "underfunded transaction fails with TxBodyErrorBalanceNegative"
             prop_makeTransactionBodyAutoBalance_balance_negative
+        , testProperty
+            "removes collateral without Plutus scripts"
+            prop_makeTransactionBodyAutoBalance_no_collateral_without_plutus
+        ]
+    , testGroup
+        "estimateBalancedTxBody"
+        [ testProperty
+            "removes collateral without Plutus scripts"
+            prop_estimateBalancedTxBody_no_collateral_without_plutus
         ]
     , testGroup
         "evaluateTransaction"
@@ -747,6 +757,133 @@ prop_makeTransactionBodyAutoBalance_balance_negative = H.property $ do
     Right _ ->
       H.annotate "Expected TxBodyErrorBalanceNegative but tx balanced successfully"
         >> H.failure
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- The ledger requires collateral only for transactions that run Plutus
+-- scripts, so balancing a transaction without Plutus scripts must not
+-- include any collateral: the collateral inputs are removed and no
+-- collateral fields are set. In particular it must not compute a return
+-- collateral output: with a collateral input holding exactly the minimum
+-- UTxO value, the computed return collateral output would fall below its own
+-- minimum UTxO value, and the ledger would reject the transaction.
+prop_makeTransactionBodyAutoBalance_no_collateral_without_plutus :: Property
+prop_makeTransactionBodyAutoBalance_no_collateral_without_plutus = H.propertyOnce $ do
+  let era = Exp.ConwayEra
+      sbe = convert era
+      systemStart = Api.SystemStart $ Time.posixSecondsToUTCTime 0
+      epochInfo =
+        Api.LedgerEpochInfo $
+          Slotting.fixedEpochInfo (Slotting.EpochSize 100) (Slotting.mkSlotLength 1000)
+
+  fundingTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+  collateralTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+
+  let addr =
+        L.Addr
+          L.Testnet
+          (L.KeyHashObj $ L.KeyHash "1c14ee8e58fbcbd48dc7367c95a63fd1d937ba989820015db16ac7e5")
+          L.StakeRefNull
+      -- The smallest realistic collateral input: it holds exactly the
+      -- minimum UTxO value.
+      minUTxOCollateral =
+        Exp.calculateMinimumUTxO exampleProtocolParams $
+          Exp.TxOut (L.mkBasicTxOut addr (L.MaryValue (L.Coin 0) mempty))
+      utxo =
+        L.UTxO $
+          Map.fromList
+            [ (Api.toShelleyTxIn fundingTxIn, L.mkBasicTxOut addr (L.MaryValue (L.Coin 12_000_000) mempty))
+            , (Api.toShelleyTxIn collateralTxIn, L.mkBasicTxOut addr (L.MaryValue minUTxOCollateral mempty))
+            ]
+      txBodyContent =
+        Exp.defaultTxBodyContent
+          & Exp.setTxIns [(fundingTxIn, Exp.AnyKeyWitnessPlaceholder)]
+          & Exp.setTxInsCollateral [collateralTxIn]
+          & Exp.setTxOuts [Exp.TxOut $ L.mkBasicTxOut addr (L.MaryValue (L.Coin 5_000_000) mempty)]
+
+  (_, balancedContent) <-
+    H.leftFail $
+      Exp.makeTransactionBodyAutoBalance
+        systemStart
+        epochInfo
+        exampleProtocolParams
+        mempty
+        mempty
+        mempty
+        utxo
+        txBodyContent
+        (Api.fromShelleyAddr sbe addr)
+        Nothing
+
+  case ( Exp.txInsCollateral balancedContent
+       , Exp.txReturnCollateral balancedContent
+       , Exp.txTotalCollateral balancedContent
+       ) of
+    ([], Nothing, Nothing) -> pure ()
+    _ -> do
+      H.annotate "Expected no collateral in a transaction without Plutus scripts"
+      H.failure
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- Like 'prop_makeTransactionBodyAutoBalance_no_collateral_without_plutus',
+-- but for 'Exp.estimateBalancedTxBody'.
+prop_estimateBalancedTxBody_no_collateral_without_plutus :: Property
+prop_estimateBalancedTxBody_no_collateral_without_plutus = H.propertyOnce $ do
+  let era = Exp.ConwayEra
+      sbe = convert era
+
+  fundingTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+  collateralTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+
+  let addr =
+        L.Addr
+          L.Testnet
+          (L.KeyHashObj $ L.KeyHash "1c14ee8e58fbcbd48dc7367c95a63fd1d937ba989820015db16ac7e5")
+          L.StakeRefNull
+      -- The smallest realistic collateral: exactly the minimum UTxO value.
+      minUTxOCollateral =
+        Exp.calculateMinimumUTxO exampleProtocolParams $
+          Exp.TxOut (L.mkBasicTxOut addr (L.MaryValue (L.Coin 0) mempty))
+      txBodyContent =
+        Exp.defaultTxBodyContent
+          & Exp.setTxIns [(fundingTxIn, Exp.AnyKeyWitnessPlaceholder)]
+          & Exp.setTxInsCollateral [collateralTxIn]
+          & Exp.setTxOuts [Exp.TxOut $ L.mkBasicTxOut addr (L.MaryValue (L.Coin 5_000_000) mempty)]
+
+  balancedContent <-
+    H.leftFail $
+      Exp.estimateBalancedTxBody
+        era
+        txBodyContent
+        exampleProtocolParams
+        mempty
+        mempty
+        mempty
+        mempty
+        minUTxOCollateral
+        1
+        0
+        0
+        (Api.fromShelleyAddr sbe addr)
+        (L.MaryValue (L.Coin 12_000_000) mempty)
+
+  case ( Exp.txInsCollateral balancedContent
+       , Exp.txReturnCollateral balancedContent
+       , Exp.txTotalCollateral balancedContent
+       ) of
+    ([], Nothing, Nothing) -> pure ()
+    _ -> do
+      H.annotate "Expected no collateral in a transaction without Plutus scripts"
+      H.failure
 
 -- | A well-funded transaction returns a positive fee from 'evaluateTransaction'.
 prop_evaluateTransaction_positive_fee :: Property

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -544,6 +544,150 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
         H.note_ "Check that collateral balance is equal to collateral in tx body"
         resTotCollValue === collBalance
 
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- The ledger requires collateral only for transactions that run Plutus
+-- scripts, so balancing a transaction without Plutus scripts must not
+-- include any collateral: the collateral inputs are removed and no
+-- collateral fields are set. In particular it must not compute a return
+-- collateral output: with a collateral input holding exactly the minimum
+-- UTxO value, the computed return collateral output would fall below its own
+-- minimum UTxO value, and the ledger would reject the transaction.
+prop_make_transaction_body_autobalance_no_collateral_without_plutus :: Property
+prop_make_transaction_body_autobalance_no_collateral_without_plutus = H.propertyOnce $ do
+  let ceo = ConwayEraOnwardsConway
+      beo = convert ceo
+      aeo = convert beo
+      sbe = convert ceo
+
+  systemStart <- parseSystemStart "2021-09-01T00:00:00Z"
+  let epochInfo = LedgerEpochInfo $ CS.fixedEpochInfo (CS.EpochSize 100) (CS.mkSlotLength 1000)
+
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+  let pparams = LedgerProtocolParameters ledgerPParams
+
+  let address =
+        AddressInEra
+          (ShelleyAddressInEra sbe)
+          ( ShelleyAddress
+              L.Testnet
+              (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+              L.StakeRefNull
+          )
+      fundingTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+      collateralTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+      -- The smallest realistic collateral input: it holds exactly the
+      -- minimum UTxO value.
+      minUTxOCollateral =
+        calculateMinimumUTxO sbe ledgerPParams $
+          TxOut address (lovelaceToTxOutValue sbe 0) TxOutDatumNone ReferenceScriptNone
+      utxos =
+        UTxO
+          [
+            ( fundingTxIn
+            , TxOut address (lovelaceToTxOutValue sbe 12_000_000) TxOutDatumNone ReferenceScriptNone
+            )
+          ,
+            ( collateralTxIn
+            , TxOut address (lovelaceToTxOutValue sbe minUTxOCollateral) TxOutDatumNone ReferenceScriptNone
+            )
+          ]
+      content =
+        defaultTxBodyContent sbe
+          & setTxIns [(fundingTxIn, BuildTxWith (KeyWitness KeyWitnessForSpending))]
+          & setTxInsCollateral (TxInsCollateral aeo [collateralTxIn])
+          & setTxOuts (mkTxOutput beo address (L.Coin 5_000_000) Nothing)
+          & setTxProtocolParams (pure $ pure pparams)
+
+  BalancedTxBody balancedContent _ _ _ <-
+    H.leftFail $
+      makeTransactionBodyAutoBalance
+        sbe
+        systemStart
+        epochInfo
+        pparams
+        mempty
+        mempty
+        mempty
+        utxos
+        content
+        address
+        Nothing
+
+  case ( txInsCollateral balancedContent
+       , txReturnCollateral balancedContent
+       , txTotalCollateral balancedContent
+       ) of
+    (TxInsCollateralNone, TxReturnCollateralNone, TxTotalCollateralNone) -> pure ()
+    collateral -> do
+      H.annotateShow collateral
+      H.annotate "Expected no collateral in a transaction without Plutus scripts"
+      H.failure
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- Like 'prop_make_transaction_body_autobalance_no_collateral_without_plutus',
+-- but for 'estimateBalancedTxBody'.
+prop_estimate_balanced_tx_body_no_collateral_without_plutus :: Property
+prop_estimate_balanced_tx_body_no_collateral_without_plutus = H.propertyOnce $ do
+  let ceo = ConwayEraOnwardsConway
+      beo = convert ceo
+      aeo = convert beo
+      meo = convert beo
+      sbe = convert ceo
+
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+
+  let address =
+        AddressInEra
+          (ShelleyAddressInEra sbe)
+          ( ShelleyAddress
+              L.Testnet
+              (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+              L.StakeRefNull
+          )
+      fundingTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+      collateralTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+      -- The smallest realistic collateral: exactly the minimum UTxO value.
+      minUTxOCollateral =
+        calculateMinimumUTxO sbe ledgerPParams $
+          TxOut address (lovelaceToTxOutValue sbe 0) TxOutDatumNone ReferenceScriptNone
+      content =
+        defaultTxBodyContent sbe
+          & setTxIns [(fundingTxIn, BuildTxWith (KeyWitness KeyWitnessForSpending))]
+          & setTxInsCollateral (TxInsCollateral aeo [collateralTxIn])
+          & setTxOuts (mkTxOutput beo address (L.Coin 5_000_000) Nothing)
+          & setTxProtocolParams (pure $ pure (LedgerProtocolParameters ledgerPParams))
+
+  BalancedTxBody balancedContent _ _ _ <-
+    H.leftFail $
+      estimateBalancedTxBody
+        meo
+        content
+        ledgerPParams
+        mempty
+        mempty
+        mempty
+        mempty
+        minUTxOCollateral
+        1
+        0
+        0
+        address
+        (lovelaceToValue 12_000_000)
+
+  case ( txInsCollateral balancedContent
+       , txReturnCollateral balancedContent
+       , txTotalCollateral balancedContent
+       ) of
+    (TxInsCollateralNone, TxReturnCollateralNone, TxTotalCollateralNone) -> pure ()
+    collateral -> do
+      H.annotateShow collateral
+      H.annotate "Expected no collateral in a transaction without Plutus scripts"
+      H.failure
+
 -- | Regression test for: https://github.com/IntersectMBO/cardano-cli/issues/1073
 prop_ensure_gov_actions_are_preserved_by_autobalance :: Property
 prop_ensure_gov_actions_are_preserved_by_autobalance = H.propertyOnce $ do
@@ -792,6 +936,12 @@ tests =
         "makeTransactionBodyAutoBalance autobalances when deregistering certificates"
         prop_make_transaction_body_autobalance_when_deregistering_certs
     , testProperty "calcReturnAndTotalCollateral constraints hold" prop_calcReturnAndTotalCollateral
+    , testProperty
+        "makeTransactionBodyAutoBalance removes collateral on transactions without Plutus scripts"
+        prop_make_transaction_body_autobalance_no_collateral_without_plutus
+    , testProperty
+        "estimateBalancedTxBody removes collateral on transactions without Plutus scripts"
+        prop_estimate_balanced_tx_body_no_collateral_without_plutus
     , testProperty
         "Governance actions are preserved by autobalance"
         prop_ensure_gov_actions_are_preserved_by_autobalance


### PR DESCRIPTION
# Context

This is the first of three stacked PRs fixing #1261: the balancing functions
(`makeTransactionBodyAutoBalance` and `estimateBalancedTxBody`, in both the traditional and the
experimental API) could build transactions that the ledger rejects at submission time because of
their collateral. Each PR contains a pair of commits — regression tests that fail, then the fix
that makes them pass — and each PR is based on the previous one, so every diff shows only its own
two commits.

🗺️ **Map** — you are here: 1️⃣

|  |  |  |
|---|---|---|
| 🚪 | [#1261](https://github.com/IntersectMBO/cardano-api/issues/1261) | the issue: `transaction build` does not validate min UTxO value of the collateral return output |
| 1️⃣ | **(this PR)** | remove collateral from transactions without Plutus scripts |
| 2️⃣ | #1266 | fail on invalid computed collateral instead of building a rejected transaction |
| 3️⃣ | #1267 | fold return collateral dust into the total collateral |

**This PR:** the ledger requires collateral only for transactions that run Plutus scripts, but
balancing keeps the collateral inputs and sets the collateral fields whenever collateral inputs
are present. With a collateral input holding exactly the minimum UTxO value, the computed return
collateral output falls below its own minimum UTxO value and the ledger rejects the transaction
with `BabbageOutputTooSmallUTxO` — the #1261 failure, reachable without any Plutus script. Since
the ledger ignores collateral on transactions without Plutus scripts, balancing now removes the
collateral inputs and sets no collateral fields. A transaction that should become invalid when
some UTxO is spent can use a reference input for that purpose.

# How to trust this PR

- The first commit adds four regression tests (one per balancing function) that fail on `master`;
  the second commit makes them pass. Check out the first commit alone and run the
  `cardano-api-test` suite to see them fail.
- The fix is a single entry-point normalization: collateral inputs are dropped when
  `collectTxBodyScriptWitnesses` finds no Plutus script witnesses; everything downstream is
  unchanged.
- The ledger rule that makes this safe: collateral validation (`validateTotalCollateral` in
  Babbage's `feesOK`) only runs when the transaction has redeemers.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
