### PR TITLE
cardano-rpc: Implement FollowTip SyncService method

### DIFF
--- a/.changes/20260722_cardano_api_chaindb_follower_reexports.yml
+++ b/.changes/20260722_cardano_api_chaindb_follower_reexports.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1268
+kind:
+  - compatible
+description: |
+  Re-export the ChainDB follower API from Cardano.Api.Consensus: newFollower, Follower, ChainType, ChainUpdate, withRegistry, ResourceRegistry, configSecurityParam and SecurityParam.

--- a/.changes/20260722_cardano_rpc_follow_tip.yml
+++ b/.changes/20260722_cardano_rpc_follow_tip.yml
@@ -1,0 +1,6 @@
+project: cardano-rpc
+pr: 1268
+kind:
+  - feature
+description: |
+  Implement the FollowTip SyncService method: streams fully parsed blocks as the chain advances, starting from the first intersection point found on the chain (an empty-hash block ref denotes origin). An empty intersect list follows from the current tip; an unmatched intersect list fails with NOT_FOUND. Rollbacks are delivered as reset actions.

--- a/.changes/20260722_cardano_rpc_follow_tip.yml
+++ b/.changes/20260722_cardano_rpc_follow_tip.yml
@@ -3,4 +3,4 @@ pr: 1268
 kind:
   - feature
 description: |
-  Implement the FollowTip SyncService method: streams fully parsed blocks as the chain advances, starting from the first intersection point found on the chain (an empty-hash block ref denotes origin). An empty intersect list follows from the current tip; an unmatched intersect list fails with NOT_FOUND. Rollbacks are delivered as reset actions.
+  Implement the FollowTip SyncService method: streams fully parsed blocks as the chain advances, starting from the first intersection point found on the chain (an empty-hash block ref denotes origin). An empty intersect list follows from the current tip; an unmatched intersect list fails with NOT_FOUND. Rollbacks are delivered as undo actions carrying the rolled-back blocks where they can be reconstructed from ChainDB, falling back to reset otherwise.

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -184,6 +184,7 @@ library
     prettyprinter-ansi-terminal,
     prettyprinter-configurable ^>=1.36,
     random,
+    resource-registry ^>=0.2,
     safe-exceptions,
     scientific,
     serialise,

--- a/cardano-api/src/Cardano/Api/Consensus.hs
+++ b/cardano-api/src/Cardano/Api/Consensus.hs
@@ -52,15 +52,20 @@ module Cardano.Api.Consensus
   , ByronBlock
   , CardanoBlock
   , ChainDB.ChainDB
+  , ChainDB.ChainType (..)
+  , ChainDB.Follower (..)
   , ChainDB.getBlockComponent
   , ChainDB.getCurrentLedger
   , ChainDB.getTipHeader
+  , ChainDB.newFollower
+  , ChainUpdate (..)
   , ConfigSupportsNode
   , ChainDepState
   , GenTx (..)
   , EraMismatch (..)
   , HasHardForkHistory (..)
   , HasHeader
+  , Header
   , HeaderHash
   , NodeKernel (..)
   , OneEraHash (..)
@@ -68,6 +73,8 @@ module Cardano.Api.Consensus
   , PraosProtocolSupportsNode
   , PraosProtocolSupportsNodeCrypto
   , RealPoint (..)
+  , ResourceRegistry
+  , SecurityParam (..)
   , ShelleyGenesisStaking (..)
   , StandardCrypto
   , TopLevelConfig
@@ -79,12 +86,14 @@ module Cardano.Api.Consensus
   , byronIdTx
   , configBlock
   , configLedger
+  , configSecurityParam
   , condense
   , getOpCertCounters
   , interpreterToEpochInfo
   , mkInterpreter
   , unsafeExtendSafeZone
   , txId
+  , withRegistry
   )
 where
 

--- a/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
@@ -2,10 +2,12 @@ module Cardano.Api.Consensus.Internal.Reexport
   ( BlockComponent (..)
   , ByronBlock
   , CardanoBlock
+  , ChainUpdate (..)
   , ConfigSupportsNode
   , ChainDepState
   , GenTx (..)
   , HasHeader
+  , Header
   , HeaderHash
   , EraMismatch (..)
   , NodeKernel (..)
@@ -15,6 +17,8 @@ module Cardano.Api.Consensus.Internal.Reexport
   , PraosProtocolSupportsNode
   , PraosProtocolSupportsNodeCrypto
   , RealPoint (..)
+  , ResourceRegistry
+  , SecurityParam (..)
   , ShelleyGenesisStaking (..)
   , StandardCrypto
   , TopLevelConfig
@@ -26,18 +30,21 @@ module Cardano.Api.Consensus.Internal.Reexport
   , byronIdTx
   , configBlock
   , configLedger
+  , configSecurityParam
   , condense
   , getOpCertCounters
   , interpreterToEpochInfo
   , mkInterpreter
   , unsafeExtendSafeZone
   , txId
+  , withRegistry
   )
 where
 
 import Cardano.Protocol.Crypto (StandardCrypto)
 import Ouroboros.Consensus.Block
   ( HasHeader
+  , Header
   , HeaderHash
   , RealPoint (..)
   , blockHash
@@ -46,7 +53,13 @@ import Ouroboros.Consensus.Block
   )
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock (byronBlockRaw), GenTx (..), byronIdTx)
 import Ouroboros.Consensus.Cardano.Block (CardanoBlock, EraMismatch (..))
-import Ouroboros.Consensus.Config (TopLevelConfig, configBlock, configLedger)
+import Ouroboros.Consensus.Config
+  ( TopLevelConfig
+  , configBlock
+  , configLedger
+  , configSecurityParam
+  )
+import Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 import Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
 import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
 import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraHash (..))
@@ -68,3 +81,6 @@ import Ouroboros.Consensus.Protocol.Praos.Common
 import Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 import Ouroboros.Consensus.Storage.Common (BlockComponent (..))
 import Ouroboros.Consensus.Util.Condense (condense)
+import Ouroboros.Network.Block (ChainUpdate (..))
+
+import Control.ResourceRegistry (ResourceRegistry, withRegistry)

--- a/cardano-rpc/README.md
+++ b/cardano-rpc/README.md
@@ -35,7 +35,7 @@ It implements [UTxO RPC](https://utxorpc.org/introduction) protobuf communicatio
 |--------|--------|
 | [FetchBlock](https://utxorpc.org/sync/spec/#fetchblockrequest) | ✅ Supported |
 | [DumpHistory](https://utxorpc.org/sync/spec/#dumphistoryrequest) | ⬜ Not supported |
-| [FollowTip](https://utxorpc.org/sync/spec/#followtiprequest) | ⬜ Not supported |
+| [FollowTip](https://utxorpc.org/sync/spec/#followtiprequest) | ✅ Supported |
 | [ReadTip](https://utxorpc.org/sync/spec/#readtiprequest) | ✅ Supported |
 
 ### [WatchService](https://utxorpc.org/watch/spec/)

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -174,6 +174,7 @@ test-suite cardano-rpc-test
     hedgehog,
     hedgehog-extras,
     memory,
+    ouroboros-consensus:cardano,
     proto-lens,
     rio,
     tasty,
@@ -192,6 +193,7 @@ test-suite cardano-rpc-test
     Test.Cardano.Rpc.ByronTx
     Test.Cardano.Rpc.Eval
     Test.Cardano.Rpc.FetchBlockTx
+    Test.Cardano.Rpc.FollowTipStream
     Test.Cardano.Rpc.Pagination
     Test.Cardano.Rpc.Predicate
     Test.Cardano.Rpc.ProtocolParameters

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -66,6 +66,7 @@ library
     Cardano.Rpc.Server.Internal.UtxoRpc.Sync
     Cardano.Rpc.Server.Internal.UtxoRpc.Type
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.BigInt
+    Cardano.Rpc.Server.Internal.UtxoRpc.Type.Block
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Byron
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Certificate
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -84,7 +84,7 @@ methodsSyncRpc
 methodsSyncRpc =
   Method (mkNonStreaming $ const unimplemented) -- dumpHistory
     . Method (mkNonStreaming $ wrapInSpan TraceRpcFetchBlockSpan . fetchBlockMethod)
-    . Method (mkServerStreaming $ \_ _ -> unimplemented) -- followTip
+    . Method (mkServerStreaming $ \req -> wrapInSpan TraceRpcFollowTipSpan . followTipMethod req)
     . Method (mkNonStreaming $ wrapInSpan TraceRpcReadTipSpan . readTipMethod)
     $ NoMoreMethods
  where

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -105,8 +105,6 @@ data TraceRpcSync
     TraceRpcFetchBlockNotFound SlotNo
   | -- | Node kernel access is not yet available
     TraceRpcNodeKernelAccessUnavailable
-  | -- | Ledger forker error
-    TraceRpcForkerError String
   deriving Show
 
 instance Pretty TraceRpcSync where
@@ -117,7 +115,6 @@ instance Pretty TraceRpcSync where
     TraceRpcReadTipSpan (SpanEnd _) -> "Finished ReadTip method"
     TraceRpcFetchBlockNotFound slot -> "Block not found at slot " <> pshow slot
     TraceRpcNodeKernelAccessUnavailable -> "Node kernel access not yet initialised"
-    TraceRpcForkerError e -> "Ledger forker error: " <> pretty e
 
 instance Error TraceRpcSync where
   prettyError = pretty

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -101,6 +101,8 @@ data TraceRpcSync
     TraceRpcFetchBlockSpan TraceSpanEvent
   | -- | ReadTip span
     TraceRpcReadTipSpan TraceSpanEvent
+  | -- | FollowTip span
+    TraceRpcFollowTipSpan TraceSpanEvent
   | -- | Requested block was not found
     TraceRpcFetchBlockNotFound SlotNo
   | -- | Node kernel access is not yet available
@@ -113,6 +115,8 @@ instance Pretty TraceRpcSync where
     TraceRpcFetchBlockSpan (SpanEnd _) -> "Finished FetchBlock method"
     TraceRpcReadTipSpan (SpanBegin _) -> "Started ReadTip method"
     TraceRpcReadTipSpan (SpanEnd _) -> "Finished ReadTip method"
+    TraceRpcFollowTipSpan (SpanBegin _) -> "Started FollowTip method"
+    TraceRpcFollowTipSpan (SpanEnd _) -> "Finished FollowTip method"
     TraceRpcFetchBlockNotFound slot -> "Block not found at slot " <> pshow slot
     TraceRpcNodeKernelAccessUnavailable -> "Node kernel access not yet initialised"
 

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
@@ -29,10 +29,13 @@ import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint
   )
 import Cardano.Rpc.Server.NodeKernelAccess
 
+import Cardano.Ledger.BaseTypes qualified as L
+
 import RIO
 
 import Data.ByteString qualified as BS
 import Data.ProtoLens (defMessage)
+import Data.Sequence qualified as Seq
 import Data.Time.Clock (UTCTime)
 import GHC.Stack (withFrozenCallStack)
 import Network.GRPC.Spec
@@ -77,22 +80,31 @@ readTipMethod _request = do
   tip <- readTipBlockRef chainDb (slotTimestampOrThrow systemStart readEraHistory)
   pure $ defMessage & U5c.maybe'tip .~ tip
 
--- | Handle the @FollowTip@ SyncService RPC method.
--- Streams fully parsed blocks as the chain advances, starting from the
--- first of the request's intersection points found on the chain (client
--- preference order). An intersection block ref with an empty hash denotes
--- origin; when the intersect list is empty, the stream follows from the
--- current tip.
--- The first streamed message is always a @reset@ announcing where the
--- stream starts. Later rollbacks are delivered the same way, as @reset@
--- actions carrying the rollback point's @BlockRef@ (slot and hash only),
--- equivalent to ChainSync's @MsgRollBackward@.
+-- | Handle the @FollowTip@ SyncService RPC method: stream fully parsed
+-- blocks as the chain advances.
+--
+-- Where the stream starts: at the first of the request's intersection
+-- points found on the chain, in client preference order. A block ref with
+-- an empty hash means origin. An empty intersect list means the current
+-- tip.
+--
+-- What the client receives: first a @reset@ announcing the start point,
+-- then an @apply@ per adopted block. A rollback becomes @undo@ actions
+-- carrying the rolled-back blocks, re-fetched from ChainDB and streamed
+-- newest first. When the blocks can no longer be re-fetched, because
+-- garbage collection won the race against the client, the rollback
+-- becomes a @reset@ carrying the rollback point's @BlockRef@ instead,
+-- slot and hash only, like ChainSync's @MsgRollBackward@. The tracked
+-- window is sized to the node's security parameter /k/, so no rollback
+-- consensus can produce falls outside it (see
+-- 'Cardano.Rpc.Server.NodeKernelAccess.Type.NodeKernelAccess').
 -- Every response also carries the current chain tip.
--- Returns @INVALID_ARGUMENT@ if an intersection block reference has an
--- invalid hash and @NOT_FOUND@ if none of the intersection points are on
--- the chain.
--- Runs until the client disconnects or the stream is otherwise closed; the
--- follower is closed on every exit path by 'withFollower'.
+--
+-- Errors: @INVALID_ARGUMENT@ if an intersection block ref has an invalid
+-- hash, @NOT_FOUND@ if none of the intersection points are on the chain.
+--
+-- Runs until the client disconnects or the stream is otherwise closed;
+-- 'withFollower' closes the follower on every exit path.
 followTipMethod
   :: MonadRpc e m
   => Proto U5c.FollowTipRequest
@@ -101,7 +113,7 @@ followTipMethod
   -- ^ Callback used to send each streamed response
   -> m ()
 followTipMethod request send = do
-  nodeKernelAccess@NodeKernelAccess{chainDb, systemStart, readEraHistory} <-
+  nodeKernelAccess@NodeKernelAccess{chainDb, systemStart, readEraHistory, securityParam} <-
     grabNodeKernelAccess
   requestedPoints <- traverse blockRefToIntersectPoint (request ^. U5c.intersect)
   withFollower nodeKernelAccess $ \follower -> do
@@ -121,6 +133,8 @@ followTipMethod request send = do
       follower
       (readTipBlockRef chainDb slotTimestamp)
       slotTimestamp
+      (fetchBlockByChainPoint nodeKernelAccess)
+      (fromIntegral . L.unNonZero $ Consensus.maxRollbacks securityParam)
       send
       startPoints
 
@@ -154,21 +168,60 @@ blockRefToPoint blockRef = do
       & either (const throwInvalidHash) pure
   pure (slot, headerHash)
 
--- | The @FollowTip@ streaming loop: given a positioned follower and a
--- resolved, non-empty list of intersection points, finds the intersection
--- and streams chain changes as they arrive.
+-- | Adapt 'fetchBlock', which takes a slot and a hash, to the point-based
+-- re-fetch parameter of 'followTipStream', which uses it to rebuild @undo@
+-- payloads.
 --
--- Takes its collaborators as plain arguments instead of a 'NodeKernelAccess',
--- so it can be driven by a scripted follower and stub capabilities in tests
--- with no live ChainDB required (see @Test.Cardano.Rpc.FollowTipStream@, the
--- first unit coverage of this loop). Only 'MonadIO' is needed: neither the
--- follower actions, the tip/timestamp readers, nor the gRPC error path
--- ('throwGrpcErrorWithMessage') require anything stronger.
+-- The genesis arm returns 'Nothing' only to keep the function total; it
+-- cannot actually be reached. 'followTipStream' re-fetches only points
+-- from its applied-points window, and every entry there comes from a
+-- decoded block's header, which always has a real slot and hash (see
+-- 'TrackedPoints').
+fetchBlockByChainPoint
+  :: MonadIO m
+  => NodeKernelAccess
+  -> ChainPoint
+  -> m (Maybe (ByteString, BlockInMode))
+fetchBlockByChainPoint _nodeKernelAccess ChainPointAtGenesis = pure Nothing
+fetchBlockByChainPoint nodeKernelAccess (ChainPoint slot headerHash) =
+  fetchBlock nodeKernelAccess slot headerHash
+
+-- | The applied points 'followTipStream' tracks for undo re-fetch, newest
+-- first.
 --
--- Rollbacks are delivered as @reset@ actions carrying the rollback point's
--- @BlockRef@ (slot and hash only), equivalent to ChainSync's
--- @MsgRollBackward@. Every emitted message, reset or apply, carries the
--- current tip.
+-- The entries are raw @(slot, header hash)@ pairs, not 'ChainPoint's.
+-- Every entry comes from 'getBlockHeader' on a decoded 'ChainApply'
+-- payload, so it always has a real slot and hash. The pair type turns
+-- "an applied point is never genesis" from a convention into a fact of
+-- the type: a @Seq ChainPoint@ would admit 'ChainPointAtGenesis' even
+-- though it could never legitimately occur here.
+type TrackedPoints = Seq.Seq (SlotNo, Hash BlockHeader)
+
+-- | The @FollowTip@ streaming loop. Finds the intersection with the given
+-- points, then streams chain changes as they arrive.
+--
+-- The collaborators are plain arguments rather than a 'NodeKernelAccess'
+-- so tests can drive the loop with a scripted follower and stubbed
+-- capabilities, no live ChainDB required (see
+-- @Test.Cardano.Rpc.FollowTipStream@, the first unit coverage of this
+-- loop). 'MonadIO' is enough for all of them, including the gRPC error
+-- path ('throwGrpcErrorWithMessage').
+--
+-- How a rollback is delivered, by case:
+--
+-- 1. The target is within the tracked window, meaning it is one of the
+--    last @trackingCap@ applied points or the window floor (the stream's
+--    start point, on which a rollback undoes everything tracked). Each
+--    rolled-back block is re-fetched by point and emitted as @undo@,
+--    newest first.
+-- 2. A re-fetch misses mid-undo because garbage collection won the race:
+--    a single @reset@ at the rollback target. Partial undo followed by
+--    reset is coherent because @reset@ is absolute positioning.
+-- 3. The target is outside the window, either deeper than the cap or the
+--    initial rollback-to-intersection when nothing is tracked yet: a
+--    single @reset@, as in 2.
+--
+-- Every emitted message, apply or undo or reset, carries the current tip.
 --
 -- Throws @NOT_FOUND@ if none of the intersection points are on the chain.
 -- Runs until the client disconnects or the stream is otherwise closed;
@@ -183,46 +236,125 @@ followTipStream
   -- ^ Read the current chain tip, projected into a @BlockRef@
   -> (SlotNo -> m UTCTime)
   -- ^ Convert a slot to its wall-clock timestamp
+  -> (ChainPoint -> m (Maybe (ByteString, BlockInMode)))
+  -- ^ Re-fetch a block by point, to reconstruct @undo@ payloads on
+  -- rollback. 'Nothing' means the block is no longer available (e.g. the
+  -- VolatileDB has garbage-collected it past the immutable tip); the loop
+  -- falls back to @reset@ in that case.
+  -> Int
+  -- ^ How many applied points to track for undo re-fetch. In production
+  -- this is the node's security parameter /k/
+  -- ('Cardano.Rpc.Server.NodeKernelAccess.Type.securityParam'). Consensus
+  -- never rolls back more than /k/ blocks, so tracking /k/ points covers
+  -- every rollback the protocol can produce, on any network. An entry
+  -- costs roughly 40 bytes, so the window costs about @40 * k@ bytes per
+  -- stream: around 86 KB on mainnet, where /k/ = 2160. A rollback deeper
+  -- than the cap degrades to @reset@.
   -> (NextElem (Proto U5c.FollowTipResponse) -> IO ())
   -- ^ Callback used to send each streamed response
   -> [ChainPoint]
   -- ^ Resolved, non-empty intersection points, in client preference order
   -> m ()
-followTipStream ChainFollower{nextChange, findIntersect} readTip slotTimestamp send startPoints =
+followTipStream ChainFollower{nextChange, findIntersect} readTip slotTimestamp fetchBlockByPoint trackingCap send startPoints =
   -- freezes the caller's call stack (e.g. 'followTipMethod's) so the
-  -- @NOT_FOUND@ thrown below - and any exception raised by the collaborator
-  -- actions threaded through the loop - points back to the real call site
-  -- rather than somewhere inside this loop; makes the 'HasCallStack'
-  -- constraint above load-bearing instead of merely a caller restriction
+  -- @NOT_FOUND@ thrown below, and any exception raised by the collaborator
+  -- actions threaded through the loop, points at the real call site rather
+  -- than somewhere inside this loop. This is what the 'HasCallStack'
+  -- constraint above is for.
   withFrozenCallStack $ do
     resolvedIntersection <- findIntersect startPoints
-    case resolvedIntersection of
+    startPoint <- case resolvedIntersection of
       Nothing ->
         throwGrpcErrorWithMessage GrpcNotFound $
           "no intersection found: none of the "
             <> tshow (length startPoints)
             <> " intersect points are on the chain"
-      Just _ ->
-        -- after a successful 'findIntersect' the follower's next instruction
-        -- is a 'RollBack' to the intersection - the loop reports it as the
-        -- initial 'reset' announcing where the stream starts
-        go
+      Just point -> pure point
+    -- after a successful 'findIntersect' the follower's next instruction is
+    -- a 'RollBack' to the intersection - the loop reports it as the initial
+    -- 'reset' announcing where the stream starts (the "nothing tracked yet"
+    -- branch of 'handleRollback' below, since the intersection is also the
+    -- initial window floor and nothing has been applied yet)
+    go startPoint Seq.empty
  where
   sendMessage action = do
     tip <- readTip
     liftIO . send . NextElem $ action & U5c.maybe'tip .~ tip
 
-  go :: m ()
-  go = do
+  go :: ChainPoint -> TrackedPoints -> m ()
+  go floorPoint tracked = do
     change <- nextChange
-    case change of
+    (floorPoint', tracked') <- case change of
       ChainApply (rawBytes, blockInMode@(BlockInMode _ block)) -> do
-        let BlockHeader slot _ _ = getBlockHeader block
+        let BlockHeader slot headerHash _ = getBlockHeader block
         timestamp <- slotTimestamp slot
         sendMessage $ defMessage & U5c.apply .~ mkAnyChainBlock rawBytes blockInMode timestamp
-      ChainRollBack point ->
+        pure (floorPoint, trackApplied trackingCap (slot, headerHash) tracked)
+      ChainRollBack point -> handleRollback point floorPoint tracked
+    go floorPoint' tracked'
+
+  -- \| Dispatch a rollback to undo or reset. The window floor starts as
+  -- the stream's start point and only ever moves forward, to a rollback
+  -- target that fell outside the window (the 'Nothing' case below). A
+  -- later rollback landing on the new floor can then be served as undo
+  -- instead of degrading to reset a second time.
+  handleRollback :: ChainPoint -> ChainPoint -> TrackedPoints -> m (ChainPoint, TrackedPoints)
+  handleRollback point floorPoint tracked =
+    case windowSplit point floorPoint tracked of
+      Nothing -> do
+        -- deeper than the cap, below the stream's start, or the initial
+        -- rollback-to-intersection with nothing tracked yet: today's
+        -- unchanged fallback, which also preserves the first-message-reset
+        -- invariant. The target becomes the new floor.
         sendMessage $ defMessage & U5c.reset .~ chainPointToBlockRef point
-    go
+        pure (point, Seq.empty)
+      Just (undone, kept)
+        | Seq.null undone ->
+            -- nothing newer than the target is tracked (the stream-opening
+            -- rollback, or a rollback that is a no-op against the current
+            -- position): reset communicates the position, with nothing to
+            -- undo
+            sendMessage (defMessage & U5c.reset .~ chainPointToBlockRef point)
+              $> (floorPoint, kept)
+        | otherwise -> do
+            kept' <- undoNewestFirst point kept undone
+            pure (floorPoint, kept')
+
+  -- \| Split the tracked points at the rollback target. 'Nothing' means
+  -- the target is outside the window: not the floor and not a tracked
+  -- point. Otherwise the first half is the points strictly newer than the
+  -- target, to be undone newest first, and the second half is what
+  -- survives: the target's own entry, if it is tracked, and everything
+  -- older.
+  windowSplit :: ChainPoint -> ChainPoint -> TrackedPoints -> Maybe (TrackedPoints, TrackedPoints)
+  windowSplit point floorPoint tracked = case point of
+    ChainPoint slot headerHash
+      | Just i <- Seq.findIndexL (== (slot, headerHash)) tracked ->
+          Just (Seq.take i tracked, Seq.drop i tracked)
+    _
+      | point == floorPoint -> Just (tracked, Seq.empty)
+      | otherwise -> Nothing
+
+  -- \| Re-fetch and emit @undo@ for each pending point, newest first.
+  -- Stops at the first fetch miss (garbage collection won the race) and
+  -- sends a single absolute @reset@ at the rollback point instead.
+  undoNewestFirst :: ChainPoint -> TrackedPoints -> TrackedPoints -> m TrackedPoints
+  undoNewestFirst point kept = loop
+   where
+    loop pending = case Seq.viewl pending of
+      Seq.EmptyL -> pure kept
+      (slot, headerHash) Seq.:< rest -> do
+        fetched <- fetchBlockByPoint (ChainPoint slot headerHash)
+        case fetched of
+          Just (rawBytes, blockInMode) -> do
+            timestamp <- slotTimestamp slot
+            sendMessage $ defMessage & U5c.undo .~ mkAnyChainBlock rawBytes blockInMode timestamp
+            loop rest
+          Nothing ->
+            sendMessage (defMessage & U5c.reset .~ chainPointToBlockRef point) $> kept
+
+  trackApplied :: Int -> (SlotNo, Hash BlockHeader) -> TrackedPoints -> TrackedPoints
+  trackApplied cap entry tracked = Seq.take cap (entry Seq.<| tracked)
 
 -- | Read the current chain tip and project it into a @BlockRef@ via
 -- 'mkTipBlockRef', or 'Nothing' at origin.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
@@ -2,12 +2,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- | Handlers for the UTxO RPC @SyncService@ - synchronising chain data
 -- (fetching blocks, dumping history, following the tip).
 module Cardano.Rpc.Server.Internal.UtxoRpc.Sync
   ( fetchBlockMethod
+  , followTipMethod
+  , followTipStream
   , readTipMethod
   )
 where
@@ -18,17 +21,25 @@ import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as U5c
 import Cardano.Rpc.Server.Internal.Error
 import Cardano.Rpc.Server.Internal.Monad
 import Cardano.Rpc.Server.Internal.Tracing ()
-import Cardano.Rpc.Server.Internal.UtxoRpc.Type (anyEraTxConstraints, txToUtxoRpcTx)
-import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Byron (byronBlockTxs)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Block (mkAnyChainBlock)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint
+  ( chainPointToBlockRef
+  , mkTipBlockRef
+  , tipHeaderPoint
+  )
 import Cardano.Rpc.Server.NodeKernelAccess
 
 import RIO
 
 import Data.ByteString qualified as BS
-import Data.ByteString.Short qualified as SBS
 import Data.ProtoLens (defMessage)
-import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
-import Network.GRPC.Spec (GrpcError (GrpcInternal, GrpcInvalidArgument, GrpcNotFound), Proto)
+import Data.Time.Clock (UTCTime)
+import GHC.Stack (withFrozenCallStack)
+import Network.GRPC.Spec
+  ( GrpcError (GrpcInternal, GrpcInvalidArgument, GrpcNotFound)
+  , NextElem (NextElem)
+  , Proto
+  )
 
 -- | Handle the @FetchBlock@ SyncService RPC method.
 -- Fetches a block from ChainDB by slot and header hash.
@@ -44,53 +55,14 @@ fetchBlockMethod
   -- ^ Response containing the fetched block with raw CBOR and cardano header
 fetchBlockMethod request = do
   nodeKernelAccess@NodeKernelAccess{systemStart, readEraHistory} <- grabNodeKernelAccess
-  let blockRef = request ^. U5c.ref
-      slot = SlotNo $ blockRef ^. U5c.slot
-      hashBytes = blockRef ^. U5c.hash
-      throwInvalidHash =
-        throwGrpcErrorWithMessage GrpcInvalidArgument $
-          "invalid block header hash (" <> tshow (BS.length hashBytes) <> " bytes)"
-      throwNotFound =
+  (slot, headerHash) <- blockRefToPoint (request ^. U5c.ref)
+  let throwNotFound =
         throwGrpcErrorWithMessage GrpcNotFound $
           "block not found at slot " <> tshow (unSlotNo slot)
-      throwPastHorizon =
-        throwGrpcErrorWithMessage GrpcInternal $
-          "cannot convert slot "
-            <> tshow (unSlotNo slot)
-            <> " to timestamp: the slot is past the era history horizon;"
-            <> " check that the requested slot is correct and that the node is fully in sync"
-  headerHash <-
-    deserialiseFromRawBytes (proxyToAsType (Proxy @(Hash BlockHeader))) hashBytes
-      & either (const throwInvalidHash) pure
-  (rawBytes, BlockInMode _ block) <-
+  (rawBytes, blockInMode) <-
     fetchBlock nodeKernelAccess slot headerHash >>= maybe throwNotFound pure
-  eraHistory <- readEraHistory
-  timestampMs <-
-    slotToUTCTime systemStart eraHistory slot
-      & either (const throwPastHorizon) (pure . round . (* 1000) . utcTimeToPOSIXSeconds)
-  let BlockHeader _ _ (BlockNo height) = getBlockHeader block
-      -- Byron transactions are not representable as cardano-api's 'Tx era',
-      -- so they are converted straight from the Byron ledger types
-      txs = case block of
-        ByronBlock consensusBlock ->
-          byronBlockTxs (byronBlockRaw consensusBlock)
-        ShelleyBlock sbe _ ->
-          anyEraTxConstraints sbe $
-            getBlockTxs block <&> \(ShelleyTx _ ledgerTx) -> txToUtxoRpcTx ledgerTx
-      blockHeader =
-        defMessage
-          & U5c.slot .~ unSlotNo slot
-          & U5c.hash .~ hashBytes
-          & U5c.height .~ height
-  pure $
-    defMessage
-      & U5c.block
-        .~ ( defMessage
-               & U5c.nativeBytes .~ rawBytes
-               & U5c.cardano . U5c.header .~ blockHeader
-               & U5c.cardano . U5c.body . U5c.tx .~ txs
-               & U5c.cardano . U5c.timestamp .~ timestampMs
-           )
+  timestamp <- slotTimestampOrThrow systemStart readEraHistory slot
+  pure $ defMessage & U5c.block .~ mkAnyChainBlock rawBytes blockInMode timestamp
 
 -- | Handle the @ReadTip@ SyncService RPC method.
 -- Reads the current chain tip from ChainDB and returns it as slot, block
@@ -102,24 +74,186 @@ readTipMethod
   -> m (Proto U5c.ReadTipResponse)
 readTipMethod _request = do
   NodeKernelAccess{chainDb, systemStart, readEraHistory} <- grabNodeKernelAccess
-  tipHeader <- liftIO $ Consensus.getTipHeader chainDb
-  tip <- forM tipHeader $ \header -> do
-    let slot = Consensus.blockSlot header
-        Consensus.OneEraHash tipHash = Consensus.blockHash header
-        BlockNo height = Consensus.blockNo header
-        throwPastHorizon =
-          throwGrpcErrorWithMessage GrpcInternal $
-            "cannot convert tip slot "
-              <> tshow (unSlotNo slot)
-              <> " to timestamp: the slot is past the era history horizon"
-    eraHistory <- readEraHistory
-    timestampMs <-
-      slotToUTCTime systemStart eraHistory slot
-        & either (const throwPastHorizon) (pure . round . (* 1000) . utcTimeToPOSIXSeconds)
-    pure $
-      defMessage
-        & U5c.slot .~ unSlotNo slot
-        & U5c.hash .~ SBS.fromShort tipHash
-        & U5c.height .~ height
-        & U5c.timestamp .~ timestampMs
+  tip <- readTipBlockRef chainDb (slotTimestampOrThrow systemStart readEraHistory)
   pure $ defMessage & U5c.maybe'tip .~ tip
+
+-- | Handle the @FollowTip@ SyncService RPC method.
+-- Streams fully parsed blocks as the chain advances, starting from the
+-- first of the request's intersection points found on the chain (client
+-- preference order). An intersection block ref with an empty hash denotes
+-- origin; when the intersect list is empty, the stream follows from the
+-- current tip.
+-- The first streamed message is always a @reset@ announcing where the
+-- stream starts. Later rollbacks are delivered the same way, as @reset@
+-- actions carrying the rollback point's @BlockRef@ (slot and hash only),
+-- equivalent to ChainSync's @MsgRollBackward@.
+-- Every response also carries the current chain tip.
+-- Returns @INVALID_ARGUMENT@ if an intersection block reference has an
+-- invalid hash and @NOT_FOUND@ if none of the intersection points are on
+-- the chain.
+-- Runs until the client disconnects or the stream is otherwise closed; the
+-- follower is closed on every exit path by 'withFollower'.
+followTipMethod
+  :: MonadRpc e m
+  => Proto U5c.FollowTipRequest
+  -- ^ Request containing optional intersection points (slot + hash)
+  -> (NextElem (Proto U5c.FollowTipResponse) -> IO ())
+  -- ^ Callback used to send each streamed response
+  -> m ()
+followTipMethod request send = do
+  nodeKernelAccess@NodeKernelAccess{chainDb, systemStart, readEraHistory} <-
+    grabNodeKernelAccess
+  requestedPoints <- traverse blockRefToIntersectPoint (request ^. U5c.intersect)
+  withFollower nodeKernelAccess $ \follower -> do
+    -- an empty intersect list follows from the current tip; resolving it
+    -- reaches into ChainDB directly (there is no 'ChainFollower' operation
+    -- for "the current tip point"), so this step stays here rather than
+    -- moving into 'followTipStream', which only takes an already-resolved,
+    -- non-empty point list
+    let slotTimestamp = slotTimestampOrThrow systemStart readEraHistory
+    startPoints <-
+      if null requestedPoints
+        then do
+          tipHeader <- liftIO $ Consensus.getTipHeader chainDb
+          pure [maybe ChainPointAtGenesis tipHeaderPoint tipHeader]
+        else pure requestedPoints
+    followTipStream
+      follower
+      (readTipBlockRef chainDb slotTimestamp)
+      slotTimestamp
+      send
+      startPoints
+
+-- | Convert an intersection @BlockRef@ to a 'ChainPoint'. A block ref with
+-- an empty hash denotes origin, so clients can append it to the intersect
+-- list as a catch-all: origin is on every chain, which makes the
+-- intersection infallible.
+-- Throws @INVALID_ARGUMENT@ if a non-empty hash is malformed.
+blockRefToIntersectPoint
+  :: MonadRpc e m
+  => Proto U5c.BlockRef
+  -> m ChainPoint
+blockRefToIntersectPoint blockRef
+  | BS.null (blockRef ^. U5c.hash) = pure ChainPointAtGenesis
+  | otherwise = uncurry ChainPoint <$> blockRefToPoint blockRef
+
+-- | Convert a @BlockRef@ into its slot and deserialised block header hash.
+-- Throws @INVALID_ARGUMENT@ if the hash is malformed.
+blockRefToPoint
+  :: MonadRpc e m
+  => Proto U5c.BlockRef
+  -> m (SlotNo, Hash BlockHeader)
+blockRefToPoint blockRef = do
+  let slot = SlotNo $ blockRef ^. U5c.slot
+      hashBytes = blockRef ^. U5c.hash
+      throwInvalidHash =
+        throwGrpcErrorWithMessage GrpcInvalidArgument $
+          "invalid block header hash (" <> tshow (BS.length hashBytes) <> " bytes)"
+  headerHash <-
+    deserialiseFromRawBytes (proxyToAsType (Proxy @(Hash BlockHeader))) hashBytes
+      & either (const throwInvalidHash) pure
+  pure (slot, headerHash)
+
+-- | The @FollowTip@ streaming loop: given a positioned follower and a
+-- resolved, non-empty list of intersection points, finds the intersection
+-- and streams chain changes as they arrive.
+--
+-- Takes its collaborators as plain arguments instead of a 'NodeKernelAccess',
+-- so it can be driven by a scripted follower and stub capabilities in tests
+-- with no live ChainDB required (see @Test.Cardano.Rpc.FollowTipStream@, the
+-- first unit coverage of this loop). Only 'MonadIO' is needed: neither the
+-- follower actions, the tip/timestamp readers, nor the gRPC error path
+-- ('throwGrpcErrorWithMessage') require anything stronger.
+--
+-- Rollbacks are delivered as @reset@ actions carrying the rollback point's
+-- @BlockRef@ (slot and hash only), equivalent to ChainSync's
+-- @MsgRollBackward@. Every emitted message, reset or apply, carries the
+-- current tip.
+--
+-- Throws @NOT_FOUND@ if none of the intersection points are on the chain.
+-- Runs until the client disconnects or the stream is otherwise closed;
+-- follower cleanup is the caller's responsibility (see 'withFollower').
+followTipStream
+  :: forall m
+   . HasCallStack
+  => MonadIO m
+  => ChainFollower
+  -- ^ Follower to stream changes from
+  -> m (Maybe (Proto U5c.BlockRef))
+  -- ^ Read the current chain tip, projected into a @BlockRef@
+  -> (SlotNo -> m UTCTime)
+  -- ^ Convert a slot to its wall-clock timestamp
+  -> (NextElem (Proto U5c.FollowTipResponse) -> IO ())
+  -- ^ Callback used to send each streamed response
+  -> [ChainPoint]
+  -- ^ Resolved, non-empty intersection points, in client preference order
+  -> m ()
+followTipStream ChainFollower{nextChange, findIntersect} readTip slotTimestamp send startPoints =
+  -- freezes the caller's call stack (e.g. 'followTipMethod's) so the
+  -- @NOT_FOUND@ thrown below - and any exception raised by the collaborator
+  -- actions threaded through the loop - points back to the real call site
+  -- rather than somewhere inside this loop; makes the 'HasCallStack'
+  -- constraint above load-bearing instead of merely a caller restriction
+  withFrozenCallStack $ do
+    resolvedIntersection <- findIntersect startPoints
+    case resolvedIntersection of
+      Nothing ->
+        throwGrpcErrorWithMessage GrpcNotFound $
+          "no intersection found: none of the "
+            <> tshow (length startPoints)
+            <> " intersect points are on the chain"
+      Just _ ->
+        -- after a successful 'findIntersect' the follower's next instruction
+        -- is a 'RollBack' to the intersection - the loop reports it as the
+        -- initial 'reset' announcing where the stream starts
+        go
+ where
+  sendMessage action = do
+    tip <- readTip
+    liftIO . send . NextElem $ action & U5c.maybe'tip .~ tip
+
+  go :: m ()
+  go = do
+    change <- nextChange
+    case change of
+      ChainApply (rawBytes, blockInMode@(BlockInMode _ block)) -> do
+        let BlockHeader slot _ _ = getBlockHeader block
+        timestamp <- slotTimestamp slot
+        sendMessage $ defMessage & U5c.apply .~ mkAnyChainBlock rawBytes blockInMode timestamp
+      ChainRollBack point ->
+        sendMessage $ defMessage & U5c.reset .~ chainPointToBlockRef point
+    go
+
+-- | Read the current chain tip and project it into a @BlockRef@ via
+-- 'mkTipBlockRef', or 'Nothing' at origin.
+readTipBlockRef
+  :: MonadIO m
+  => Consensus.ChainDB IO (Consensus.CardanoBlock Consensus.StandardCrypto)
+  -> (SlotNo -> m UTCTime)
+  -- ^ Convert a slot to its wall-clock timestamp
+  -> m (Maybe (Proto U5c.BlockRef))
+readTipBlockRef chainDb slotTimestamp = do
+  tipHeader <- liftIO $ Consensus.getTipHeader chainDb
+  forM tipHeader $ \header ->
+    mkTipBlockRef header <$> slotTimestamp (Consensus.blockSlot header)
+
+-- | Convert a slot to its wall-clock timestamp.
+-- Throws @INTERNAL@ when the slot is past the era history horizon.
+slotTimestampOrThrow
+  :: MonadIO m
+  => SystemStart
+  -> m EraHistory
+  -- ^ Read current era history from the ledger state
+  -> SlotNo
+  -> m UTCTime
+slotTimestampOrThrow systemStart readEraHistory slot = do
+  eraHistory <- readEraHistory
+  slotToUTCTime systemStart eraHistory slot
+    & either (const throwPastHorizon) pure
+ where
+  throwPastHorizon =
+    throwGrpcErrorWithMessage GrpcInternal $
+      "cannot convert slot "
+        <> tshow (unSlotNo slot)
+        <> " to timestamp: the slot is past the era history horizon;"
+        <> " check that the requested slot is correct and that the node is fully in sync"

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Block.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Block.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE GADTs #-}
+
+-- | Conversion of a fetched or streamed chain block to the UTxO RPC
+-- @AnyChainBlock@ message.
+module Cardano.Rpc.Server.Internal.UtxoRpc.Type.Block
+  ( mkAnyChainBlock
+  )
+where
+
+import Cardano.Api.Block
+import Cardano.Api.Consensus (byronBlockRaw)
+import Cardano.Api.Serialise.Raw
+import Cardano.Api.Tx
+import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as U5c
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Byron (byronBlockTxs)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint (utcTimeToMs)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Tx (anyEraTxConstraints, txToUtxoRpcTx)
+
+import RIO
+
+import Data.ProtoLens (defMessage)
+import Data.Time.Clock (UTCTime)
+import Network.GRPC.Spec
+
+-- | Assemble the @AnyChainBlock@ proto message: raw CBOR bytes, the cardano
+-- header (slot, hash, height - derived from the block itself) and the parsed
+-- transactions (all eras), plus the given slot timestamp.
+mkAnyChainBlock
+  :: ByteString
+  -- ^ Raw CBOR bytes of the block, exactly as stored on chain
+  -> BlockInMode
+  -- ^ The same block, parsed and placed in its era context
+  -> UTCTime
+  -- ^ Slot wall-clock time; encoded as milliseconds since the Unix epoch
+  -> Proto U5c.AnyChainBlock
+  -- ^ Message carrying the native bytes, the parsed cardano block and the timestamp
+mkAnyChainBlock rawBytes (BlockInMode _ block) timestamp =
+  let BlockHeader slot headerHash (BlockNo height) = getBlockHeader block
+      -- Byron transactions are not representable as cardano-api's 'Tx era',
+      -- so they are converted straight from the Byron ledger types
+      txs = case block of
+        ByronBlock consensusBlock ->
+          byronBlockTxs (byronBlockRaw consensusBlock)
+        ShelleyBlock sbe _ ->
+          anyEraTxConstraints sbe $
+            getBlockTxs block <&> \(ShelleyTx _ ledgerTx) -> txToUtxoRpcTx ledgerTx
+      blockHeader =
+        defMessage
+          & U5c.slot .~ unSlotNo slot
+          & U5c.hash .~ serialiseToRawBytes headerHash
+          & U5c.height .~ height
+   in defMessage
+        & U5c.nativeBytes .~ rawBytes
+        & U5c.cardano . U5c.header .~ blockHeader
+        & U5c.cardano . U5c.body . U5c.tx .~ txs
+        & U5c.cardano . U5c.timestamp .~ utcTimeToMs timestamp

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/ChainPoint.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/ChainPoint.hs
@@ -3,15 +3,21 @@
 module Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint
   ( mkChainPointMsg
   , utxoRpcChainPointMsgToChainPoint
+  , mkTipBlockRef
+  , chainPointToBlockRef
+  , tipHeaderPoint
+  , utcTimeToMs
   )
 where
 
 import Cardano.Api.Block
+import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Api.Error
 import Cardano.Api.Hash
 import Cardano.Api.Serialise.Raw
 import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as U5c
 import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as UtxoRpc
+import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as Sync
 
 import Cardano.Ledger.BaseTypes (WithOrigin (..))
 
@@ -35,12 +41,11 @@ mkChainPointMsg chainPoint blockNo timestamp = do
       blockHeight = case blockNo of
         Origin -> 0
         At (BlockNo h) -> h
-      timestampMs = round . (* 1000) . utcTimeToPOSIXSeconds $ timestamp
   defMessage
     & U5c.slot .~ slotNo
     & U5c.hash .~ blockHash
     & U5c.height .~ blockHeight
-    & U5c.timestamp .~ timestampMs
+    & U5c.timestamp .~ utcTimeToMs timestamp
 
 -- | Inverse of 'mkChainPointMsg'. Note: @Origin@ and @At (BlockNo 0)@ both
 -- encode to @height=0@, so the decode always maps @0@ back to @Origin@.
@@ -64,3 +69,41 @@ utxoRpcChainPointMsgToChainPoint msg = do
         | blockHeight == 0 = Origin
         | otherwise = At (BlockNo blockHeight)
   pure (chainPoint, blockNo, timestamp)
+
+-- | Milliseconds since the Unix epoch, the timestamp encoding UTxO RPC uses.
+utcTimeToMs :: UTCTime -> Word64
+utcTimeToMs = round . (* 1000) . utcTimeToPOSIXSeconds
+
+-- | Project a ChainDB header and a slot timestamp into a @BlockRef@: slot,
+-- header hash, block height and timestamp.
+mkTipBlockRef
+  :: Consensus.Header (Consensus.CardanoBlock Consensus.StandardCrypto)
+  -> UTCTime
+  -- ^ Slot wall-clock time; encoded as milliseconds since the Unix epoch
+  -> Proto Sync.BlockRef
+mkTipBlockRef header timestamp =
+  let slot = Consensus.blockSlot header
+      Consensus.OneEraHash tipHash = Consensus.blockHash header
+      BlockNo height = Consensus.blockNo header
+   in defMessage
+        & Sync.slot .~ unSlotNo slot
+        & Sync.hash .~ SBS.fromShort tipHash
+        & Sync.height .~ height
+        & Sync.timestamp .~ utcTimeToMs timestamp
+
+-- | The 'ChainPoint' of a ChainDB tip header.
+tipHeaderPoint :: Consensus.Header (Consensus.CardanoBlock Consensus.StandardCrypto) -> ChainPoint
+tipHeaderPoint header =
+  let Consensus.OneEraHash tipHash = Consensus.blockHash header
+   in ChainPoint (Consensus.blockSlot header) (HeaderHash tipHash)
+
+-- | Project a 'ChainPoint' into a @BlockRef@ with slot and hash only - a
+-- rollback reference has no height or timestamp, so those are left at
+-- their proto defaults. 'ChainPointAtGenesis' becomes the default message
+-- (origin).
+chainPointToBlockRef :: ChainPoint -> Proto Sync.BlockRef
+chainPointToBlockRef ChainPointAtGenesis = defMessage
+chainPointToBlockRef (ChainPoint slot headerHash) =
+  defMessage
+    & Sync.slot .~ unSlotNo slot
+    & Sync.hash .~ serialiseToRawBytes headerHash

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
@@ -2,12 +2,17 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE NoFieldSelectors #-}
 
 module Cardano.Rpc.Server.NodeKernelAccess
   ( NodeKernelAccess (..)
   , mkNodeKernelAccess
   , fetchBlock
   , grabNodeKernelAccess
+  , ChainChange (..)
+  , ChainFollower (..)
+  , withFollower
   )
 where
 
@@ -16,7 +21,7 @@ import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Rpc.Server.Internal.Monad (MonadRpc, grab)
 import Cardano.Rpc.Server.NodeKernelAccess.Type
 
-import RIO (atomically, throwIO)
+import RIO (MonadUnliftIO, atomically, bracket, throwIO, withRunInIO)
 
 import Control.Tracer (Tracer, traceWith)
 import Data.ByteString (ByteString)
@@ -34,17 +39,19 @@ mkNodeKernelAccess
   -> Consensus.BlockType blk
   -- ^ Block type witness
   -> Consensus.TopLevelConfig blk
-  -- ^ Top-level consensus config (for system start and era history)
+  -- ^ Top-level consensus config (for system start, era history and the
+  -- security parameter)
   -> Consensus.NodeKernel IO addrNTN addrNTC blk
   -- ^ Consensus node kernel
   -> m (Maybe NodeKernelAccess)
 mkNodeKernelAccess tracer blockType topLevelConfig kernel = case blockType of
   Consensus.CardanoBlockType ->
-    pure $ Just NodeKernelAccess{chainDb, systemStart, readEraHistory}
+    pure $ Just NodeKernelAccess{chainDb, systemStart, readEraHistory, securityParam}
    where
     chainDb = Consensus.getChainDB kernel
     ledgerConfig = Consensus.configLedger topLevelConfig
     systemStart = Consensus.nodeSystemStart topLevelConfig
+    securityParam = Consensus.configSecurityParam topLevelConfig
     -- Read the current ledger state (cheap STM TVar read) and recompute
     -- the era summary on every call - O(number_of_eras).
     -- This is the same approach consensus uses for GetInterpreter queries
@@ -94,3 +101,81 @@ fetchBlock NodeKernelAccess{chainDb} slot (HeaderHash shortHash) = do
   let point = Consensus.RealPoint slot (Consensus.OneEraHash shortHash)
       component = (,) <$> fmap BSL.toStrict Consensus.GetRawBlock <*> fmap fromConsensusBlock Consensus.GetBlock
   liftIO $ Consensus.getBlockComponent chainDb component point
+
+-- | A single instruction produced by a chain follower.
+--
+-- 'ChainApply' carries the raw CBOR block bytes together with the same block
+-- parsed into its era context - exactly the pair 'fetchBlock' returns.
+-- Consensus rollbacks are point-only: 'ChainRollBack' never carries the
+-- blocks being rolled back, only the point to roll back to.
+data ChainChange
+  = ChainApply (ByteString, BlockInMode)
+  | ChainRollBack ChainPoint
+
+-- | A handle to a running chain follower.
+data ChainFollower = ChainFollower
+  { nextChange :: forall m. MonadIO m => m ChainChange
+  -- ^ Block until the next chain update is available.
+  , findIntersect :: forall m. MonadIO m => [ChainPoint] -> m (Maybe ChainPoint)
+  -- ^ Move the follower to the first of the given points found on the
+  -- current chain, returning that point, or 'Nothing' if none of them are
+  -- on the chain.
+  }
+
+-- | Run an action with a 'ChainFollower' tracking the selected chain.
+--
+-- The follower and the resource registry backing it are closed on every
+-- exit path, including exceptions. The follower itself runs in 'IO',
+-- because the ChainDB handle is monomorphic, so the bracket runs there and
+-- the action is unlifted into it.
+--
+-- Creating a follower is cheap: a few in-memory STM operations, nothing
+-- proportional to chain length. The costs are steady-state instead. A
+-- caught-up follower receives an O(1) notification per adopted block. A
+-- follower catching up streams blocks from the ImmutableDB, paying a disk
+-- read and a deserialisation per block, with file handles owned by the
+-- registry. The node already runs one such follower per connected N2C
+-- ChainSync client, so one follower per stream scales the same way.
+withFollower
+  :: MonadUnliftIO m
+  => NodeKernelAccess
+  -> (ChainFollower -> m a)
+  -> m a
+withFollower NodeKernelAccess{chainDb} action =
+  withRunInIO $ \runInIO ->
+    Consensus.withRegistry $ \registry ->
+      bracket
+        (Consensus.newFollower chainDb registry Consensus.SelectedChain component)
+        Consensus.followerClose
+        (runInIO . action . toChainFollower)
+ where
+  component
+    :: Consensus.BlockComponent
+         (Consensus.CardanoBlock Consensus.StandardCrypto)
+         (ByteString, BlockInMode)
+  component =
+    (,) <$> fmap BSL.toStrict Consensus.GetRawBlock <*> fmap fromConsensusBlock Consensus.GetBlock
+
+  toChainFollower
+    :: Consensus.Follower
+         IO
+         (Consensus.CardanoBlock Consensus.StandardCrypto)
+         (ByteString, BlockInMode)
+    -> ChainFollower
+  toChainFollower follower =
+    ChainFollower
+      { nextChange = liftIO $ toChainChange <$> Consensus.followerInstructionBlocking follower
+      , findIntersect = \points ->
+          liftIO $
+            fmap fromConsensusPointHF
+              <$> Consensus.followerForward follower (map toConsensusPointHF points)
+      }
+
+  toChainChange
+    :: Consensus.ChainUpdate
+         (Consensus.CardanoBlock Consensus.StandardCrypto)
+         (ByteString, BlockInMode)
+    -> ChainChange
+  toChainChange = \case
+    Consensus.AddBlock rawBlock -> ChainApply rawBlock
+    Consensus.RollBack point -> ChainRollBack (fromConsensusPointHF point)

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Type.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Type.hs
@@ -25,4 +25,7 @@ data NodeKernelAccess = NodeKernelAccess
   -- always safe: the ledger state is at or ahead of any block in ChainDB,
   -- and era summaries only grow, so the returned history always covers the
   -- slot of any block fetched from ChainDB.
+  , securityParam :: Consensus.SecurityParam
+  -- ^ The protocol security parameter /k/: consensus never rolls back more
+  -- than /k/ blocks.
   }

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FollowTipStream.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FollowTipStream.hs
@@ -7,7 +7,7 @@
 -- extracted from 'Cardano.Rpc.Server.Internal.UtxoRpc.Sync.followTipMethod'.
 -- The loop takes its collaborators as plain arguments instead of closing over
 -- 'Cardano.Rpc.Server.NodeKernelAccess.NodeKernelAccess', so it can be
--- driven here with a scripted 'ChainFollower' and stub tip/timestamp
+-- driven here with a scripted 'ChainFollower' and stub tip/timestamp/fetch
 -- capabilities, without a live ChainDB.
 module Test.Cardano.Rpc.FollowTipStream where
 
@@ -52,7 +52,7 @@ hprop_follow_tip_stream_reset_then_applies_in_order = H.propertyOnce $ do
         ]
   sent <-
     expectScriptExhausted
-      =<< runFollowTipStream script (Just ChainPointAtGenesis) [ChainPointAtGenesis]
+      =<< runFollowTipStream script (Just ChainPointAtGenesis) fetchNever testUndoWindow [ChainPointAtGenesis]
 
   H.note_ "reset(origin), apply(b1), apply(b2), each carrying the stub tip, in order"
   let expectedReset =
@@ -82,7 +82,7 @@ hprop_follow_tip_stream_intersection_success_synthesises_no_extra_reset = H.prop
       script = [ChainRollBack intersectionPoint, ChainApply (rawBytes, blockInMode)]
   sent <-
     expectScriptExhausted
-      =<< runFollowTipStream script (Just intersectionPoint) [intersectionPoint]
+      =<< runFollowTipStream script (Just intersectionPoint) fetchNever testUndoWindow [intersectionPoint]
 
   H.note_ "Exactly the two scripted messages are emitted - no reset beyond the scripted rollback"
   length sent === 2
@@ -97,7 +97,7 @@ hprop_follow_tip_stream_intersection_success_synthesises_no_extra_reset = H.prop
 hprop_follow_tip_stream_not_found_before_any_send :: Property
 hprop_follow_tip_stream_not_found_before_any_send = H.propertyOnce $ do
   let unknownPoint = ChainPoint 100 (HeaderHash (SBS.replicate 32 0xAA))
-  (outcome, sent) <- runFollowTipStream [] Nothing [unknownPoint]
+  (outcome, sent) <- runFollowTipStream [] Nothing fetchNever testUndoWindow [unknownPoint]
 
   H.note_ "No message is sent before the intersection failure"
   sent === []
@@ -112,6 +112,179 @@ hprop_follow_tip_stream_not_found_before_any_send = H.propertyOnce $ do
       H.annotateShow outcome
       H.failure
 
+-- | A rollback whose target is a tracked applied point is delivered as a
+-- single @undo@ carrying the re-fetched block, not a @reset@:
+-- 'followTipStream' prefers undo delivery whenever the target is within the
+-- tracked window. The undo payload is built from the same
+-- @mkAnyChainBlock@ call as the original @apply@, so it is identical to it
+-- by construction - deterministic re-assembly from the same raw bytes and
+-- block.
+hprop_follow_tip_stream_rollback_within_window_undoes_via_refetch :: Property
+hprop_follow_tip_stream_rollback_within_window_undoes_via_refetch = H.propertyOnce $ do
+  block1@(rawBytes1, blockInMode1@(BlockInMode _ rawBlock1)) <- mainBlockInMode
+  block2@(rawBytes2, blockInMode2@(BlockInMode _ rawBlock2)) <- boundaryBlockInMode
+  let BlockHeader slot1 headerHash1 _ = getBlockHeader rawBlock1
+      BlockHeader slot2 headerHash2 _ = getBlockHeader rawBlock2
+      point1 = ChainPoint slot1 headerHash1
+      point2 = ChainPoint slot2 headerHash2
+      script =
+        [ ChainRollBack ChainPointAtGenesis
+        , ChainApply block1
+        , ChainApply block2
+        , ChainRollBack point1
+        ]
+      fetchBlockByPoint = fetchKnownBlocks [(point2, block2)]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream
+        script
+        (Just ChainPointAtGenesis)
+        fetchBlockByPoint
+        testUndoWindow
+        [ChainPointAtGenesis]
+
+  H.note_ "reset(origin), apply(b1), apply(b2), undo(b2) - b2 re-fetched successfully"
+  let block2Payload = mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+      expectedReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef ChainPointAtGenesis & U5c.tip .~ stubTip
+      expectedApply1 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedApply2 = defMessage & U5c.apply .~ block2Payload & U5c.tip .~ stubTip
+      expectedUndo2 = defMessage & U5c.undo .~ block2Payload & U5c.tip .~ stubTip
+  sent === (NextElem <$> [expectedReset, expectedApply1, expectedApply2, expectedUndo2])
+
+-- | If the block a rollback would undo can no longer be re-fetched (the
+-- VolatileDB has garbage-collected it - simulated here with 'fetchNever'),
+-- 'followTipStream' stops the undo sequence and falls back to a single
+-- @reset@ at the rollback point rather than emitting a partial or
+-- incorrect undo.
+hprop_follow_tip_stream_rollback_fetch_miss_falls_back_to_reset :: Property
+hprop_follow_tip_stream_rollback_fetch_miss_falls_back_to_reset = H.propertyOnce $ do
+  block1@(rawBytes1, blockInMode1@(BlockInMode _ rawBlock1)) <- mainBlockInMode
+  block2 <- boundaryBlockInMode
+  let BlockHeader slot1 headerHash1 _ = getBlockHeader rawBlock1
+      point1 = ChainPoint slot1 headerHash1
+      script =
+        [ ChainRollBack ChainPointAtGenesis
+        , ChainApply block1
+        , ChainApply block2
+        , ChainRollBack point1
+        ]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream script (Just ChainPointAtGenesis) fetchNever testUndoWindow [ChainPointAtGenesis]
+
+  H.note_
+    "reset(origin), apply(b1), apply(b2), reset(b1) - re-fetch missed, so undo falls back to reset"
+  let (rawBytes2, blockInMode2) = block2
+      expectedReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef ChainPointAtGenesis & U5c.tip .~ stubTip
+      expectedApply1 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedApply2 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedRollbackReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef point1 & U5c.tip .~ stubTip
+  sent === (NextElem <$> [expectedReset, expectedApply1, expectedApply2, expectedRollbackReset])
+
+-- | A rollback landing exactly on the stream's start point (the window
+-- floor) undoes everything currently tracked, newest first: with two
+-- applied blocks, that is @undo(b2)@ then @undo(b1)@, in that order,
+-- landing back at the start point.
+hprop_follow_tip_stream_rollback_to_start_undoes_all_newest_first :: Property
+hprop_follow_tip_stream_rollback_to_start_undoes_all_newest_first = H.propertyOnce $ do
+  block1@(rawBytes1, blockInMode1@(BlockInMode _ rawBlock1)) <- mainBlockInMode
+  block2@(rawBytes2, blockInMode2@(BlockInMode _ rawBlock2)) <- boundaryBlockInMode
+  let BlockHeader slot1 headerHash1 _ = getBlockHeader rawBlock1
+      BlockHeader slot2 headerHash2 _ = getBlockHeader rawBlock2
+      point1 = ChainPoint slot1 headerHash1
+      point2 = ChainPoint slot2 headerHash2
+      script =
+        [ ChainRollBack ChainPointAtGenesis
+        , ChainApply block1
+        , ChainApply block2
+        , ChainRollBack ChainPointAtGenesis
+        ]
+      fetchBlockByPoint = fetchKnownBlocks [(point1, block1), (point2, block2)]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream
+        script
+        (Just ChainPointAtGenesis)
+        fetchBlockByPoint
+        testUndoWindow
+        [ChainPointAtGenesis]
+
+  H.note_
+    "reset(origin), apply(b1), apply(b2), undo(b2), undo(b1) - newest first, back to the start point"
+  let expectedReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef ChainPointAtGenesis & U5c.tip .~ stubTip
+      expectedApply1 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedApply2 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedUndo2 =
+        defMessage
+          & U5c.undo .~ mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedUndo1 =
+        defMessage
+          & U5c.undo .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+  sent
+    === (NextElem <$> [expectedReset, expectedApply1, expectedApply2, expectedUndo2, expectedUndo1])
+
+-- | A rollback target that has fallen out of the tracking cap is treated as
+-- outside the window even when the block itself would still be
+-- re-fetchable: with @trackingCap = 1@, applying b1 then b2 evicts b1's
+-- tracked point before the rollback arrives, so the rollback degrades to a
+-- @reset@. The fetch stub below would succeed for b1's point if it were
+-- ever asked, proving the fallback here is driven by the cap, not a fetch
+-- miss (it is never called: 'followTipStream' recognises the target is
+-- outside the window before attempting any re-fetch).
+hprop_follow_tip_stream_rollback_beyond_cap_falls_back_to_reset :: Property
+hprop_follow_tip_stream_rollback_beyond_cap_falls_back_to_reset = H.propertyOnce $ do
+  block1@(rawBytes1, blockInMode1@(BlockInMode _ rawBlock1)) <- mainBlockInMode
+  block2 <- boundaryBlockInMode
+  let BlockHeader slot1 headerHash1 _ = getBlockHeader rawBlock1
+      point1 = ChainPoint slot1 headerHash1
+      script =
+        [ ChainRollBack ChainPointAtGenesis
+        , ChainApply block1
+        , ChainApply block2
+        , ChainRollBack point1
+        ]
+      fetchBlockByPoint = fetchKnownBlocks [(point1, block1)]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream script (Just ChainPointAtGenesis) fetchBlockByPoint 1 [ChainPointAtGenesis]
+
+  H.note_ "reset(origin), apply(b1), apply(b2), reset(b1) - b1's tracked point was evicted by the cap"
+  let (rawBytes2, blockInMode2) = block2
+      expectedReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef ChainPointAtGenesis & U5c.tip .~ stubTip
+      expectedApply1 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedApply2 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedRollbackReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef point1 & U5c.tip .~ stubTip
+  sent === (NextElem <$> [expectedReset, expectedApply1, expectedApply2, expectedRollbackReset])
+
 -- | Run 'followTipStream' against a 'scriptedFollower' and the stub tip and
 -- timestamp above, capturing every message sent until the run ends - either
 -- because the script was exhausted ('ScriptExhausted') or because
@@ -125,10 +298,15 @@ runFollowTipStream
   -- ^ Script 'scriptedFollower's @nextChange@ plays back
   -> Maybe ChainPoint
   -- ^ Fixed @findIntersect@ result
+  -> (ChainPoint -> IO (Maybe (ByteString, BlockInMode)))
+  -- ^ Block-by-point fetch stub for undo re-fetch, e.g. 'fetchNever' or
+  -- 'fetchKnownBlocks'
+  -> Int
+  -- ^ Tracking cap passed to 'followTipStream'
   -> [ChainPoint]
   -- ^ Start points passed to 'followTipStream'
   -> m (Either SomeException (), [NextElem (Proto U5c.FollowTipResponse)])
-runFollowTipStream script intersectResult startPoints = liftIO $ do
+runFollowTipStream script intersectResult fetchBlockByPoint trackingCap startPoints = liftIO $ do
   follower <- scriptedFollower script intersectResult
   sentRef <- newIORef []
   outcome <-
@@ -137,6 +315,8 @@ runFollowTipStream script intersectResult startPoints = liftIO $ do
         follower
         (pure (Just stubTip))
         (const (pure stubTimestamp))
+        fetchBlockByPoint
+        trackingCap
         (\nextElem -> modifyIORef' sentRef (nextElem :))
         startPoints
   sent <- reverse <$> readIORef sentRef
@@ -177,6 +357,27 @@ scriptedFollower script intersectResult = do
       , findIntersect = const $ pure intersectResult
       }
 
+-- | A block-by-point fetch stub that never finds anything - the simplest
+-- 'followTipStream' fetch parameter for scripts that either never roll back
+-- into the tracked window, or where the fetch-miss (@reset@ fallback) path
+-- is exactly what is under test.
+fetchNever :: MonadIO m => ChainPoint -> m (Maybe (ByteString, BlockInMode))
+fetchNever = const $ pure Nothing
+
+-- | A block-by-point fetch stub backed by a fixed association list of known
+-- blocks (keyed by their own 'ChainPoint'), used to simulate a successful
+-- ChainDB re-fetch for undo delivery. Looks up 'mempty' (i.e. 'Nothing') for
+-- any point not in the list.
+fetchKnownBlocks
+  :: MonadIO m
+  => [(ChainPoint, (ByteString, BlockInMode))]
+  -- ^ Known blocks table, mapping chain points to their raw bytes and parsed block wrappers
+  -> ChainPoint
+  -- ^ Chain point to fetch the block for
+  -> m (Maybe (ByteString, BlockInMode))
+  -- ^ Block data (raw bytes and parsed block) for the given point if found, 'Nothing' otherwise
+fetchKnownBlocks table point = pure $ lookup point table
+
 -- | A fixed stub tip, returned regardless of stream position: the properties
 -- below only assert that every message carries it, not on tip content.
 stubTip :: Proto U5c.BlockRef
@@ -185,6 +386,11 @@ stubTip = defMessage & U5c.slot .~ 999 & U5c.hash .~ SBS.fromShort (SBS.replicat
 -- | A fixed stub slot timestamp, returned regardless of the slot asked for.
 stubTimestamp :: UTCTime
 stubTimestamp = posixSecondsToUTCTime 1700000000
+
+-- | A tracking cap comfortably above the two-block scripts used below, for
+-- tests that are not themselves about cap-overflow behaviour.
+testUndoWindow :: Int
+testUndoWindow = 100
 
 -- | A genuine Byron 'BlockInMode' decoded from the mainnet main-block golden
 -- fixture also used by 'Test.Cardano.Rpc.ByronTx'. 'followTipStream'

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FollowTipStream.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/FollowTipStream.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Unit coverage for 'followTipStream', the @FollowTip@ streaming loop
+-- extracted from 'Cardano.Rpc.Server.Internal.UtxoRpc.Sync.followTipMethod'.
+-- The loop takes its collaborators as plain arguments instead of closing over
+-- 'Cardano.Rpc.Server.NodeKernelAccess.NodeKernelAccess', so it can be
+-- driven here with a scripted 'ChainFollower' and stub tip/timestamp
+-- capabilities, without a live ChainDB.
+module Test.Cardano.Rpc.FollowTipStream where
+
+import Cardano.Api
+import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as U5c
+import Cardano.Rpc.Server.Internal.UtxoRpc.Sync (followTipStream)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Block (mkAnyChainBlock)
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint (chainPointToBlockRef)
+import Cardano.Rpc.Server.NodeKernelAccess (ChainChange (..), ChainFollower (..))
+
+import Cardano.Chain.Epoch.File (mainnetEpochSlots)
+import Ouroboros.Consensus.Byron.Ledger (mkByronBlock)
+
+import RIO
+
+import Codec.Compression.GZip qualified as GZip
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString.Short qualified as SBS
+import Data.ProtoLens (defMessage)
+import Data.Time.Clock (UTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import GHC.Stack (withFrozenCallStack)
+import Network.GRPC.Spec (GrpcError (GrpcNotFound), GrpcException (..), NextElem (..), Proto)
+
+import Test.Cardano.Rpc.ByronTx (decodeBlockOrBoundaryFixture)
+
+import Hedgehog as H
+import Hedgehog.Extras qualified as H
+
+-- | The current 'followTipMethod' semantics: the stream opens with the
+-- follower's initial rollback reported as a @reset@, then streams 'ChainApply'
+-- changes as @apply@ messages in order, every message carrying the current
+-- tip as reported by the stub 'readTip'.
+hprop_follow_tip_stream_reset_then_applies_in_order :: Property
+hprop_follow_tip_stream_reset_then_applies_in_order = H.propertyOnce $ do
+  block1@(rawBytes1, blockInMode1) <- mainBlockInMode
+  block2@(rawBytes2, blockInMode2) <- boundaryBlockInMode
+  let script =
+        [ ChainRollBack ChainPointAtGenesis
+        , ChainApply block1
+        , ChainApply block2
+        ]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream script (Just ChainPointAtGenesis) [ChainPointAtGenesis]
+
+  H.note_ "reset(origin), apply(b1), apply(b2), each carrying the stub tip, in order"
+  let expectedReset =
+        defMessage & U5c.reset .~ chainPointToBlockRef ChainPointAtGenesis & U5c.tip .~ stubTip
+      expectedApply1 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes1 blockInMode1 stubTimestamp
+          & U5c.tip .~ stubTip
+      expectedApply2 =
+        defMessage
+          & U5c.apply .~ mkAnyChainBlock rawBytes2 blockInMode2 stubTimestamp
+          & U5c.tip .~ stubTip
+  sent === (NextElem <$> [expectedReset, expectedApply1, expectedApply2])
+
+-- | A successful intersection ('findIntersect' returning 'Just') does not
+-- cause 'followTipStream' to synthesise an extra @reset@ of its own: the
+-- only @reset@ the client sees is the follower's natural post-forward
+-- rollback to the intersection point, exactly as the current
+-- 'followTipMethod' documentation describes it. This mirrors current
+-- semantics exactly - the loop never inspects 'findIntersect's returned
+-- point, only whether it found one.
+hprop_follow_tip_stream_intersection_success_synthesises_no_extra_reset :: Property
+hprop_follow_tip_stream_intersection_success_synthesises_no_extra_reset = H.propertyOnce $ do
+  (rawBytes, blockInMode@(BlockInMode _ block)) <- mainBlockInMode
+  let BlockHeader slot headerHash _ = getBlockHeader block
+      intersectionPoint = ChainPoint slot headerHash
+      script = [ChainRollBack intersectionPoint, ChainApply (rawBytes, blockInMode)]
+  sent <-
+    expectScriptExhausted
+      =<< runFollowTipStream script (Just intersectionPoint) [intersectionPoint]
+
+  H.note_ "Exactly the two scripted messages are emitted - no reset beyond the scripted rollback"
+  length sent === 2
+  firstMessage <- H.nothingFail $ listToMaybe sent
+  firstMessage
+    === NextElem
+      (defMessage & U5c.reset .~ chainPointToBlockRef intersectionPoint & U5c.tip .~ stubTip)
+
+-- | When none of the intersection points are on the chain ('findIntersect'
+-- returning 'Nothing'), 'followTipStream' fails the stream with @NOT_FOUND@
+-- before sending any message.
+hprop_follow_tip_stream_not_found_before_any_send :: Property
+hprop_follow_tip_stream_not_found_before_any_send = H.propertyOnce $ do
+  let unknownPoint = ChainPoint 100 (HeaderHash (SBS.replicate 32 0xAA))
+  (outcome, sent) <- runFollowTipStream [] Nothing [unknownPoint]
+
+  H.note_ "No message is sent before the intersection failure"
+  sent === []
+
+  H.note_ "The stream fails with a NOT_FOUND GrpcException"
+  case outcome of
+    Left e
+      | Just GrpcException{grpcError} <- fromException e ->
+          grpcError === GrpcNotFound
+    _ -> do
+      H.note_ "Expected a NOT_FOUND GrpcException"
+      H.annotateShow outcome
+      H.failure
+
+-- | Run 'followTipStream' against a 'scriptedFollower' and the stub tip and
+-- timestamp above, capturing every message sent until the run ends - either
+-- because the script was exhausted ('ScriptExhausted') or because
+-- 'followTipStream' itself threw (e.g. the @NOT_FOUND@ 'GrpcException' from a
+-- failed intersection). Messages captured before an exception are returned
+-- alongside it, so callers can assert "nothing was sent before this error"
+-- as well as "these messages were sent, in this order".
+runFollowTipStream
+  :: MonadIO m
+  => [ChainChange]
+  -- ^ Script 'scriptedFollower's @nextChange@ plays back
+  -> Maybe ChainPoint
+  -- ^ Fixed @findIntersect@ result
+  -> [ChainPoint]
+  -- ^ Start points passed to 'followTipStream'
+  -> m (Either SomeException (), [NextElem (Proto U5c.FollowTipResponse)])
+runFollowTipStream script intersectResult startPoints = liftIO $ do
+  follower <- scriptedFollower script intersectResult
+  sentRef <- newIORef []
+  outcome <-
+    try @IO @SomeException $
+      followTipStream
+        follower
+        (pure (Just stubTip))
+        (const (pure stubTimestamp))
+        (\nextElem -> modifyIORef' sentRef (nextElem :))
+        startPoints
+  sent <- reverse <$> readIORef sentRef
+  pure (outcome, sent)
+
+-- | Assert that a 'runFollowTipStream' outcome ended because the script was
+-- exhausted - the expected, clean termination for a script that runs out
+-- rather than one that hit an error - and return the messages sent.
+expectScriptExhausted
+  :: HasCallStack
+  => MonadTest m
+  => (Either SomeException (), [NextElem (Proto U5c.FollowTipResponse)])
+  -> m [NextElem (Proto U5c.FollowTipResponse)]
+expectScriptExhausted (outcome, sent) = withFrozenCallStack $ do
+  case outcome of
+    Left e | Just ScriptExhausted <- fromException e -> pure ()
+    _ -> do
+      H.note_ "Expected the run to end with ScriptExhausted"
+      H.annotateShow outcome
+      H.failure
+  pure sent
+
+-- | A 'ChainFollower' whose @nextChange@ pops messages off the given script
+-- in order, held in a mutable ref, and whose @findIntersect@ always returns
+-- the given fixed result regardless of the points it is asked about - the
+-- properties below assert on the points passed to 'followTipStream' and on
+-- the streamed messages, not on what @findIntersect@ does with its argument.
+scriptedFollower :: MonadIO m => [ChainChange] -> Maybe ChainPoint -> m ChainFollower
+scriptedFollower script intersectResult = do
+  scriptRef <- liftIO $ newIORef script
+  pure
+    ChainFollower
+      { nextChange =
+          liftIO $
+            readIORef scriptRef >>= \case
+              [] -> throwIO ScriptExhausted
+              change : rest -> writeIORef scriptRef rest $> change
+      , findIntersect = const $ pure intersectResult
+      }
+
+-- | A fixed stub tip, returned regardless of stream position: the properties
+-- below only assert that every message carries it, not on tip content.
+stubTip :: Proto U5c.BlockRef
+stubTip = defMessage & U5c.slot .~ 999 & U5c.hash .~ SBS.fromShort (SBS.replicate 32 0x99)
+
+-- | A fixed stub slot timestamp, returned regardless of the slot asked for.
+stubTimestamp :: UTCTime
+stubTimestamp = posixSecondsToUTCTime 1700000000
+
+-- | A genuine Byron 'BlockInMode' decoded from the mainnet main-block golden
+-- fixture also used by 'Test.Cardano.Rpc.ByronTx'. 'followTipStream'
+-- assembles the full @AnyChainBlock@ via 'mkAnyChainBlock' for every
+-- 'ChainApply', so the scripted blocks must be real, valid blocks rather
+-- than placeholders; decoding an existing fixture through the same
+-- 'mkByronBlock' smart constructor the node's ChainDB uses is the cheapest
+-- way to get one, and reuses a fixture already checked in for this purpose.
+mainBlockInMode :: HasCallStack => MonadTest m => MonadIO m => m (ByteString, BlockInMode)
+mainBlockInMode = do
+  rawBytes <-
+    liftIO $ LBS.toStrict <$> LBS.readFile "test/cardano-rpc-test/files/golden/byron-main-block.cbor"
+  blockOrBoundary <- decodeBlockOrBoundaryFixture (LBS.fromStrict rawBytes)
+  pure (rawBytes, BlockInMode ByronEra (ByronBlock (mkByronBlock mainnetEpochSlots blockOrBoundary)))
+
+-- | A genuine Byron 'BlockInMode' decoded from the mainnet epoch-boundary
+-- golden fixture also used by 'Test.Cardano.Rpc.ByronTx'; see
+-- 'mainBlockInMode'. Distinct from it (a boundary block instead of a main
+-- block, at a different slot and hash), so a two-block script has two
+-- genuinely different blocks to distinguish, for free.
+boundaryBlockInMode :: HasCallStack => MonadTest m => MonadIO m => m (ByteString, BlockInMode)
+boundaryBlockInMode = do
+  compressedBytes <- liftIO $ LBS.readFile "test/cardano-rpc-test/files/golden/byron-ebb.cbor.gz"
+  let rawBytes = LBS.toStrict $ GZip.decompress compressedBytes
+  blockOrBoundary <- decodeBlockOrBoundaryFixture (LBS.fromStrict rawBytes)
+  pure (rawBytes, BlockInMode ByronEra (ByronBlock (mkByronBlock mainnetEpochSlots blockOrBoundary)))
+
+-- | Sentinel exception 'scriptedFollower's @nextChange@ throws once its
+-- script is exhausted. 'followTipStream' loops via 'forever' and never
+-- returns normally, so a distinctive exception is the simplest deterministic
+-- way to end a scripted run: 'runFollowTipStream' catches exactly this
+-- exception (and no other) to recognise "the script played out cleanly, with
+-- no unexpected error along the way".
+data ScriptExhausted = ScriptExhausted
+  deriving Show
+
+instance Exception ScriptExhausted


### PR DESCRIPTION
# Context

Implements the `SyncService.FollowTip` method (#1219), the primary blocker of the Kupo/Ogmios replacement effort (#1229). It is the gRPC analogue of the Ouroboros ChainSync mini-protocol, built on in-process ChainDB followers (ADR-019).

Stacked on #1259; review the commits after #1259's.

`FollowTip` streams fully parsed blocks as the chain advances, reusing the same block-to-proto conversion `FetchBlock` uses. The client's intersect list is honoured in preference order, and the first streamed message is always a reset announcing the resolved start point. An empty-hash block ref denotes origin, handled as an infallible catch-all rather than a special case. An empty intersect list follows from the current tip, matching Dolos's behaviour; an intersect list that matches nothing on the chain fails with `NOT_FOUND` before any message is sent. Every response carries the current tip alongside the action, for lag measurement.

Rollbacks are delivered as `undo` messages carrying the rolled-back blocks, newest first. Consensus's `RollBack` is point-only, it never carries block data, so each stream tracks the points of its last *k* applied blocks (the security parameter, about 86 KB per stream on mainnet) and re-fetches the undone blocks from the ChainDB on rollback. The stream falls back to a `reset` at the rollback point in the two cases where `undo` is impossible: the rollback target is outside the tracked window, or a re-fetch misses because the block was garbage-collected first.

## Implementation notes

- `NodeKernelAccess` gains `withFollower`, a bracket over `ChainDB.newFollower` that closes the follower and its resource registry on every exit path, including client disconnect, plus the `ChainFollower`/`ChainChange` types wrapping the raw follower API.
- `Cardano.Api.Consensus` gains the follower re-exports (`newFollower`, `Follower`, `ChainType`, `ChainUpdate`, `withRegistry`, `ResourceRegistry`).
- `FollowTip` is the first server-streaming handler in cardano-rpc, wired via grapesy's `mkServerStreaming`.
- A `TraceRpcFollowTipSpan` trace wraps the handler; the node-side rendering and the `rpc.request.SyncService.FollowTip` prometheus counter land in IntersectMBO/cardano-node#6579, the fetchblock-series node PR that already carries the earlier tracing and E2E work (there is no dedicated FollowTip node PR).
- The dead `TraceRpcForkerError` constructor is removed.

# How to trust this PR

The unit suite (83 tests) covers the conversion layer.

The E2E test in IntersectMBO/cardano-node#6579 exercises the streaming semantics live: full sync from origin, resuming from a point, an empty intersect list resolving from the current tip, and the `NOT_FOUND` path for an unmatched intersect list. It also adds a live-tail scenario, being added right now in the node working tree, that submits a transaction over gRPC and asserts it arrives via `FollowTip` as a parsed apply action.

Run it with:

```
cabal test cardano-rpc-test
TASTY_PATTERN='/RPC FollowTip/' cabal test cardano-testnet-test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

