### PR TITLE
cardano-wasm demo: UTxOs and balances via Blockfrost

### DIFF
--- a/.changes/20260718_cardano_wasm_demo_utxos.yml
+++ b/.changes/20260718_cardano_wasm_demo_utxos.yml
@@ -1,0 +1,9 @@
+project: cardano-wasm
+
+pr: 1276
+
+kind:
+  - feature
+
+description: |
+  Demo: UTxOs and balances via Blockfrost (per-network project id, token-UTxO flagging).

--- a/cardano-wasm/demo/src/Blockfrost.elm
+++ b/cardano-wasm/demo/src/Blockfrost.elm
@@ -1,0 +1,191 @@
+module Blockfrost exposing (fetchUtxos, isBlockfrostNotFound, pageSize, utxosDecoder)
+
+{-| The Blockfrost boundary (plain HTTP, CORS-friendly from a static page).
+Supplies UTxOs, authenticated with the per-network project id the user types
+into the UI. Deliberately independent of `State`, so state helpers can build
+on this module without an import cycle.
+-}
+
+import Format
+import Http
+import Json.Decode as D
+import Net exposing (blockfrostBase)
+import Types exposing (..)
+
+
+
+-- REQUESTS
+
+
+{-| One page of UTxOs, newest first. The result is stamped with the network it
+was requested on, so a response that survives a network switch can be dropped.
+-}
+fetchUtxos : String -> Network -> WalletId -> String -> Cmd Msg
+fetchUtxos key network wid addr =
+    request key
+        network
+        "GET"
+        ("/addresses/" ++ addr ++ "/utxos?order=desc&count=" ++ String.fromInt pageSize)
+        Http.emptyBody
+        (expectUtxos (GotUtxos wid network))
+
+
+{-| Blockfrost's maximum page size; a full page means more UTxOs may exist.
+-}
+pageSize : Int
+pageSize =
+    100
+
+
+request : String -> Network -> String -> String -> Http.Body -> Http.Expect Msg -> Cmd Msg
+request key network method path body expect =
+    Http.request
+        { method = method
+        , headers = [ Http.header "project_id" key ]
+        , url = blockfrostBase network ++ path
+        , body = body
+        , expect = expect
+
+        -- a stalled request must not wedge the wallet in Loading forever
+        , timeout = Just 30000
+        , tracker = Nothing
+        }
+
+
+
+-- RESPONSES
+
+
+{-| Route a string response: statuses go to `onStatus` (good AND bad — the code
+is in the metadata), transport failures become ready-made error strings.
+-}
+expectResponse : (Http.Metadata -> String -> Result String a) -> (Result String a -> Msg) -> Http.Expect Msg
+expectResponse onStatus toMsg =
+    Http.expectStringResponse toMsg <|
+        \response ->
+            case response of
+                Http.GoodStatus_ meta body ->
+                    onStatus meta body
+
+                Http.BadStatus_ meta body ->
+                    onStatus meta body
+
+                Http.NetworkError_ ->
+                    Err "network error"
+
+                Http.Timeout_ ->
+                    Err "timeout"
+
+                Http.BadUrl_ u ->
+                    Err ("bad url " ++ u)
+
+
+{-| Blockfrost answers 404 with its own error JSON for an address it has never
+seen — treat exactly that as "no UTxOs". Any other 404 (proxy error page,
+wrong path) stays an error instead of becoming a confident empty wallet.
+-}
+expectUtxos : (Result String UtxoPage -> Msg) -> Http.Expect Msg
+expectUtxos =
+    expectResponse
+        (\meta body ->
+            if meta.statusCode == 404 && isBlockfrostNotFound body then
+                Ok { utxos = [], truncated = False }
+
+            else if meta.statusCode >= 200 && meta.statusCode < 300 then
+                D.decodeString utxosDecoder body
+                    |> Result.map (\us -> { utxos = us, truncated = List.length us == pageSize })
+                    |> Result.mapError D.errorToString
+
+            else
+                Err (statusErrStr meta body)
+        )
+
+
+{-| Exposed for the test suite.
+-}
+isBlockfrostNotFound : String -> Bool
+isBlockfrostNotFound body =
+    D.decodeString (D.field "status_code" D.int) body == Ok 404
+
+
+{-| "HTTP 403 — Network token mismatch" beats a bare "HTTP 403": Blockfrost's
+error bodies distinguish an invalid project id from a right-id-wrong-network
+one, the two most likely first-run mistakes.
+-}
+statusErrStr : Http.Metadata -> String -> String
+statusErrStr meta body =
+    "HTTP "
+        ++ String.fromInt meta.statusCode
+        ++ (case D.decodeString (D.field "message" D.string) body of
+                Ok message ->
+                    " — " ++ message
+
+                Err _ ->
+                    ""
+           )
+
+
+
+-- DECODERS
+
+
+{-| Exposed for the test suite.
+-}
+utxosDecoder : D.Decoder (List Utxo)
+utxosDecoder =
+    D.list
+        (D.map3
+            (\h i units ->
+                { txId = h
+                , txIx = i
+                , lovelace = lovelaceIn units
+
+                -- any non-lovelace unit = native tokens (unusable in this ADA-only demo)
+                , hasAssets = List.any (\( u, _ ) -> u /= "lovelace") units
+                }
+            )
+            (D.field "tx_hash" D.string)
+            (D.field "output_index" D.int)
+            (D.field "amount" unitsDecoder)
+        )
+
+
+{-| Blockfrost's "amount" is a list of { unit, quantity } entries, quantities
+as strings. Only the lovelace quantities are parsed — and loudly: a malformed
+one fails the decode instead of counting as 0. Token quantities can exceed Int
+precision and are never used, so they are not parsed at all.
+-}
+unitsDecoder : D.Decoder (List ( String, Int ))
+unitsDecoder =
+    D.list
+        (D.field "unit" D.string
+            |> D.andThen
+                (\unit ->
+                    if unit == "lovelace" then
+                        D.field "quantity" lovelaceQuantityDecoder |> D.map (Tuple.pair unit)
+
+                    else
+                        D.succeed ( unit, 0 )
+                )
+        )
+
+
+{-| A lovelace quantity is a plain digit run; anything else is a decode failure.
+-}
+lovelaceQuantityDecoder : D.Decoder Int
+lovelaceQuantityDecoder =
+    D.string
+        |> D.andThen
+            (\s ->
+                case Format.digits s of
+                    Just n ->
+                        D.succeed n
+
+                    Nothing ->
+                        D.fail ("bad lovelace quantity: " ++ s)
+            )
+
+
+lovelaceIn : List ( String, Int ) -> Int
+lovelaceIn units =
+    units |> List.filter (\( u, _ ) -> u == "lovelace") |> List.map Tuple.second |> List.sum

--- a/cardano-wasm/demo/src/Format.elm
+++ b/cardano-wasm/demo/src/Format.elm
@@ -1,4 +1,4 @@
-module Format exposing (ada, adaToLovelace, amountError, lovelaceToAda, orDefault, shorten)
+module Format exposing (ada, adaToLovelace, amountError, digits, lovelaceToAda, orDefault, shorten)
 
 {-| String formatting and parsing: ada ↔ lovelace, abbreviation, small text helpers.
 -}
@@ -28,6 +28,7 @@ adaToLovelace s =
 
 
 {-| String.toInt restricted to plain digit runs (rejects signs and exponents).
+Also the parser for Blockfrost's decimal quantity strings.
 -}
 digits : String -> Maybe Int
 digits str =
@@ -67,11 +68,17 @@ lovelaceToAda l =
         a =
             abs l
 
+        rest =
+            modBy 1000000 a
+
         whole =
-            a // 1000000
+            -- Elm's // truncates through a 32-bit cast, which garbles whole-ADA
+            -- counts above ~2.1e9. Subtracting the remainder first makes the
+            -- float division exact, so floor is safe for the full Int range.
+            floor (toFloat (a - rest) / 1.0e6)
 
         frac =
-            String.padLeft 6 '0' (String.fromInt (modBy 1000000 a)) |> stripTrailingZeros
+            String.padLeft 6 '0' (String.fromInt rest) |> stripTrailingZeros
     in
     sign
         ++ String.fromInt whole

--- a/cardano-wasm/demo/src/State.elm
+++ b/cardano-wasm/demo/src/State.elm
@@ -1,15 +1,19 @@
 module State exposing
     ( addWallet
     , aliasOf
+    , currentKey
     , emptyRestoreForm
     , getWallet
     , init
     , log
     , mapWallet
+    , setCurrentKey
     , setRestorePay
     , setRestoreStake
     , toastNow
     , toggleRestore
+    , utxosTruncated
+    , walletBalance
     )
 
 {-| Everything about the Model: the initial state, derived queries (what the view
@@ -28,9 +32,11 @@ import Types exposing (..)
 init : () -> ( Model, Cmd Msg )
 init _ =
     ( { network = Preview
+      , deriving = False
       , wallets = []
       , nextWid = 1
       , modal = NoModal
+      , bfKeys = { mainnet = "", preprod = "", preview = "" }
       , restore = emptyRestoreForm
       , console =
             [ LogLine LogInfo "cardano-wasm loaded · post-link module ready" ]
@@ -44,6 +50,49 @@ init _ =
 emptyRestoreForm : RestoreForm
 emptyRestoreForm =
     { open = False, paymentSkey = "", stakeSkey = "" }
+
+
+
+-- BLOCKFROST KEY (stored per network, in memory only)
+
+
+currentKey : Model -> String
+currentKey model =
+    case model.network of
+        Mainnet ->
+            model.bfKeys.mainnet
+
+        Preprod ->
+            model.bfKeys.preprod
+
+        Preview ->
+            model.bfKeys.preview
+
+
+setCurrentKey : String -> Model -> Model
+setCurrentKey v model =
+    let
+        -- project ids are plain ASCII; pasted whitespace or invisible characters
+        -- (a zero-width space would even make the request header throw) must not
+        -- reach the header
+        cleaned =
+            String.filter (\c -> Char.toCode c > 32 && Char.toCode c < 127) v
+
+        k =
+            model.bfKeys
+    in
+    { model
+        | bfKeys =
+            case model.network of
+                Mainnet ->
+                    { k | mainnet = cleaned }
+
+                Preprod ->
+                    { k | preprod = cleaned }
+
+                Preview ->
+                    { k | preview = cleaned }
+    }
 
 
 
@@ -94,11 +143,42 @@ addWallet p model =
             , alias = "Wallet " ++ String.fromInt model.nextWid
             , address = p.address
             , keys = p.keys
+            , utxos = NotAsked
             , expanded = True
             , color = color
             }
     in
     { model | wallets = model.wallets ++ [ w ], nextWid = model.nextWid + 1 }
+
+
+{-| The wallet's on-chain ADA. It includes lovelace sitting on token-carrying
+UTxOs the demo cannot spend: this is the real chain balance, not a spendable
+amount (a later slice distinguishes the two when building payments).
+-}
+walletBalance : Wallet -> Loadable Int
+walletBalance w =
+    case w.utxos of
+        NotAsked ->
+            NotAsked
+
+        Loading ->
+            Loading
+
+        Failed e ->
+            Failed e
+
+        Loaded page ->
+            Loaded (List.map .lovelace page.utxos |> List.sum)
+
+
+utxosTruncated : Wallet -> Bool
+utxosTruncated w =
+    case w.utxos of
+        Loaded page ->
+            page.truncated
+
+        _ ->
+            False
 
 
 

--- a/cardano-wasm/demo/src/Types.elm
+++ b/cardano-wasm/demo/src/Types.elm
@@ -4,6 +4,8 @@ module Types exposing (..)
 and the Msg (everything that can happen).
 -}
 
+import Http
+
 
 type Network
     = Mainnet
@@ -25,11 +27,36 @@ type alias Keys =
     }
 
 
+type alias Utxo =
+    { txId : String
+    , txIx : Int
+    , lovelace : Int
+    , hasAssets : Bool -- carries native tokens; unusable as input in this ADA-only demo
+    }
+
+
+{-| One fetched page of a wallet's UTxOs. `truncated` means the page came back
+full, so the on-chain set may be larger and sums are lower bounds.
+-}
+type alias UtxoPage =
+    { utxos : List Utxo
+    , truncated : Bool
+    }
+
+
+type Loadable a
+    = NotAsked
+    | Loading
+    | Loaded a
+    | Failed String
+
+
 type alias Wallet =
     { id : WalletId
     , alias : String
     , address : String
     , keys : Keys
+    , utxos : Loadable UtxoPage
     , expanded : Bool
     , color : String
     }
@@ -61,14 +88,22 @@ type alias GenPayload =
 
 type alias Model =
     { network : Network
+
+    -- a network switch re-derives addresses asynchronously; loads wait for it
+    , deriving : Bool
     , wallets : List Wallet
     , nextWid : Int
     , modal : Modal
+    , bfKeys : BfKeys
     , restore : RestoreForm
     , console : List LogLine
     , toast : Maybe String
     , toastSeq : Int
     }
+
+
+type alias BfKeys =
+    { mainnet : String, preprod : String, preview : String }
 
 
 type Msg
@@ -87,6 +122,10 @@ type Msg
     | RequestForget WalletId
     | ConfirmForget WalletId
     | CancelForget
+    | UpdateBfKey String
+    | ClickLoadUtxos WalletId
+    | ClickLoadAll
+    | GotUtxos WalletId Network (Result String UtxoPage)
     | Copy String
     | ClearConsole
     | ClearToast Int

--- a/cardano-wasm/demo/src/Update.elm
+++ b/cardano-wasm/demo/src/Update.elm
@@ -4,6 +4,7 @@ module Update exposing (update)
 helpers; effects go through Wasm (ports).
 -}
 
+import Blockfrost
 import Net exposing (netName)
 import Ports exposing (clipboardWrite)
 import State exposing (..)
@@ -19,9 +20,15 @@ update msg model =
 
         -- ── network ────────────────────────────────────────────────────────────
         SelectNetwork n ->
-            -- Wallet keys survive a network switch; addresses are re-derived below
-            -- (the bech32 encoding is network-specific, the keys are not).
-            ( { model | network = n }
+            -- Balances are network-specific and swept. Wallet keys survive a network
+            -- switch; addresses are re-derived below (the bech32 encoding is
+            -- network-specific, the keys are not). Loads pause while the
+            -- re-derivation is pending so no request carries a stale address.
+            ( { model
+                | network = n
+                , wallets = List.map (\w -> { w | utxos = NotAsked }) model.wallets
+                , deriving = not (List.isEmpty model.wallets)
+              }
                 |> log LogInfo ("switched to " ++ netName n)
             , if List.isEmpty model.wallets then
                 Cmd.none
@@ -32,7 +39,8 @@ update msg model =
 
         GotDerivedAddresses (Ok pairs) ->
             ( { model
-                | wallets =
+                | deriving = False
+                , wallets =
                     List.map
                         (\w ->
                             case List.filter (\( i, _ ) -> i == w.id) pairs |> List.head of
@@ -48,7 +56,7 @@ update msg model =
             )
 
         GotDerivedAddresses (Err e) ->
-            ( log LogWarn ("derive addresses failed: " ++ e) model, Cmd.none )
+            ( log LogWarn ("derive addresses failed: " ++ e) { model | deriving = False }, Cmd.none )
 
         -- ── wallets: generate / restore / edit / forget ────────────────────────
         ClickNewWallet ->
@@ -107,6 +115,95 @@ update msg model =
                 |> log LogWarn "forgot wallet"
             , Cmd.none
             )
+
+        -- ── UTxOs (Blockfrost reads) ───────────────────────────────────────────
+        UpdateBfKey v ->
+            ( setCurrentKey v model, Cmd.none )
+
+        ClickLoadUtxos wid ->
+            case getWallet wid model of
+                Just w ->
+                    if currentKey model == "" then
+                        toastNow "Enter a Blockfrost project id first" model
+
+                    else if model.deriving then
+                        toastNow "Re-deriving addresses — try again in a moment" model
+
+                    else if w.utxos == Loading then
+                        -- a request is already in flight
+                        ( model, Cmd.none )
+
+                    else
+                        ( mapWallet wid (\x -> { x | utxos = Loading }) model
+                            |> log LogInfo ("GET blockfrost /addresses/…/utxos · " ++ w.alias)
+                        , Blockfrost.fetchUtxos (currentKey model) model.network wid w.address
+                        )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+        ClickLoadAll ->
+            if currentKey model == "" then
+                toastNow "Enter a Blockfrost project id first" model
+
+            else if model.deriving then
+                toastNow "Re-deriving addresses — try again in a moment" model
+
+            else
+                -- reload ALL wallets (not just never-loaded ones), skipping in-flight
+                -- requests; one predicate decides both the sweep and the commands
+                let
+                    toLoad =
+                        List.filter (\w -> w.utxos /= Loading) model.wallets
+
+                    loadingIds =
+                        List.map .id toLoad
+                in
+                ( { model
+                    | wallets =
+                        List.map
+                            (\w ->
+                                if List.member w.id loadingIds then
+                                    { w | utxos = Loading }
+
+                                else
+                                    w
+                            )
+                            model.wallets
+                  }
+                    |> log LogInfo ("GET blockfrost /addresses/…/utxos × " ++ String.fromInt (List.length toLoad))
+                , Cmd.batch (List.map (\w -> Blockfrost.fetchUtxos (currentKey model) model.network w.id w.address) toLoad)
+                )
+
+        GotUtxos wid net result ->
+            if net /= model.network then
+                -- fired before a network switch; the wallet was already swept
+                ( log LogWarn (aliasOf wid model ++ ": dropped a UTxO response from the previous network") model
+                , Cmd.none
+                )
+
+            else
+                case result of
+                    Ok page ->
+                        let
+                            warnTruncated m =
+                                if page.truncated then
+                                    log LogWarn (aliasOf wid m ++ " has more UTxOs than one page — the balance is a lower bound") m
+
+                                else
+                                    m
+                        in
+                        ( mapWallet wid (\w -> { w | utxos = Loaded page }) model
+                            |> log LogOk (aliasOf wid model ++ ": loaded " ++ String.fromInt (List.length page.utxos) ++ " UTxOs")
+                            |> warnTruncated
+                        , Cmd.none
+                        )
+
+                    Err err ->
+                        ( mapWallet wid (\w -> { w | utxos = Failed err }) model
+                            |> log LogWarn (aliasOf wid model ++ ": UTxO load failed: " ++ err)
+                        , Cmd.none
+                        )
 
         -- ── misc ───────────────────────────────────────────────────────────────
         Copy t ->

--- a/cardano-wasm/demo/src/View.elm
+++ b/cardano-wasm/demo/src/View.elm
@@ -4,12 +4,12 @@ module View exposing (view)
 dialog and the toast. Pure Model → Html.
 -}
 
-import Format exposing (shorten)
+import Format exposing (ada, lovelaceToAda, shorten)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput, stopPropagationOn)
 import Json.Decode as D
-import Net exposing (faucetUrl, netMagic, netName)
+import Net exposing (faucetUrl, netMagic, netName, netTag)
 import State exposing (..)
 import Types exposing (..)
 
@@ -20,7 +20,7 @@ view model =
         [ div [ class "mock" ] [ text "◆ DEMO — keys, balances, fees and transactions are real cardano-wasm calls on the selected network. Use TESTNETS only." ]
         , viewTopbar model
         , div [ class "grid" ]
-            [ div [ class "col" ] [ viewWalletsCard model ]
+            [ div [ class "col" ] [ viewDataSource model, viewWalletsCard model ]
             , div [ class "col" ]
                 [ div [ class "card" ]
                     [ h3 [] [ text "Transaction builder" ]
@@ -46,6 +46,20 @@ viewTopbar model =
                 [ Mainnet, Preprod, Preview ]
             )
         , span [ class "magic" ] [ text ("magic " ++ netMagic model.network) ]
+        ]
+
+
+viewDataSource : Model -> Html Msg
+viewDataSource model =
+    div [ class "card" ]
+        [ h3 [] [ text "Data source · Blockfrost" ]
+        , label [] [ text ("project id (" ++ netName model.network ++ ")") ]
+        , input [ type_ "password", autocomplete False, placeholder (netTag model.network ++ "…"), value (currentKey model), onInput UpdateBfKey ] []
+        , div [ class "muted small", style "margin-top" "6px" ]
+            [ text "Free key per network at "
+            , a [ href "https://blockfrost.io", target "_blank", rel "noopener noreferrer" ] [ text "blockfrost.io" ]
+            , text " · kept in memory only, never bundled."
+            ]
         ]
 
 
@@ -76,6 +90,11 @@ viewWalletsCard model =
 
           else
             div [] (List.map (viewWallet model) model.wallets)
+        , if List.isEmpty model.wallets then
+            text ""
+
+          else
+            button [ class "btn ghost sm block", onClick ClickLoadAll ] [ text "↻ Load all UTxOs (Blockfrost)" ]
         , case faucetUrl model.network of
             Just url ->
                 if List.isEmpty model.wallets then
@@ -99,6 +118,7 @@ viewWallet model w =
                 [ input [ class "walias", value w.alias, stopClick, onInput (EditAlias w.id) ] []
                 , span [ class "waddr mono" ] [ text (shorten w.address) ]
                 ]
+            , span [ class "wbal", title (balanceTitle w) ] [ text (balanceLabel w) ]
             ]
         , if w.expanded then
             div [ class "wbody" ]
@@ -120,12 +140,111 @@ viewWallet model w =
                     , kv "stake keyhash" (shorten w.keys.stakeKeyHash)
                     ]
                 , div [ class "hrow", style "margin-top" "8px" ]
-                    [ button [ class "btn xs danger", onClick (RequestForget w.id) ] [ text "🗑 forget" ] ]
+                    [ button [ class "btn ghost xs", onClick (ClickLoadUtxos w.id), disabled (w.utxos == Loading) ]
+                        [ text
+                            (if w.utxos == NotAsked then
+                                "↻ load UTxOs"
+
+                             else if w.utxos == Loading then
+                                "loading…"
+
+                             else
+                                "↻ reload UTxOs"
+                            )
+                        ]
+                    , button [ class "btn xs danger", onClick (RequestForget w.id) ] [ text "🗑 forget" ]
+                    ]
+                , viewWalletUtxos w
                 ]
 
           else
             text ""
         ]
+
+
+viewWalletUtxos : Wallet -> Html Msg
+viewWalletUtxos w =
+    case w.utxos of
+        NotAsked ->
+            div [ class "empty" ] [ text "UTxOs not loaded" ]
+
+        Loading ->
+            div [ class "empty" ] [ text "loading…" ]
+
+        Failed e ->
+            div [ class "empty" ] [ text ("failed: " ++ e) ]
+
+        Loaded { utxos, truncated } ->
+            if List.isEmpty utxos then
+                div [ class "empty" ] [ text "no UTxOs at this address" ]
+
+            else
+                table []
+                    (tr [] [ th [] [ text "txid#ix" ], th [ class "right" ] [ text "₳" ] ]
+                        :: List.map
+                            (\u ->
+                                tr []
+                                    [ td [ class "mono" ]
+                                        [ text (String.left 8 u.txId ++ "…#" ++ String.fromInt u.txIx)
+                                        , if u.hasAssets then
+                                            span [ class "pill warn", title "carries native tokens — can't be spent in this ADA-only demo" ] [ text "tokens" ]
+
+                                          else
+                                            text ""
+                                        ]
+                                    , td [ class "right" ] [ text (lovelaceToAda u.lovelace) ]
+                                    ]
+                            )
+                            utxos
+                        ++ (if truncated then
+                                [ tr [] [ td [ class "muted small" ] [ text "… more UTxOs exist — only the first page is shown" ] ] ]
+
+                            else
+                                []
+                           )
+                    )
+
+
+{-| The header balance: placeholders while loading / after a failure, and a
+"≥" lower bound when the loaded page was truncated.
+-}
+balanceLabel : Wallet -> String
+balanceLabel w =
+    case walletBalance w of
+        NotAsked ->
+            "—"
+
+        Loading ->
+            "…"
+
+        Failed _ ->
+            "⚠ failed"
+
+        Loaded n ->
+            (if utxosTruncated w then
+                "≥ "
+
+             else
+                ""
+            )
+                ++ ada n
+
+
+balanceTitle : Wallet -> String
+balanceTitle w =
+    case walletBalance w of
+        Failed e ->
+            e
+
+        Loaded _ ->
+            if utxosTruncated w then
+                "more UTxOs than one page — the balance is a lower bound"
+
+            else
+                ""
+
+        _ ->
+            ""
 
 
 viewConsole : Model -> Html Msg


### PR DESCRIPTION


This PR adds the following functionality to the `cardano-wasm` demo:
- data-source panel: per-network Blockfrost project id (memory only)
- per-wallet UTxO load/reload with in-flight guards; load-all button
- 404 from Blockfrost means "address never seen" -> empty list
- token-carrying UTxOs are flagged (unusable in this ADA-only demo)
- balances in the wallet headers; truncation warning at 100+ UTxOs
- network switch now sweeps the (network-specific) balances

# Context

This is a follow up of: https://github.com/IntersectMBO/cardano-api/pull/1270

# How to trust this PR

- First slice with network calls: HTTPS to Blockfrost only, only after you type a project id, and the id stays in memory (it is never bundled and nothing is persisted).
- All Cardano logic still goes through `cardano-wasm`; `Blockfrost.elm` only decodes JSON (404 = empty wallet, token UTxOs flagged unusable).
- You can try it by serving the`cardano-wasm-demo` artifact.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

