### PR TITLE
Fix Haddock dead-link CI failure: add fs-api's doc site

### DIFF
--- a/.changes/20260807_cardano_api_haddock_fs_api_doc_site.yml
+++ b/.changes/20260807_cardano_api_haddock_fs_api_doc_site.yml
@@ -1,0 +1,6 @@
+project: cardano-api
+pr: 1284
+kind:
+  - maintenance
+description: |
+  Fix the Haddock dead-link CI failure on master (#1279): add the fs-sim repository's documentation site (which hosts `fs-api`'s Haddocks) to `IOG_DOC_BASES` in `scripts/fix-haddock-links.sh`.

--- a/scripts/fix-haddock-links.sh
+++ b/scripts/fix-haddock-links.sh
@@ -146,6 +146,7 @@ IOG_DOC_BASES=(
   "https://ouroboros-network.cardano.intersectmbo.org"
   "https://intersectmbo.github.io/io-sim"
   "https://intersectmbo.github.io/typed-protocols"
+  "https://input-output-hk.github.io/fs-sim"
 )
 
 # CHaP packages we've confirmed have no public Haddocks anywhere (no


### PR DESCRIPTION

# Context

Since https://github.com/IntersectMBO/cardano-api/pull/1221, the CI action that generates haddocks for `cardano-api` noticed there are broken links that couldn't be solved using the heuristics available so far. That resulted on the automatically generated issue: https://github.com/IntersectMBO/cardano-api/issues/1279

This PR addresses this issue by Adding https://input-output-hk.github.io/fs-sim to `IOG_DOC_BASES`. The site serves doc-index.html and module pages for both fs-api and fs-sim, so cross-package links resolve instead of failing the build.

# How to trust this PR

The functional change is a single probe-configuration line — one new entry in IOG_DOC_BASES — plus the changelog fragment. It is strictly additive: the new base is the last candidate probed, so every package that resolved before this PR still resolves to exactly the same site; the only behavioural change is that fs-api (and fs-sim, hosted on the same site) now resolve instead of failing the run.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
