### PR TITLE
cardano-wasm demo: payment builder (inputs, outputs, address validation)

### DIFF
--- a/.changes/20260718_cardano_wasm_demo_payments.yml
+++ b/.changes/20260718_cardano_wasm_demo_payments.yml
@@ -1,0 +1,9 @@
+project: cardano-wasm
+
+pr: 1278
+
+kind:
+  - feature
+
+description: |
+  Demo: payment builder — address book with inspectAddress validation, outputs with change, input selection.

--- a/cardano-wasm/demo/src/Blockfrost.elm
+++ b/cardano-wasm/demo/src/Blockfrost.elm
@@ -139,6 +139,7 @@ utxosDecoder =
                 { txId = h
                 , txIx = i
                 , lovelace = lovelaceIn units
+                , selected = False
 
                 -- any non-lovelace unit = native tokens (unusable in this ADA-only demo)
                 , hasAssets = List.any (\( u, _ ) -> u /= "lovelace") units

--- a/cardano-wasm/demo/src/Main.elm
+++ b/cardano-wasm/demo/src/Main.elm
@@ -29,6 +29,7 @@ subscriptions _ =
         [ Ports.wasmWalletGenerated (Wasm.decodeResult Wasm.genDecoder >> GotGeneratedWallet)
         , Ports.wasmWalletRestored (Wasm.decodeResult Wasm.genDecoder >> GotRestoredWallet)
         , Ports.wasmAddressesDerived (Wasm.decodeResult Wasm.addrsDecoder >> GotDerivedAddresses)
+        , Ports.wasmAddressInspected (Wasm.decodeResult Wasm.inspectedDecoder >> GotAddressInspected)
         ]
 
 

--- a/cardano-wasm/demo/src/Net.elm
+++ b/cardano-wasm/demo/src/Net.elm
@@ -1,6 +1,7 @@
 module Net exposing
     ( blockfrostBase
     , cliFlag
+    , expectedNetKind
     , explorerTx
     , faucetUrl
     , netMagic
@@ -106,3 +107,16 @@ cliFlag n =
 
         Preview ->
             "--testnet-magic 2"
+
+
+{-| The network kind an address must have to be usable on the selected network.
+Addresses only encode mainnet-vs-testnet, so preprod and preview both map to TestKind.
+-}
+expectedNetKind : Network -> NetKind
+expectedNetKind n =
+    case n of
+        Mainnet ->
+            MainKind
+
+        _ ->
+            TestKind

--- a/cardano-wasm/demo/src/Ports.elm
+++ b/cardano-wasm/demo/src/Ports.elm
@@ -22,6 +22,9 @@ port wasmRestoreWallet : E.Value -> Cmd msg
 port wasmDeriveAddresses : E.Value -> Cmd msg
 
 
+port wasmInspectAddress : E.Value -> Cmd msg
+
+
 port clipboardWrite : String -> Cmd msg
 
 
@@ -36,3 +39,6 @@ port wasmWalletRestored : (D.Value -> msg) -> Sub msg
 
 
 port wasmAddressesDerived : (D.Value -> msg) -> Sub msg
+
+
+port wasmAddressInspected : (D.Value -> msg) -> Sub msg

--- a/cardano-wasm/demo/src/State.elm
+++ b/cardano-wasm/demo/src/State.elm
@@ -1,17 +1,38 @@
 module State exposing
     ( addWallet
+    , addrFlagged
+    , addrIssue
+    , addrVerdict
     , aliasOf
+    , changeRow
     , currentKey
+    , deselectInputs
+    , emptyBookForm
     , emptyRestoreForm
+    , explicitOutputsTotal
+    , fetching
     , getWallet
     , init
+    , inputsTotal
     , log
     , mapWallet
+    , outputAddressesOk
+    , outputsComplete
+    , ownBook
+    , removeAt
+    , selectedInputs
+    , setBookAddr
+    , setBookAlias
     , setCurrentKey
     , setRestorePay
     , setRestoreStake
+    , startFetch
     , toastNow
+    , toggleBook
+    , toggleOutputChange
     , toggleRestore
+    , toggleUtxo
+    , updateAt
     , utxosTruncated
     , walletBalance
     )
@@ -20,7 +41,11 @@ module State exposing
 and update read), and the small pure updaters. No commands except the toast timer.
 -}
 
+import Dict
+import Format exposing (adaToLovelace)
+import Net exposing (expectedNetKind)
 import Process
+import Set
 import Task
 import Types exposing (..)
 
@@ -33,15 +58,20 @@ init : () -> ( Model, Cmd Msg )
 init _ =
     ( { network = Preview
       , deriving = False
+      , reloading = Set.empty
       , wallets = []
       , nextWid = 1
+      , book = []
+      , outputs = []
       , modal = NoModal
       , bfKeys = { mainnet = "", preprod = "", preview = "" }
       , restore = emptyRestoreForm
+      , bookForm = emptyBookForm
       , console =
             [ LogLine LogInfo "cardano-wasm loaded · post-link module ready" ]
       , toast = Nothing
       , toastSeq = 0
+      , addrChecks = Dict.empty
       }
     , Cmd.none
     )
@@ -50,6 +80,11 @@ init _ =
 emptyRestoreForm : RestoreForm
 emptyRestoreForm =
     { open = False, paymentSkey = "", stakeSkey = "" }
+
+
+emptyBookForm : BookForm
+emptyBookForm =
+    { open = False, alias = "", address = "" }
 
 
 
@@ -151,6 +186,27 @@ addWallet p model =
     { model | wallets = model.wallets ++ [ w ], nextWid = model.nextWid + 1 }
 
 
+{-| A request for this wallet is in flight: a first load (Loading) or a
+reload (id in model.reloading, page kept visible meanwhile).
+-}
+fetching : Wallet -> Model -> Bool
+fetching w model =
+    w.utxos == Loading || Set.member w.id model.reloading
+
+
+{-| Mark a wallet's fetch as started. A first load shows Loading; a reload
+keeps the current page (and its ticked inputs) visible until the response.
+-}
+startFetch : Wallet -> Model -> Model
+startFetch w model =
+    case w.utxos of
+        Loaded _ ->
+            { model | reloading = Set.insert w.id model.reloading }
+
+        _ ->
+            mapWallet w.id (\x -> { x | utxos = Loading }) model
+
+
 {-| The wallet's on-chain ADA. It includes lovelace sitting on token-carrying
 UTxOs the demo cannot spend: this is the real chain balance, not a spendable
 amount (a later slice distinguishes the two when building payments).
@@ -225,3 +281,262 @@ setRestorePay s r =
 setRestoreStake : String -> RestoreForm -> RestoreForm
 setRestoreStake s r =
     { r | stakeSkey = s }
+
+
+{-| The address book shows own wallets first (derived, always current) plus the
+manually added external entries stored in model.book.
+-}
+ownBook : Model -> List BookEntry
+ownBook model =
+    List.map (\w -> BookEntry w.alias w.address) model.wallets
+
+
+
+-- INPUTS (selected UTxOs across all wallets)
+
+
+{-| The ticked inputs across all wallets, deduplicated by outpoint: restoring
+the same keys twice lists the same UTxOs under two wallets, and one outpoint
+must only be spent once.
+-}
+selectedInputs : Model -> List ( Wallet, Utxo )
+selectedInputs model =
+    model.wallets
+        |> List.concatMap
+            (\w ->
+                case w.utxos of
+                    Loaded page ->
+                        page.utxos |> List.filter .selected |> List.map (\u -> ( w, u ))
+
+                    _ ->
+                        []
+            )
+        |> dedupeByOutpoint
+
+
+dedupeByOutpoint : List ( Wallet, Utxo ) -> List ( Wallet, Utxo )
+dedupeByOutpoint pairs =
+    List.foldl
+        (\( w, u ) ( seen, acc ) ->
+            if Set.member ( u.txId, u.txIx ) seen then
+                ( seen, acc )
+
+            else
+                ( Set.insert ( u.txId, u.txIx ) seen, ( w, u ) :: acc )
+        )
+        ( Set.empty, [] )
+        pairs
+        |> Tuple.second
+        |> List.reverse
+
+
+toggleUtxo : String -> Int -> Wallet -> Wallet
+toggleUtxo txId txIx w =
+    case w.utxos of
+        Loaded page ->
+            -- token-bearing UTxOs stay unselectable (the checkbox is disabled too)
+            { w
+                | utxos =
+                    Loaded
+                        { page
+                            | utxos =
+                                List.map
+                                    (\u ->
+                                        if u.txId == txId && u.txIx == txIx && not u.hasAssets then
+                                            { u | selected = not u.selected }
+
+                                        else
+                                            u
+                                    )
+                                    page.utxos
+                        }
+            }
+
+        _ ->
+            w
+
+
+deselectInputs : Model -> Model
+deselectInputs model =
+    { model
+        | wallets =
+            List.map
+                (\w ->
+                    case w.utxos of
+                        Loaded page ->
+                            { w | utxos = Loaded { page | utxos = List.map (\u -> { u | selected = False }) page.utxos } }
+
+                        _ ->
+                            w
+                )
+                model.wallets
+    }
+
+
+{-| Mark/unmark output i as the change output; at most one: marking one
+unmarks any other.
+-}
+toggleOutputChange : Int -> List Output -> List Output
+toggleOutputChange i outputs =
+    List.indexedMap
+        (\j o ->
+            if j == i then
+                { o
+                    | amount =
+                        if o.amount == Change then
+                            Lovelace ""
+
+                        else
+                            Change
+                }
+
+            else if o.amount == Change then
+                { o | amount = Lovelace "" }
+
+            else
+                o
+        )
+        outputs
+
+
+
+-- TRANSACTION TOTALS (read by the fee/signing UI)
+
+
+inputsTotal : Model -> Int
+inputsTotal model =
+    selectedInputs model |> List.map (\( _, u ) -> u.lovelace) |> List.sum
+
+
+{-| Sum of the typed (non-change) outputs.
+-}
+explicitOutputsTotal : Model -> Int
+explicitOutputsTotal model =
+    model.outputs
+        |> List.filterMap
+            (\o ->
+                case o.amount of
+                    Lovelace s ->
+                        adaToLovelace s
+
+                    Change ->
+                        Nothing
+            )
+        |> List.sum
+
+
+{-| The output marked "change" (at most one), if any.
+-}
+changeRow : Model -> Maybe Output
+changeRow model =
+    model.outputs |> List.filter (\o -> o.amount == Change) |> List.head
+
+
+{-| Every non-change output parses to a positive lovelace amount.
+-}
+outputsComplete : Model -> Bool
+outputsComplete model =
+    List.all
+        (\o ->
+            case o.amount of
+                Change ->
+                    True
+
+                Lovelace s ->
+                    adaToLovelace s |> Maybe.map (\n -> n > 0) |> Maybe.withDefault False
+        )
+        model.outputs
+
+
+{-| Every output address is confirmed valid and on the right network kind.
+-}
+outputAddressesOk : Model -> Bool
+outputAddressesOk model =
+    List.all (\o -> addrIssue model o.address == Nothing) model.outputs
+
+
+
+-- ADDRESS CHECKS (results of cardano-wasm's inspectAddress, cached by address)
+
+
+{-| The cached verdict for an address, if it has been inspected.
+-}
+addrVerdict : Model -> String -> Maybe AddrCheck
+addrVerdict model a =
+    Dict.get a model.addrChecks
+
+
+{-| Nothing = address is fine; Just reason otherwise. Unchecked counts as a problem
+(inspection is near-instant, so this only blocks momentarily).
+-}
+addrIssue : Model -> String -> Maybe String
+addrIssue model a =
+    case addrVerdict model a of
+        Nothing ->
+            Just "checking address…"
+
+        Just CheckInvalid ->
+            Just "invalid address"
+
+        Just CheckFailed ->
+            Just "address check failed"
+
+        Just (CheckValid kind) ->
+            if kind == expectedNetKind model.network then
+                Nothing
+
+            else
+                Just
+                    ("wrong network ("
+                        ++ (if kind == MainKind then
+                                "mainnet"
+
+                            else
+                                "testnet"
+                           )
+                        ++ " address)"
+                    )
+
+
+{-| Like addrIssue, but only settled answers (invalid / wrong network / check
+failed) — an address still being checked is not flagged. For display; gating
+(fee/sign) uses addrIssue.
+-}
+addrFlagged : Model -> String -> Maybe String
+addrFlagged model a =
+    addrVerdict model a |> Maybe.andThen (\_ -> addrIssue model a)
+
+
+toggleBook : BookForm -> BookForm
+toggleBook b =
+    { b | open = not b.open }
+
+
+setBookAlias : String -> BookForm -> BookForm
+setBookAlias s b =
+    { b | alias = s }
+
+
+setBookAddr : String -> BookForm -> BookForm
+setBookAddr s b =
+    { b | address = s }
+
+
+removeAt : Int -> List a -> List a
+removeAt i xs =
+    List.indexedMap (\j x -> ( j, x )) xs
+        |> List.filter (\( j, _ ) -> j /= i)
+        |> List.map Tuple.second
+
+
+updateAt : Int -> (a -> a) -> List a -> List a
+updateAt i f xs =
+    List.indexedMap
+        (\j x ->
+            if j == i then
+                f x
+
+            else
+                x
+        )
+        xs

--- a/cardano-wasm/demo/src/Types.elm
+++ b/cardano-wasm/demo/src/Types.elm
@@ -4,7 +4,9 @@ module Types exposing (..)
 and the Msg (everything that can happen).
 -}
 
+import Dict exposing (Dict)
 import Http
+import Set exposing (Set)
 
 
 type Network
@@ -31,6 +33,7 @@ type alias Utxo =
     { txId : String
     , txIx : Int
     , lovelace : Int
+    , selected : Bool -- ticked as an input in the payment builder
     , hasAssets : Bool -- carries native tokens; unusable as input in this ADA-only demo
     }
 
@@ -62,9 +65,47 @@ type alias Wallet =
     }
 
 
+type alias BookEntry =
+    { alias : String
+    , address : String
+    }
+
+
+type OutputAmount
+    = Lovelace String
+    | Change
+
+
+type alias Output =
+    { address : String
+    , alias : String
+    , amount : OutputAmount
+    }
+
+
+{-| Which family of networks an address belongs to. Addresses only encode
+mainnet-vs-testnet, so preprod and preview cannot be told apart.
+-}
+type NetKind
+    = MainKind
+    | TestKind
+
+
+{-| Result of cardano-wasm's inspectAddress for one address.
+-}
+type AddrCheck
+    = CheckInvalid
+    | CheckValid NetKind
+    | CheckFailed -- the checker itself errored; not a verdict about the address
+
+
 type Modal
     = NoModal
     | ForgetDialog WalletId
+
+
+type alias BookForm =
+    { open : Bool, alias : String, address : String }
 
 
 type alias RestoreForm =
@@ -91,14 +132,22 @@ type alias Model =
 
     -- a network switch re-derives addresses asynchronously; loads wait for it
     , deriving : Bool
+
+    -- wallets whose Loaded UTxO page is being refreshed; the page (and its
+    -- ticked inputs) stays visible until the response lands
+    , reloading : Set WalletId
     , wallets : List Wallet
     , nextWid : Int
+    , book : List BookEntry
+    , outputs : List Output
     , modal : Modal
     , bfKeys : BfKeys
     , restore : RestoreForm
+    , bookForm : BookForm
     , console : List LogLine
     , toast : Maybe String
     , toastSeq : Int
+    , addrChecks : Dict String AddrCheck -- inspectAddress results, keyed by address
     }
 
 
@@ -126,6 +175,20 @@ type Msg
     | ClickLoadUtxos WalletId
     | ClickLoadAll
     | GotUtxos WalletId Network (Result String UtxoPage)
+    | ToggleUtxoSelected WalletId String Int
+    | ClickAddBookToggle
+    | UpdateBookAlias String
+    | UpdateBookAddr String
+    | SaveBookEntry
+    | CancelBookEntry
+    | DeleteBookEntry Int
+    | UseBookAddress String String
+    | UpdateOutputAmount Int String
+    | ToggleOutputChange Int
+    | DeleteOutput Int
+    | ClearInputs
+    | ClearOutputs
+    | GotAddressInspected (Result String ( String, AddrCheck ))
     | Copy String
     | ClearConsole
     | ClearToast Int

--- a/cardano-wasm/demo/src/Update.elm
+++ b/cardano-wasm/demo/src/Update.elm
@@ -5,11 +5,31 @@ helpers; effects go through Wasm (ports).
 -}
 
 import Blockfrost
+import Dict
+import Format
 import Net exposing (netName)
 import Ports exposing (clipboardWrite)
+import Set
 import State exposing (..)
 import Types exposing (..)
 import Wasm
+
+
+{-| Inspect an address via cardano-wasm unless we already have a verdict for it.
+A failed check is not a verdict, so it does not block a retry: re-adding or
+re-using the address inspects it again, as the "check failed" badge promises.
+-}
+inspectIfNew : Model -> String -> Cmd Msg
+inspectIfNew model a =
+    case Dict.get a model.addrChecks of
+        Just CheckFailed ->
+            Wasm.inspectAddress a
+
+        Just _ ->
+            Cmd.none
+
+        Nothing ->
+            Wasm.inspectAddress a
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -28,6 +48,8 @@ update msg model =
                 | network = n
                 , wallets = List.map (\w -> { w | utxos = NotAsked }) model.wallets
                 , deriving = not (List.isEmpty model.wallets)
+                , reloading = Set.empty
+                , outputs = []
               }
                 |> log LogInfo ("switched to " ++ netName n)
             , if List.isEmpty model.wallets then
@@ -52,7 +74,7 @@ update msg model =
                         )
                         model.wallets
               }
-            , Cmd.none
+            , Cmd.batch (List.map (\( _, addr ) -> inspectIfNew model addr) pairs)
             )
 
         GotDerivedAddresses (Err e) ->
@@ -65,7 +87,7 @@ update msg model =
             )
 
         GotGeneratedWallet (Ok p) ->
-            ( addWallet p model |> log LogOk "generated wallet", Cmd.none )
+            ( addWallet p model |> log LogOk "generated wallet", inspectIfNew model p.address )
 
         GotGeneratedWallet (Err e) ->
             ( log LogWarn ("generate failed: " ++ e) model, Cmd.none )
@@ -89,7 +111,7 @@ update msg model =
 
         GotRestoredWallet (Ok p) ->
             ( addWallet p { model | restore = emptyRestoreForm } |> log LogOk "restored wallet"
-            , Cmd.none
+            , inspectIfNew model p.address
             )
 
         GotRestoredWallet (Err e) ->
@@ -129,12 +151,12 @@ update msg model =
                     else if model.deriving then
                         toastNow "Re-deriving addresses — try again in a moment" model
 
-                    else if w.utxos == Loading then
+                    else if fetching w model then
                         -- a request is already in flight
                         ( model, Cmd.none )
 
                     else
-                        ( mapWallet wid (\x -> { x | utxos = Loading }) model
+                        ( startFetch w model
                             |> log LogInfo ("GET blockfrost /addresses/…/utxos · " ++ w.alias)
                         , Blockfrost.fetchUtxos (currentKey model) model.network wid w.address
                         )
@@ -154,38 +176,41 @@ update msg model =
                 -- requests; one predicate decides both the sweep and the commands
                 let
                     toLoad =
-                        List.filter (\w -> w.utxos /= Loading) model.wallets
-
-                    loadingIds =
-                        List.map .id toLoad
+                        List.filter (\w -> not (fetching w model)) model.wallets
                 in
-                ( { model
-                    | wallets =
-                        List.map
-                            (\w ->
-                                if List.member w.id loadingIds then
-                                    { w | utxos = Loading }
-
-                                else
-                                    w
-                            )
-                            model.wallets
-                  }
+                ( List.foldl startFetch model toLoad
                     |> log LogInfo ("GET blockfrost /addresses/…/utxos × " ++ String.fromInt (List.length toLoad))
                 , Cmd.batch (List.map (\w -> Blockfrost.fetchUtxos (currentKey model) model.network w.id w.address) toLoad)
                 )
 
         GotUtxos wid net result ->
+            let
+                settled =
+                    { model | reloading = Set.remove wid model.reloading }
+            in
             if net /= model.network then
                 -- fired before a network switch; the wallet was already swept
-                ( log LogWarn (aliasOf wid model ++ ": dropped a UTxO response from the previous network") model
+                ( log LogWarn (aliasOf wid settled ++ ": dropped a UTxO response from the previous network") settled
                 , Cmd.none
                 )
 
             else
                 case result of
                     Ok page ->
+                        -- On a reload the previous page is still in place, so ticks are
+                        -- kept for UTxOs that still exist.
                         let
+                            prevSelected =
+                                case getWallet wid settled |> Maybe.map .utxos of
+                                    Just (Loaded old) ->
+                                        old.utxos |> List.filter .selected |> List.map (\u -> ( u.txId, u.txIx ))
+
+                                    _ ->
+                                        []
+
+                            restored =
+                                List.map (\u -> { u | selected = List.member ( u.txId, u.txIx ) prevSelected }) page.utxos
+
                             warnTruncated m =
                                 if page.truncated then
                                     log LogWarn (aliasOf wid m ++ " has more UTxOs than one page — the balance is a lower bound") m
@@ -193,17 +218,99 @@ update msg model =
                                 else
                                     m
                         in
-                        ( mapWallet wid (\w -> { w | utxos = Loaded page }) model
-                            |> log LogOk (aliasOf wid model ++ ": loaded " ++ String.fromInt (List.length page.utxos) ++ " UTxOs")
+                        ( mapWallet wid (\w -> { w | utxos = Loaded { page | utxos = restored } }) settled
+                            |> log LogOk (aliasOf wid settled ++ ": loaded " ++ String.fromInt (List.length restored) ++ " UTxOs")
                             |> warnTruncated
                         , Cmd.none
                         )
 
                     Err err ->
-                        ( mapWallet wid (\w -> { w | utxos = Failed err }) model
-                            |> log LogWarn (aliasOf wid model ++ ": UTxO load failed: " ++ err)
-                        , Cmd.none
-                        )
+                        case getWallet wid settled |> Maybe.map .utxos of
+                            Just (Loaded _) ->
+                                -- a failed reload keeps showing the last known page
+                                ( log LogWarn (aliasOf wid settled ++ ": UTxO reload failed (showing last known data): " ++ err) settled
+                                , Cmd.none
+                                )
+
+                            _ ->
+                                ( mapWallet wid (\w -> { w | utxos = Failed err }) settled
+                                    |> log LogWarn (aliasOf wid settled ++ ": UTxO load failed: " ++ err)
+                                , Cmd.none
+                                )
+
+        ToggleUtxoSelected wid txId txIx ->
+            ( mapWallet wid (toggleUtxo txId txIx) model, Cmd.none )
+
+        -- ── address book ───────────────────────────────────────────────────────
+        ClickAddBookToggle ->
+            ( { model | bookForm = toggleBook model.bookForm }, Cmd.none )
+
+        UpdateBookAlias s ->
+            ( { model | bookForm = setBookAlias s model.bookForm }, Cmd.none )
+
+        UpdateBookAddr s ->
+            ( { model | bookForm = setBookAddr s model.bookForm }, Cmd.none )
+
+        CancelBookEntry ->
+            ( { model | bookForm = emptyBookForm }, Cmd.none )
+
+        SaveBookEntry ->
+            -- pasted addresses often carry stray whitespace; store them clean so the
+            -- verdict cache and the inspection see the address the chain would
+            let
+                addr =
+                    String.trim model.bookForm.address
+            in
+            if addr == "" then
+                toastNow "Enter an address" model
+
+            else
+                ( { model
+                    | book = model.book ++ [ BookEntry (Format.orDefault "Saved address" model.bookForm.alias) addr ]
+                    , bookForm = emptyBookForm
+                  }
+                    |> log LogInfo "added address to book"
+                , inspectIfNew model addr
+                )
+
+        DeleteBookEntry i ->
+            ( { model | book = removeAt i model.book }, Cmd.none )
+
+        GotAddressInspected (Ok ( a, verdict )) ->
+            ( { model | addrChecks = Dict.insert a verdict model.addrChecks }
+                |> (if verdict == CheckInvalid then
+                        log LogWarn ("invalid address: " ++ Format.shorten a)
+
+                    else
+                        identity
+                   )
+            , Cmd.none
+            )
+
+        GotAddressInspected (Err e) ->
+            ( log LogWarn ("address inspection failed: " ++ e) model, Cmd.none )
+
+        -- ── outputs ────────────────────────────────────────────────────────────
+        UseBookAddress alias addr ->
+            ( { model | outputs = model.outputs ++ [ Output addr alias (Lovelace "") ] }
+            , inspectIfNew model addr
+            )
+
+        UpdateOutputAmount i s ->
+            ( { model | outputs = updateAt i (\o -> { o | amount = Lovelace s }) model.outputs }, Cmd.none )
+
+        ToggleOutputChange i ->
+            ( { model | outputs = toggleOutputChange i model.outputs }, Cmd.none )
+
+        DeleteOutput i ->
+            ( { model | outputs = removeAt i model.outputs }, Cmd.none )
+
+        -- ── clearing ───────────────────────────────────────────────────────────
+        ClearInputs ->
+            ( deselectInputs model, Cmd.none )
+
+        ClearOutputs ->
+            ( { model | outputs = [] }, Cmd.none )
 
         -- ── misc ───────────────────────────────────────────────────────────────
         Copy t ->

--- a/cardano-wasm/demo/src/View.elm
+++ b/cardano-wasm/demo/src/View.elm
@@ -1,15 +1,15 @@
 module View exposing (view)
 
-{-| The UI: wallets column · (builder placeholder) · console column, the forget
-dialog and the toast. Pure Model → Html.
+{-| The UI: wallets + address book column · transaction builder · console
+column, the forget dialog and the toast. Pure Model → Html.
 -}
 
-import Format exposing (ada, lovelaceToAda, shorten)
+import Format exposing (ada, adaToLovelace, amountError, lovelaceToAda, shorten)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput, stopPropagationOn)
 import Json.Decode as D
-import Net exposing (faucetUrl, netMagic, netName, netTag)
+import Net exposing (expectedNetKind, faucetUrl, netMagic, netName, netTag)
 import State exposing (..)
 import Types exposing (..)
 
@@ -20,13 +20,8 @@ view model =
         [ div [ class "mock" ] [ text "◆ DEMO — keys, balances, fees and transactions are real cardano-wasm calls on the selected network. Use TESTNETS only." ]
         , viewTopbar model
         , div [ class "grid" ]
-            [ div [ class "col" ] [ viewDataSource model, viewWalletsCard model ]
-            , div [ class "col" ]
-                [ div [ class "card" ]
-                    [ h3 [] [ text "Transaction builder" ]
-                    , div [ class "empty" ] [ text "coming in a later change" ]
-                    ]
-                ]
+            [ div [ class "col" ] [ viewDataSource model, viewWalletsCard model, viewBookCard model ]
+            , div [ class "col" ] [ viewBuilder model ]
             , div [ class "col" ] [ viewConsole model ]
             ]
         , viewModal model
@@ -140,12 +135,12 @@ viewWallet model w =
                     , kv "stake keyhash" (shorten w.keys.stakeKeyHash)
                     ]
                 , div [ class "hrow", style "margin-top" "8px" ]
-                    [ button [ class "btn ghost xs", onClick (ClickLoadUtxos w.id), disabled (w.utxos == Loading) ]
+                    [ button [ class "btn ghost xs", onClick (ClickLoadUtxos w.id), disabled (fetching w model) ]
                         [ text
                             (if w.utxos == NotAsked then
                                 "↻ load UTxOs"
 
-                             else if w.utxos == Loading then
+                             else if fetching w model then
                                 "loading…"
 
                              else
@@ -180,11 +175,12 @@ viewWalletUtxos w =
 
             else
                 table []
-                    (tr [] [ th [] [ text "txid#ix" ], th [ class "right" ] [ text "₳" ] ]
+                    (tr [] [ th [] [], th [] [ text "txid#ix" ], th [ class "right" ] [ text "₳" ] ]
                         :: List.map
                             (\u ->
-                                tr []
-                                    [ td [ class "mono" ]
+                                tr [ classList [ ( "sel", u.selected ) ] ]
+                                    [ td [] [ input [ type_ "checkbox", checked u.selected, disabled u.hasAssets, onClick (ToggleUtxoSelected w.id u.txId u.txIx) ] [] ]
+                                    , td [ class "mono" ]
                                         [ text (String.left 8 u.txId ++ "…#" ++ String.fromInt u.txIx)
                                         , if u.hasAssets then
                                             span [ class "pill warn", title "carries native tokens — can't be spent in this ADA-only demo" ] [ text "tokens" ]
@@ -197,7 +193,7 @@ viewWalletUtxos w =
                             )
                             utxos
                         ++ (if truncated then
-                                [ tr [] [ td [ class "muted small" ] [ text "… more UTxOs exist — only the first page is shown" ] ] ]
+                                [ tr [] [ td [] [], td [ class "muted small" ] [ text "… more UTxOs exist — only the first page is shown" ] ] ]
 
                             else
                                 []
@@ -245,6 +241,203 @@ balanceTitle w =
 
         _ ->
             ""
+
+
+viewBookCard : Model -> Html Msg
+viewBookCard model =
+    let
+        ownEntries =
+            ownBook model |> List.map (\b -> ( b, True ))
+
+        extEntries =
+            List.indexedMap (\i b -> ( b, i )) model.book
+    in
+    div [ class "card" ]
+        [ h3 [] [ text "Address book", span [ class "btn xs", onClick ClickAddBookToggle ] [ text "+ Add" ] ]
+        , if model.bookForm.open then
+            div [ class "restore" ]
+                [ input [ placeholder "label (e.g. Exchange)", value model.bookForm.alias, onInput UpdateBookAlias ] []
+                , input [ placeholder "addr…", value model.bookForm.address, onInput UpdateBookAddr, style "margin-top" "6px" ] []
+                , div [ class "hrow", style "margin-top" "6px" ]
+                    [ button [ class "btn sm", style "flex" "1", onClick SaveBookEntry ] [ text "Save to book" ]
+                    , button [ class "btn ghost sm", onClick CancelBookEntry ] [ text "Cancel" ]
+                    ]
+                ]
+
+          else
+            text ""
+        , if List.isEmpty ownEntries && List.isEmpty extEntries then
+            div [ class "empty" ] [ text "Own wallets appear here automatically" ]
+
+          else
+            div []
+                (List.map (\( b, _ ) -> viewBookRow model b Nothing) ownEntries
+                    ++ List.map (\( b, i ) -> viewBookRow model b (Just i)) extEntries
+                )
+        ]
+
+
+{-| One address-book row. `deletableAt` is Nothing for own wallets (derived rows,
+not deletable) and Just the index into model.book for manual entries.
+-}
+viewBookRow : Model -> BookEntry -> Maybe Int -> Html Msg
+viewBookRow model b deletableAt =
+    let
+        isInvalid =
+            addrVerdict model b.address == Just CheckInvalid
+    in
+    div [ class "bookrow" ]
+        [ span [ class "nm" ] [ text b.alias ]
+        , case deletableAt of
+            Nothing ->
+                span [] [ span [ class "pill own" ] [ text "own" ], viewAddrBadge model b.address ]
+
+            Just _ ->
+                viewAddrBadge model b.address
+        , span [ class "ad mono" ] [ text (shorten b.address) ]
+        , button [ class "btn ghost xs", disabled (isInvalid || model.deriving), onClick (UseBookAddress b.alias b.address) ] [ text "use" ]
+        , case deletableAt of
+            Nothing ->
+                text ""
+
+            Just i ->
+                button [ class "btn xs danger", onClick (DeleteBookEntry i) ] [ text "×" ]
+        ]
+
+
+{-| Verdict badge for a non-own address: invalid, or its network when it differs from the
+selected one. Valid + matching needs no badge. (Preprod/preview can't be told apart.)
+-}
+viewAddrBadge : Model -> String -> Html Msg
+viewAddrBadge model a =
+    case addrVerdict model a of
+        Nothing ->
+            text ""
+
+        Just CheckInvalid ->
+            span [ class "pill bad" ] [ text "invalid ✗" ]
+
+        Just (CheckValid kind) ->
+            if kind == expectedNetKind model.network then
+                text ""
+
+            else
+                span [ class "pill warn" ] [ text "wrong net" ]
+
+        Just CheckFailed ->
+            span [ class "pill warn", title "the address check errored — re-add the address to retry" ] [ text "check failed" ]
+
+
+viewBuilder : Model -> Html Msg
+viewBuilder model =
+    div [ class "card" ]
+        [ h3 [] [ text "Transaction builder" ]
+        , sectionLabel "Inputs — tick UTxOs inside a wallet panel" (not (List.isEmpty (selectedInputs model))) ClearInputs
+        , viewInputs model
+        , sectionLabel "Outputs — add recipients from the address book" (not (List.isEmpty model.outputs)) ClearOutputs
+        , viewOutputs model
+        ]
+
+
+viewInputs : Model -> Html Msg
+viewInputs model =
+    let
+        ins =
+            selectedInputs model
+    in
+    if List.isEmpty ins then
+        div [ class "empty" ] [ text "No inputs yet — tick UTxOs in a wallet panel" ]
+
+    else
+        div []
+            (List.map
+                (\( w, u ) ->
+                    div [ class "inrow" ]
+                        [ span [ class "mono grow" ] [ text (u.txId ++ "#" ++ String.fromInt u.txIx) ]
+                        , span [ class "muted nowrap" ] [ text w.alias ]
+                        , span [ class "nowrap" ] [ text (ada u.lovelace) ]
+                        ]
+                )
+                ins
+            )
+
+
+viewOutputs : Model -> Html Msg
+viewOutputs model =
+    if List.isEmpty model.outputs then
+        div [ class "empty" ] [ text "No outputs yet — pick an address with “use” in the address book" ]
+
+    else
+        let
+            hasInvalid =
+                List.any
+                    (\o ->
+                        case o.amount of
+                            Lovelace s ->
+                                amountError s
+
+                            Change ->
+                                False
+                    )
+                    model.outputs
+
+            addrProblems =
+                model.outputs |> List.filterMap (\o -> addrFlagged model o.address)
+
+            hint =
+                (if hasInvalid then
+                    [ div [ class "small", style "color" "var(--bad)", style "margin-top" "4px" ]
+                        [ text "⚠ invalid amount — use “.” as the decimal separator" ]
+                    ]
+
+                 else
+                    []
+                )
+                    ++ (case addrProblems of
+                            [] ->
+                                []
+
+                            p :: _ ->
+                                [ div [ class "small", style "color" "var(--bad)", style "margin-top" "4px" ]
+                                    [ text ("⚠ " ++ p ++ " — fix or remove the flagged recipient") ]
+                                ]
+                       )
+
+            row i o =
+                div [ class "outrow" ]
+                    [ div [ classList [ ( "orec", True ), ( "chg", o.amount == Change ), ( "badaddr", addrFlagged model o.address /= Nothing ) ] ]
+                        [ b [] [ text o.alias ], span [ class "mono" ] [ text o.address ] ]
+                    , case o.amount of
+                        Change ->
+                            div [ class "orec chg center" ] [ b [] [ text "change" ], span [] [ text "remaining" ] ]
+
+                        Lovelace s ->
+                            input [ classList [ ( "amt", True ), ( "bad", amountError s ) ], placeholder "₳", value s, onInput (UpdateOutputAmount i) ] []
+                    , button [ classList [ ( "chgbtn", True ), ( "on", o.amount == Change ) ], title "use as change", onClick (ToggleOutputChange i) ]
+                        [ text
+                            (if o.amount == Change then
+                                "✓ change"
+
+                             else
+                                "as change"
+                            )
+                        ]
+                    , button [ class "x", onClick (DeleteOutput i) ] [ text "×" ]
+                    ]
+        in
+        div [] (List.indexedMap row model.outputs ++ hint)
+
+
+sectionLabel : String -> Bool -> Msg -> Html Msg
+sectionLabel txt canClear clearMsg =
+    div [ class "seclabel" ]
+        [ label [] [ text txt ]
+        , if canClear then
+            button [ class "btn ghost xs", onClick clearMsg ] [ text "clear" ]
+
+          else
+            text ""
+        ]
 
 
 viewConsole : Model -> Html Msg

--- a/cardano-wasm/demo/src/Wasm.elm
+++ b/cardano-wasm/demo/src/Wasm.elm
@@ -4,6 +4,8 @@ module Wasm exposing
     , deriveAddresses
     , genDecoder
     , generateWallet
+    , inspectAddress
+    , inspectedDecoder
     , restoreWallet
     )
 
@@ -104,3 +106,35 @@ keysDecoder =
 addrsDecoder : D.Decoder (List ( WalletId, String ))
 addrsDecoder =
     D.list (D.map2 Tuple.pair (D.field "id" D.int) (D.field "address" D.string))
+
+
+{-| Validate an address and detect its network kind.
+-}
+inspectAddress : String -> Cmd msg
+inspectAddress addr =
+    Ports.wasmInspectAddress (E.object [ ( "address", E.string addr ) ])
+
+
+inspectedDecoder : D.Decoder ( String, AddrCheck )
+inspectedDecoder =
+    D.map2 Tuple.pair
+        (D.field "address" D.string)
+        (D.field "network" D.string
+            |> D.map
+                (\n ->
+                    case n of
+                        "mainnet" ->
+                            CheckValid MainKind
+
+                        "testnet" ->
+                            CheckValid TestKind
+
+                        "invalid" ->
+                            CheckInvalid
+
+                        _ ->
+                            -- unknown answer or checker failure: distinct from a
+                            -- verdict, so a real address is never called invalid
+                            CheckFailed
+                )
+        )

--- a/cardano-wasm/demo/web/ports.js
+++ b/cardano-wasm/demo/web/ports.js
@@ -1,5 +1,5 @@
 // Port glue: Elm ⇄ cardano-wasm. The wrapper does the Cardano work here —
-// key generation and restoration, address encoding.
+// key generation and restoration, address encoding and inspection.
 import initialise from "./cardano-api.js";
 
 const magic = { mainnet: undefined, preprod: 1, preview: 2 };
@@ -50,6 +50,16 @@ function wire(app, api) {
       }
       app.ports.wasmAddressesDerived.send(out);
     } catch (e) { app.ports.wasmAddressesDerived.send({ error: String(e) }); }
+  });
+
+  app.ports.wasmInspectAddress.subscribe(async ({ address }) => {
+    try {
+      const r = await api.inspectAddress(address); // { network } | null — never throws
+      app.ports.wasmAddressInspected.send({ address, network: r ? r.network : "invalid" });
+    } catch (e) {
+      // Belt and braces: report a checker failure distinctly from an invalid address.
+      app.ports.wasmAddressInspected.send({ address, network: "error" });
+    }
   });
 
   app.ports.clipboardWrite.subscribe((t) => { if (navigator.clipboard) navigator.clipboard.writeText(t).catch(() => {}); });


### PR DESCRIPTION
This PR adds the following functionality to the cardano-wasm demo:
- address book: own wallets auto-listed + manual entries (trimmed on save); every address is validated by cardano-wasm's inspectAddress (invalid / wrong-network / check-failed badges, "use" disabled for invalid ones and while a network switch is re-deriving addresses)
- outputs added from the book with amount validation; one output can be marked as the change output
- inputs picked by ticking UTxOs (token-carrying ones stay unselectable); duplicate wallets can't select the same outpoint twice
- reloads keep the current UTxO page (and its ticks) in place until the response arrives; a failed reload keeps the last known data
- clear buttons per section; network switch also sweeps the outputs

# Context

This is a follow up of: https://github.com/IntersectMBO/cardano-api/pull/1276

# How to trust this PR

- Diff is entirely `cardano-wasm/demo/` + a changelog fragment; CI already compiles it and checks `elm-format`.
- Nothing can move funds yet: the builder only drafts a transaction in memory. The one new cardano-wasm call is `inspectAddress` (read-only validation); no new network requests, no key material touched.
- Try it by serving this PR's `cardano-wasm-demo` artifact.
- `elm-tests` for this logic will be added later.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
