### PR TITLE
Fold return collateral dust into the total collateral

### DIFF
--- a/.changes/20260723_cardano_api_collateral_balancing.yml
+++ b/.changes/20260723_cardano_api_collateral_balancing.yml
@@ -1,0 +1,7 @@
+project: cardano-api
+pr: 1267
+kind:
+  - bugfix
+description: |
+  Issue: when the collateral is ada-only and the ada left over after covering the required collateral is below the minimum UTxO value of a return collateral output, balancing fails, even though a valid transaction exists.
+  Solution: the ada left over is now folded into the total collateral, with no return collateral output: it is only lost if a Plutus script fails on chain. `estimateBalancedTxBody` cannot see the content of the collateral inputs, so it computes collateral under the documented assumption that they contain no native tokens.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -785,8 +785,8 @@ calcReturnAndTotalCollateral fee pp' _ mTxReturnCollateral mTxTotalCollateral cA
                   )
             | L.isZero nonAdaCollateral ->
                 -- The ada left over is too small for a return collateral output, so
-                -- use the whole collateral as total collateral instead. The extra ada
-                -- is only lost if a Plutus script fails on chain.
+                -- use all of the collateral inputs as total collateral instead. The
+                -- extra ada is only lost if a Plutus script fails on chain.
                 Right (Nothing, Just $ TxTotalCollateral totalCollateralLovelace)
             | otherwise ->
                 Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -232,7 +232,11 @@ estimateBalancedTxBody
   -> Map (Ledger.PlutusPurpose Ledger.AsIx (LedgerEra era)) ExecutionUnits
   -- ^ Plutus script execution units.
   -> Coin
-  -- ^ Total potential collateral amount.
+  -- ^ Total potential collateral amount. The content of the collateral
+  --   inputs is not visible to this function, so they are assumed to
+  --   contain no native tokens. To use collateral inputs that carry
+  --   native tokens, provide 'txReturnCollateral' and 'txTotalCollateral'
+  --   explicitly.
   -> Int
   -- ^ The number of key witnesses to be added to the transaction.
   -> Int
@@ -292,7 +296,11 @@ estimateBalancedTxBody'
   -> Map ScriptWitnessIndex ExecutionUnits
   -- ^ Plutus script execution units.
   -> Coin
-  -- ^ Total potential collateral amount.
+  -- ^ Total potential collateral amount. The content of the collateral
+  --   inputs is not visible to this function, so they are assumed to
+  --   contain no native tokens. To use collateral inputs that carry
+  --   native tokens, provide 'txReturnCollateral' and 'txTotalCollateral'
+  --   explicitly.
   -> Int
   -- ^ The number of key witnesses to be added to the transaction.
   -> Int
@@ -769,13 +777,19 @@ calcReturnAndTotalCollateral fee pp' _ mTxReturnCollateral mTxTotalCollateral cA
       | otherwise -> obtainCommonConstraints (useEra @era) $ do
           let returnCollateralTxOut = L.mkBasicTxOut (toShelleyAddr cAddr) returnCollateral
               minReturnUTxO = calculateMinimumUTxO pp' (TxOut returnCollateralTxOut)
-          if returnCollateralAda < minReturnUTxO
-            then Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO
-            else
-              Right
-                ( Just $ TxReturnCollateral returnCollateralTxOut
-                , Just $ TxTotalCollateral totalCollateral
-                )
+          if
+            | returnCollateralAda >= minReturnUTxO ->
+                Right
+                  ( Just $ TxReturnCollateral returnCollateralTxOut
+                  , Just $ TxTotalCollateral totalCollateral
+                  )
+            | L.isZero nonAdaCollateral ->
+                -- The ada left over is too small for a return collateral output, so
+                -- use the whole collateral as total collateral instead. The extra ada
+                -- is only lost if a Plutus script fails on chain.
+                Right (Nothing, Just $ TxTotalCollateral totalCollateralLovelace)
+            | otherwise ->
+                Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO
 
 -- | Transaction fees can be computed for a proposed transaction based on the
 -- expected number of key witnesses (i.e. signatures).

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -1373,8 +1373,8 @@ calcReturnAndTotalCollateral w fee pp' TxInsCollateral{} txReturnCollateral txTo
                 Right (TxReturnCollateral w returnCollateralTxOut, totalCollateral)
             | L.isZero nonAdaCollateral ->
                 -- The ada left over is too small for a return collateral output, so
-                -- use the whole collateral as total collateral instead. The extra ada
-                -- is only lost if a Plutus script fails on chain.
+                -- use all of the collateral inputs as total collateral instead. The
+                -- extra ada is only lost if a Plutus script fails on chain.
                 Right (TxReturnCollateralNone, TxTotalCollateral w totalCollateralLovelace)
             | otherwise ->
                 Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -213,7 +213,11 @@ estimateBalancedTxBody
   -> Map ScriptWitnessIndex ExecutionUnits
   -- ^ Plutus script execution units.
   -> Coin
-  -- ^ Total potential collateral amount.
+  -- ^ Total potential collateral amount. The content of the collateral
+  --   inputs is not visible to this function, so they are assumed to
+  --   contain no native tokens. To use collateral inputs that carry
+  --   native tokens, provide 'txReturnCollateral' and 'txTotalCollateral'
+  --   explicitly.
   -> Int
   -- ^ The number of key witnesses to be added to the transaction.
   -> Int
@@ -940,7 +944,8 @@ data FeeEstimationMode era
   | -- | Less accurate fee estimation.
     EstimateWithoutSpendableUTxO
       Coin
-      -- ^ Total potential collateral amount
+      -- ^ Total potential collateral amount, assuming the collateral
+      --   inputs contain no native tokens
       Value
       -- ^ Total value of UTxOs being spent
       (Map ScriptWitnessIndex ExecutionUnits)
@@ -1363,9 +1368,16 @@ calcReturnAndTotalCollateral w fee pp' TxInsCollateral{} txReturnCollateral txTo
                   TxOutDatumNone
                   ReferenceScriptNone
               minReturnUTxO = calculateMinimumUTxO sbe pp' returnCollateralTxOut
-          if returnCollateralAda < minReturnUTxO
-            then Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO
-            else Right (TxReturnCollateral w returnCollateralTxOut, totalCollateral)
+          if
+            | returnCollateralAda >= minReturnUTxO ->
+                Right (TxReturnCollateral w returnCollateralTxOut, totalCollateral)
+            | L.isZero nonAdaCollateral ->
+                -- The ada left over is too small for a return collateral output, so
+                -- use the whole collateral as total collateral instead. The extra ada
+                -- is only lost if a Plutus script fails on chain.
+                Right (TxReturnCollateralNone, TxTotalCollateral w totalCollateralLovelace)
+            | otherwise ->
+                Left $ ReturnCollateralBelowMinimumUTxO returnCollateralAda minReturnUTxO
 
 -- | Calculate the partial change - this does not include certificates' deposits
 calculatePartialChangeValue

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
@@ -1003,7 +1003,7 @@ prop_makeTransactionBodyAutoBalance_return_collateral_with_tokens_below_min_utxo
 -- With an ada-only collateral input holding exactly the minimum UTxO value,
 -- the ada left after covering the required collateral (150% of the fee) is
 -- necessarily below the minimum UTxO value of a return collateral output.
--- Instead of failing, balancing must use the whole collateral input as total
+-- Instead of failing, balancing must use all of the collateral inputs as total
 -- collateral and omit the return collateral output: the extra ada is only
 -- lost if the Plutus script fails on chain.
 prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral :: Property
@@ -1082,12 +1082,14 @@ prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral = H.propert
         (Api.fromShelleyAddr sbe addr)
         Nothing
 
-  case (Exp.txReturnCollateral balancedContent, Exp.txTotalCollateral balancedContent) of
-    (Nothing, Just (Exp.TxTotalCollateral totalCollateral)) ->
-      totalCollateral H.=== minUTxOCollateral
-    _ -> do
-      H.annotate "Expected the whole collateral as total collateral, with no return collateral output"
-      H.failure
+  let returnCollateralAda =
+        (^. L.coinTxOutL) . Exp.unTxReturnCollateral <$> Exp.txReturnCollateral balancedContent
+      totalCollateralAda = Exp.unTxTotalCollateral <$> Exp.txTotalCollateral balancedContent
+
+  H.note_ "Check that there is no return collateral output"
+  returnCollateralAda H.=== Nothing
+  H.note_ "Check that all of the collateral inputs are used as total collateral"
+  totalCollateralAda H.=== Just minUTxOCollateral
 
 -- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
 --
@@ -1167,12 +1169,14 @@ prop_estimateBalancedTxBody_folds_dust_into_total_collateral = H.propertyOnce $ 
         (Api.fromShelleyAddr sbe addr)
         (L.MaryValue (L.Coin 12_000_000) mempty)
 
-  case (Exp.txReturnCollateral balancedContent, Exp.txTotalCollateral balancedContent) of
-    (Nothing, Just (Exp.TxTotalCollateral totalCollateral)) ->
-      totalCollateral H.=== minUTxOCollateral
-    _ -> do
-      H.annotate "Expected the whole collateral as total collateral, with no return collateral output"
-      H.failure
+  let returnCollateralAda =
+        (^. L.coinTxOutL) . Exp.unTxReturnCollateral <$> Exp.txReturnCollateral balancedContent
+      totalCollateralAda = Exp.unTxTotalCollateral <$> Exp.txTotalCollateral balancedContent
+
+  H.note_ "Check that there is no return collateral output"
+  returnCollateralAda H.=== Nothing
+  H.note_ "Check that all of the collateral inputs are used as total collateral"
+  totalCollateralAda H.=== Just minUTxOCollateral
 
 -- | A well-funded transaction returns a positive fee from 'evaluateTransaction'.
 prop_evaluateTransaction_positive_fee :: Property

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Experimental/Fee.hs
@@ -20,7 +20,9 @@ import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Monad.Error (failEitherWith)
 import Cardano.Api.Parser.Text qualified as Api
 
+import Cardano.Ledger.Alonzo.Scripts qualified as Alonzo
 import Cardano.Ledger.Api qualified as UnexportedLedger
+import Cardano.Ledger.Conway.Scripts qualified as Conway
 import Cardano.Ledger.Core qualified as L
 import Cardano.Ledger.Mary.Value qualified as Mary
 import Cardano.Ledger.Tools qualified as L (calcMinFeeTx)
@@ -118,12 +120,18 @@ tests =
         , testProperty
             "fails on return collateral with tokens below min UTxO"
             prop_makeTransactionBodyAutoBalance_return_collateral_with_tokens_below_min_utxo
+        , testProperty
+            "folds return collateral dust into the total collateral"
+            prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral
         ]
     , testGroup
         "estimateBalancedTxBody"
         [ testProperty
             "removes collateral without Plutus scripts"
             prop_estimateBalancedTxBody_no_collateral_without_plutus
+        , testProperty
+            "folds return collateral dust into the total collateral"
+            prop_estimateBalancedTxBody_folds_dust_into_total_collateral
         ]
     , testGroup
         "evaluateTransaction"
@@ -988,6 +996,182 @@ prop_makeTransactionBodyAutoBalance_return_collateral_with_tokens_below_min_utxo
       H.failure
     Right _ -> do
       H.annotate "Expected balancing to fail with ReturnCollateralBelowMinimumUTxO, but it succeeded"
+      H.failure
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- With an ada-only collateral input holding exactly the minimum UTxO value,
+-- the ada left after covering the required collateral (150% of the fee) is
+-- necessarily below the minimum UTxO value of a return collateral output.
+-- Instead of failing, balancing must use the whole collateral input as total
+-- collateral and omit the return collateral output: the extra ada is only
+-- lost if the Plutus script fails on chain.
+prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral :: Property
+prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral = H.propertyOnce $ do
+  let era = Exp.ConwayEra
+      sbe = convert era
+      systemStart = Api.SystemStart $ Time.posixSecondsToUTCTime 0
+      epochInfo =
+        Api.LedgerEpochInfo $
+          Slotting.fixedEpochInfo (Slotting.EpochSize 100) (Slotting.mkSlotLength 1000)
+
+  -- Protocol parameters with cost models, so that the Plutus script can run.
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+
+  scriptEnvelope <-
+    H.evalIO $ B.readFile "test/cardano-api-test/files/input/plutus/v3.alwaysTrue.json"
+  Exp.AnyPlutusScript plutusScript <- H.evalEither $ Exp.readAnyScriptBytes era scriptEnvelope
+
+  fundingTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+  collateralTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+
+  let addr =
+        L.Addr
+          L.Testnet
+          (L.KeyHashObj $ L.KeyHash "1c14ee8e58fbcbd48dc7367c95a63fd1d937ba989820015db16ac7e5")
+          L.StakeRefNull
+      ledgerScriptHash = ExpPlutus.hashPlutusScriptInEra plutusScript
+      mintWitness =
+        Exp.AnyScriptWitnessPlutus $
+          Exp.AnyPlutusMintingScriptWitness $
+            Exp.PlutusScriptWitness
+              (ExpPlutus.plutusScriptInEraSLanguage plutusScript)
+              (Exp.PScript plutusScript)
+              Exp.NoScriptDatum
+              (Api.unsafeHashableScriptData (Api.ScriptDataMap []))
+              (Api.ExecutionUnits 0 0)
+      -- The ada-only collateral input holds exactly its minimum UTxO value.
+      minUTxOCollateral =
+        Exp.calculateMinimumUTxO ledgerPParams $
+          Exp.TxOut (L.mkBasicTxOut addr (L.MaryValue (L.Coin 0) mempty))
+      utxo =
+        L.UTxO $
+          Map.fromList
+            [ (Api.toShelleyTxIn fundingTxIn, L.mkBasicTxOut addr (L.MaryValue (L.Coin 12_000_000) mempty))
+            , (Api.toShelleyTxIn collateralTxIn, L.mkBasicTxOut addr (L.MaryValue minUTxOCollateral mempty))
+            ]
+      txBodyContent =
+        Exp.defaultTxBodyContent
+          & Exp.setTxIns [(fundingTxIn, Exp.AnyKeyWitnessPlaceholder)]
+          & Exp.setTxInsCollateral [collateralTxIn]
+          & Exp.setTxOuts [Exp.TxOut $ L.mkBasicTxOut addr (L.MaryValue (L.Coin 5_000_000) mempty)]
+          & Exp.setTxMintValue
+            ( Exp.TxMintValue $
+                Map.singleton
+                  (Api.PolicyId $ Api.ScriptHash ledgerScriptHash)
+                  (fromList [(Api.UnsafeAssetName "eeee", 1)], mintWitness)
+            )
+          & Exp.setTxProtocolParams ledgerPParams
+
+  (_, balancedContent) <-
+    H.leftFail $
+      Exp.makeTransactionBodyAutoBalance
+        systemStart
+        epochInfo
+        ledgerPParams
+        mempty
+        mempty
+        mempty
+        utxo
+        txBodyContent
+        (Api.fromShelleyAddr sbe addr)
+        Nothing
+
+  case (Exp.txReturnCollateral balancedContent, Exp.txTotalCollateral balancedContent) of
+    (Nothing, Just (Exp.TxTotalCollateral totalCollateral)) ->
+      totalCollateral H.=== minUTxOCollateral
+    _ -> do
+      H.annotate "Expected the whole collateral as total collateral, with no return collateral output"
+      H.failure
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- Like 'prop_makeTransactionBodyAutoBalance_folds_dust_into_total_collateral',
+-- but for 'Exp.estimateBalancedTxBody'.
+prop_estimateBalancedTxBody_folds_dust_into_total_collateral :: Property
+prop_estimateBalancedTxBody_folds_dust_into_total_collateral = H.propertyOnce $ do
+  let era = Exp.ConwayEra
+      sbe = convert era
+
+  -- Protocol parameters with cost models, so that the Plutus script can run.
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+
+  scriptEnvelope <-
+    H.evalIO $ B.readFile "test/cardano-api-test/files/input/plutus/v3.alwaysTrue.json"
+  Exp.AnyPlutusScript plutusScript <- H.evalEither $ Exp.readAnyScriptBytes era scriptEnvelope
+
+  fundingTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+  collateralTxIn <-
+    H.evalEither $
+      Api.runParser Api.parseTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+
+  let addr =
+        L.Addr
+          L.Testnet
+          (L.KeyHashObj $ L.KeyHash "1c14ee8e58fbcbd48dc7367c95a63fd1d937ba989820015db16ac7e5")
+          L.StakeRefNull
+      ledgerScriptHash = ExpPlutus.hashPlutusScriptInEra plutusScript
+      mintWitness =
+        Exp.AnyScriptWitnessPlutus $
+          Exp.AnyPlutusMintingScriptWitness $
+            Exp.PlutusScriptWitness
+              (ExpPlutus.plutusScriptInEraSLanguage plutusScript)
+              (Exp.PScript plutusScript)
+              Exp.NoScriptDatum
+              (Api.unsafeHashableScriptData (Api.ScriptDataMap []))
+              (Api.ExecutionUnits 0 0)
+      -- The smallest realistic ada-only collateral: exactly the minimum UTxO
+      -- value.
+      minUTxOCollateral =
+        Exp.calculateMinimumUTxO ledgerPParams $
+          Exp.TxOut (L.mkBasicTxOut addr (L.MaryValue (L.Coin 0) mempty))
+      txBodyContent =
+        Exp.defaultTxBodyContent
+          & Exp.setTxIns [(fundingTxIn, Exp.AnyKeyWitnessPlaceholder)]
+          & Exp.setTxInsCollateral [collateralTxIn]
+          & Exp.setTxOuts [Exp.TxOut $ L.mkBasicTxOut addr (L.MaryValue (L.Coin 5_000_000) mempty)]
+          & Exp.setTxMintValue
+            ( Exp.TxMintValue $
+                Map.singleton
+                  (Api.PolicyId $ Api.ScriptHash ledgerScriptHash)
+                  (fromList [(Api.UnsafeAssetName "eeee", 1)], mintWitness)
+            )
+          & Exp.setTxProtocolParams ledgerPParams
+      exUnitsMap =
+        Map.singleton
+          (Conway.ConwayMinting (Alonzo.AsIx 0))
+          (Api.ExecutionUnits 84_851_308 325_610)
+
+  balancedContent <-
+    H.leftFail $
+      Exp.estimateBalancedTxBody
+        era
+        txBodyContent
+        ledgerPParams
+        mempty
+        mempty
+        mempty
+        exUnitsMap
+        minUTxOCollateral
+        1
+        0
+        0
+        (Api.fromShelleyAddr sbe addr)
+        (L.MaryValue (L.Coin 12_000_000) mempty)
+
+  case (Exp.txReturnCollateral balancedContent, Exp.txTotalCollateral balancedContent) of
+    (Nothing, Just (Exp.TxTotalCollateral totalCollateral)) ->
+      totalCollateral H.=== minUTxOCollateral
+    _ -> do
+      H.annotate "Expected the whole collateral as total collateral, with no return collateral output"
       H.failure
 
 -- | A well-funded transaction returns a positive fee from 'evaluateTransaction'.

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -796,6 +796,154 @@ prop_make_transaction_body_autobalance_return_collateral_with_tokens_below_min_u
       H.annotate "Expected balancing to fail with ReturnCollateralBelowMinimumUTxO, but it succeeded"
       H.failure
 
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- With an ada-only collateral input holding exactly the minimum UTxO value,
+-- the ada left after covering the required collateral (150% of the fee) is
+-- necessarily below the minimum UTxO value of a return collateral output.
+-- Instead of failing, balancing must use the whole collateral input as total
+-- collateral and omit the return collateral output: the extra ada is only
+-- lost if the Plutus script fails on chain.
+prop_make_transaction_body_autobalance_folds_dust_into_total_collateral :: Property
+prop_make_transaction_body_autobalance_folds_dust_into_total_collateral = H.propertyOnce $ do
+  let ceo = ConwayEraOnwardsConway
+      beo = convert ceo
+      aeo = convert beo
+      meo = convert beo
+      sbe = convert ceo
+
+  systemStart <- parseSystemStart "2021-09-01T00:00:00Z"
+  let epochInfo = LedgerEpochInfo $ CS.fixedEpochInfo (CS.EpochSize 100) (CS.mkSlotLength 1000)
+
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+  let pparams = LedgerProtocolParameters ledgerPParams
+
+  (sh@(ScriptHash _), plutusWitness) <- loadPlutusWitness ceo
+  let policyId' = PolicyId sh
+      address =
+        AddressInEra
+          (ShelleyAddressInEra sbe)
+          ( ShelleyAddress
+              L.Testnet
+              (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+              L.StakeRefNull
+          )
+      fundingTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+      collateralTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+      -- The ada-only collateral input holds exactly its minimum UTxO value.
+      minUTxOCollateral =
+        calculateMinimumUTxO sbe ledgerPParams $
+          TxOut address (lovelaceToTxOutValue sbe 0) TxOutDatumNone ReferenceScriptNone
+      utxos =
+        UTxO
+          [
+            ( fundingTxIn
+            , TxOut address (lovelaceToTxOutValue sbe 12_000_000) TxOutDatumNone ReferenceScriptNone
+            )
+          ,
+            ( collateralTxIn
+            , TxOut address (lovelaceToTxOutValue sbe minUTxOCollateral) TxOutDatumNone ReferenceScriptNone
+            )
+          ]
+      txMint =
+        TxMintValue
+          meo
+          [(policyId', ([(UnsafeAssetName "eeee", 1)], BuildTxWith plutusWitness))]
+      content =
+        defaultTxBodyContent sbe
+          & setTxIns [(fundingTxIn, BuildTxWith (KeyWitness KeyWitnessForSpending))]
+          & setTxInsCollateral (TxInsCollateral aeo [collateralTxIn])
+          & setTxOuts (mkTxOutput beo address (L.Coin 5_000_000) Nothing)
+          & setTxMintValue txMint
+          & setTxProtocolParams (pure $ pure pparams)
+
+  BalancedTxBody balancedContent _ _ _ <-
+    H.leftFail $
+      makeTransactionBodyAutoBalance
+        sbe
+        systemStart
+        epochInfo
+        pparams
+        mempty
+        mempty
+        mempty
+        utxos
+        content
+        address
+        Nothing
+
+  txReturnCollateral balancedContent === TxReturnCollateralNone
+  txTotalCollateral balancedContent === TxTotalCollateral beo minUTxOCollateral
+
+-- | Regression test for: https://github.com/IntersectMBO/cardano-api/issues/1261
+--
+-- Like
+-- 'prop_make_transaction_body_autobalance_folds_dust_into_total_collateral',
+-- but for 'estimateBalancedTxBody'.
+prop_estimate_balanced_tx_body_folds_dust_into_total_collateral :: Property
+prop_estimate_balanced_tx_body_folds_dust_into_total_collateral = H.propertyOnce $ do
+  let ceo = ConwayEraOnwardsConway
+      beo = convert ceo
+      aeo = convert beo
+      meo = convert beo
+      sbe = convert ceo
+
+  ledgerPParams <-
+    H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
+  let pparams = LedgerProtocolParameters ledgerPParams
+
+  (sh@(ScriptHash _), plutusWitness) <- loadPlutusWitness ceo
+  let policyId' = PolicyId sh
+      address =
+        AddressInEra
+          (ShelleyAddressInEra sbe)
+          ( ShelleyAddress
+              L.Testnet
+              (mkCredential "keyHash-ebe9de78a37f84cc819c0669791aa0474d4f0a764e54b9f90cfe2137")
+              L.StakeRefNull
+          )
+      fundingTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#0"
+      collateralTxIn = mkTxIn "01f4b788593d4f70de2a45c2e1e87088bfbdfa29577ae1b62aba60e095e3ab53#1"
+      -- The smallest realistic ada-only collateral: exactly the minimum UTxO
+      -- value.
+      minUTxOCollateral =
+        calculateMinimumUTxO sbe ledgerPParams $
+          TxOut address (lovelaceToTxOutValue sbe 0) TxOutDatumNone ReferenceScriptNone
+      txMint =
+        TxMintValue
+          meo
+          [(policyId', ([(UnsafeAssetName "eeee", 1)], BuildTxWith plutusWitness))]
+      content =
+        defaultTxBodyContent sbe
+          & setTxIns [(fundingTxIn, BuildTxWith (KeyWitness KeyWitnessForSpending))]
+          & setTxInsCollateral (TxInsCollateral aeo [collateralTxIn])
+          & setTxOuts (mkTxOutput beo address (L.Coin 5_000_000) Nothing)
+          & setTxMintValue txMint
+          & setTxProtocolParams (pure $ pure pparams)
+      exUnitsMap =
+        [(ScriptWitnessIndexMint 0, ExecutionUnits 84_851_308 325_610)]
+
+  BalancedTxBody balancedContent _ _ _ <-
+    H.leftFail $
+      estimateBalancedTxBody
+        meo
+        content
+        ledgerPParams
+        mempty
+        mempty
+        mempty
+        exUnitsMap
+        minUTxOCollateral
+        1
+        0
+        0
+        address
+        (lovelaceToValue 12_000_000)
+
+  txReturnCollateral balancedContent === TxReturnCollateralNone
+  txTotalCollateral balancedContent === TxTotalCollateral beo minUTxOCollateral
+
 -- | Regression test for: https://github.com/IntersectMBO/cardano-cli/issues/1073
 prop_ensure_gov_actions_are_preserved_by_autobalance :: Property
 prop_ensure_gov_actions_are_preserved_by_autobalance = H.propertyOnce $ do
@@ -1053,6 +1201,12 @@ tests =
     , testProperty
         "makeTransactionBodyAutoBalance fails on return collateral with tokens below min UTxO"
         prop_make_transaction_body_autobalance_return_collateral_with_tokens_below_min_utxo
+    , testProperty
+        "makeTransactionBodyAutoBalance folds return collateral dust into the total collateral"
+        prop_make_transaction_body_autobalance_folds_dust_into_total_collateral
+    , testProperty
+        "estimateBalancedTxBody folds return collateral dust into the total collateral"
+        prop_estimate_balanced_tx_body_folds_dust_into_total_collateral
     , testProperty
         "Governance actions are preserved by autobalance"
         prop_ensure_gov_actions_are_preserved_by_autobalance

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/Transaction/Autobalance.hs
@@ -481,19 +481,36 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
   let beo = BabbageEraOnwardsConway
       sbe = convert beo
       era = convert beo
+      address = AddressInEra (ShelleyAddressInEra sbe) (ShelleyAddress L.Testnet def L.StakeRefNull)
   feeCoin@(L.Coin fee) <- forAll genLovelace
-  totalCollateral <- forAll $ genLedgerValueForTxOut sbe
-  let totalCollateralAda = totalCollateral ^. Api.adaAssetL sbe
   pparams <-
     H.readJsonFileOk "test/cardano-api-test/files/input/protocol-parameters/conway.json"
   requiredCollateralPct <- H.noteShow . fromIntegral $ pparams ^. L.ppCollateralPercentageL
   requiredCollateralAda <-
     H.noteShow . L.rationalToCoinViaCeiling $ (fee * requiredCollateralPct) % 100
+  -- The ada left for the return collateral output is the collateral ada minus
+  -- the required collateral, so 'genLedgerValueForTxOut' alone (1 or 2
+  -- lovelace of ada) always lands far below the minimum UTxO value of that
+  -- output. Add ada around that minimum so that the property exercises both
+  -- sides of the boundary, and shrinks towards it.
+  let L.Coin adaOnlyMinUTxO =
+        calculateMinimumUTxO sbe pparams $
+          TxOut address (lovelaceToTxOutValue sbe 0) TxOutDatumNone ReferenceScriptNone
+  totalCollateral <- forAll $ do
+    generatedCollateral <- genLedgerValueForTxOut sbe
+    -- Keeping some collateral without the extra ada preserves the coverage of
+    -- the insufficient collateral case.
+    extraAda <-
+      Gen.frequency
+        [ (1, pure 0)
+        , (4, Gen.integral $ Range.linearFrom adaOnlyMinUTxO 0 (2 * adaOnlyMinUTxO))
+        ]
+    pure $ generatedCollateral <> Api.mkAdaValue sbe (L.Coin extraAda)
+  let totalCollateralAda = totalCollateral ^. Api.adaAssetL sbe
   txInsColl <- forAll $ genTxInsCollateral era
   txRetColl <-
     forAll $ Gen.frequency [(4, pure TxReturnCollateralNone), (1, genTxReturnCollateral sbe)]
   txTotColl <- forAll $ Gen.frequency [(4, pure TxTotalCollateralNone), (1, genTxTotalCollateral era)]
-  let address = AddressInEra (ShelleyAddressInEra sbe) (ShelleyAddress L.Testnet def L.StakeRefNull)
 
   let result =
         calcReturnAndTotalCollateral
@@ -555,6 +572,34 @@ prop_calcReturnAndTotalCollateral = H.withTests 400 . H.property $ do
             H.assertWith collBalance $ L.pointwise (<=) (L.inject requiredCollateralAda)
             H.note_ "Check that collateral balance is equal to collateral in tx body"
             resTotCollValue === collBalance
+            -- Pin the minimum UTxO boundary of the return collateral output in
+            -- both directions: an output that is produced must be spendable,
+            -- and one that is omitted must have been impossible to produce.
+            case resRetColl of
+              TxReturnCollateral _ resRetCollTxOut@(TxOut _ resRetCollTxOutValue _ _) -> do
+                H.note_ "Check that the return collateral output meets its own minimum UTxO value"
+                H.diff
+                  (txOutValueToLovelace resRetCollTxOutValue)
+                  (>=)
+                  (calculateMinimumUTxO sbe pparams resRetCollTxOut)
+              TxReturnCollateralNone -> do
+                -- The return collateral output the function would have built
+                -- had it not folded the leftover ada into the total collateral.
+                let L.Coin candidateReturnAmount =
+                      totalCollateralAda * 100 - L.Coin (fee * requiredCollateralPct)
+                    candidateReturnAda = L.rationalToCoinViaFloor $ candidateReturnAmount % 100
+                    candidateReturnValue =
+                      Api.mkAdaValue sbe candidateReturnAda
+                        <> L.modifyCoin (const mempty) totalCollateral
+                candidateTxOut <-
+                  H.noteShow $
+                    TxOut
+                      address
+                      (TxOutValueShelleyBased sbe candidateReturnValue)
+                      TxOutDatumNone
+                      ReferenceScriptNone
+                H.note_ "Check that the omitted return collateral output could not have met its minimum UTxO value"
+                H.diff candidateReturnAda (<) (calculateMinimumUTxO sbe pparams candidateTxOut)
           Left err@InsufficientCollateral{} -> do
             H.annotateShow err
             H.annotate "Unreachable: the guard above ensures the collateral covers the requirement"
@@ -801,7 +846,7 @@ prop_make_transaction_body_autobalance_return_collateral_with_tokens_below_min_u
 -- With an ada-only collateral input holding exactly the minimum UTxO value,
 -- the ada left after covering the required collateral (150% of the fee) is
 -- necessarily below the minimum UTxO value of a return collateral output.
--- Instead of failing, balancing must use the whole collateral input as total
+-- Instead of failing, balancing must use all of the collateral inputs as total
 -- collateral and omit the return collateral output: the extra ada is only
 -- lost if the Plutus script fails on chain.
 prop_make_transaction_body_autobalance_folds_dust_into_total_collateral :: Property


### PR DESCRIPTION
# Context

This is the third of three stacked PRs fixing #1261: the balancing functions
(`makeTransactionBodyAutoBalance` and `estimateBalancedTxBody`, in both the traditional and the
experimental API) could build transactions that the ledger rejects at submission time because of
their collateral. Each PR contains a pair of commits — regression tests that fail, then the fix
that makes them pass — and each PR is based on the previous one, so every diff shows only its own
two commits.

🗺️ **Map** — you are here: 3️⃣

|  |  |  |
|---|---|---|
| 🚪 | [#1261](https://github.com/IntersectMBO/cardano-api/issues/1261) | the issue: `transaction build` does not validate min UTxO value of the collateral return output |
| 1️⃣ | #1265 | remove collateral from transactions without Plutus scripts |
| 2️⃣ | #1266 | fail on invalid computed collateral instead of building a rejected transaction |
| 3️⃣ | **(this PR)** | fold return collateral dust into the total collateral |

**This PR:** after the previous PR, balancing fails when the ada left over for the return
collateral output is below its minimum UTxO value — even when the collateral is ada-only and a
valid transaction exists. `calcReturnAndTotalCollateral` (both copies) now folds that ada into
the total collateral and omits the return collateral output instead of failing; the extra ada is
only lost if a Plutus script fails on chain. `estimateBalancedTxBody` cannot see the content of
the collateral inputs, so it computes collateral under the assumption that they contain no native
tokens — now documented on its `totalPotentialCollateral` parameters. A transaction built under a
wrong assumption is rejected by the ledger, and tokens are never lost: a valid transaction must
always give the tokens back in the return collateral output. Fixes #1261.

# How to trust this PR

- The first commit adds four regression tests (one per balancing function) with an ada-only
  collateral input holding exactly its minimum UTxO value: balancing must succeed, with no return
  collateral output and the whole input as total collateral. On the base branch they fail with
  the `ReturnCollateralBelowMinimumUTxO` collateral error; the second commit makes them pass.
- The fold only happens when the collateral value is ada-only (`isZero` on the non-ada part):
  token-carrying collateral keeps failing, and the tests from the previous PR still pass.
- The pre-existing property test `prop_calcReturnAndTotalCollateral` needs no change: its
  computed-case assertions hold for folded results.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

