### PR TITLE
Make owner-permission file writes atomic on POSIX

### DIFF
--- a/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
+++ b/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
@@ -1,0 +1,11 @@
+project: cardano-api
+
+pr: 1286
+
+kind:
+  - bugfix
+
+description: |
+  On POSIX, the `WithOwnerPermissions` family of functions (`writeFileTextEnvelopeWithOwnerPermissions`, `writeByteStringFileWithOwnerPermissions`, `writeLazyByteStringFileWithOwnerPermissions`, `writeTextFileWithOwnerPermissions`) and `writeSecrets` now write atomically: the contents go to a temporary file, are synced to disk, and the temporary file is renamed over the target, as was already the case on Windows.
+  If writing fails midway (crash, full disk, power loss), the previous contents of the target file are kept instead of being destroyed.
+  Behaviour change: a pre-existing target no longer keeps its permission bits (the replacement is always owner-only, `0600` filtered by `umask`), and a symlink at the target path is replaced by a regular file instead of being written through.

--- a/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
+++ b/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
@@ -3,6 +3,7 @@ project: cardano-api
 pr: 1286
 
 kind:
+  - breaking
   - bugfix
 
 description: |

--- a/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
+++ b/.changes/20260810_120000_cardano-api_palas_atomic_owner_permission_writes.yml
@@ -10,3 +10,4 @@ description: |
   On POSIX, the `WithOwnerPermissions` family of functions (`writeFileTextEnvelopeWithOwnerPermissions`, `writeByteStringFileWithOwnerPermissions`, `writeLazyByteStringFileWithOwnerPermissions`, `writeTextFileWithOwnerPermissions`) and `writeSecrets` now write atomically: the contents go to a temporary file, are synced to disk, and the temporary file is renamed over the target, as was already the case on Windows.
   If writing fails midway (crash, full disk, power loss), the previous contents of the target file are kept instead of being destroyed.
   Behaviour change: a pre-existing target no longer keeps its permission bits (the replacement is always owner-only, `0600` filtered by `umask`), and a symlink at the target path is replaced by a regular file instead of being written through.
+  The affected functions (and `writeSecrets`) are also generalised from `IO` to any `MonadIO m`.

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -39,7 +39,7 @@ common project-config
 
 common maybe-unix
   if !(os(windows) || arch(wasm32))
-    build-depends: unix
+    build-depends: unix >=2.8
 
 common maybe-Win32
   if os(windows)

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -350,13 +350,19 @@ library gen
     text,
 
 test-suite cardano-api-test
-  import: project-config
+  import: project-config, maybe-unix
   hs-source-dirs: test/cardano-api-test
   main-is: cardano-api-test.hs
   type: exitcode-stdio-1.0
 
   if arch(wasm32)
     buildable: False
+
+  if os(windows)
+    hs-source-dirs: test/cardano-api-test-compat/windows
+  else
+    hs-source-dirs: test/cardano-api-test-compat/posix
+
   build-depends:
     FailT,
     QuickCheck,
@@ -398,7 +404,6 @@ test-suite cardano-api-test
     tasty-quickcheck,
     text,
     time,
-    unix-compat,
 
   other-modules:
     Test.Cardano.Api.Address
@@ -415,6 +420,7 @@ test-suite cardano-api-test
     Test.Cardano.Api.Genesis
     Test.Cardano.Api.GovAnchorValidation
     Test.Cardano.Api.IO
+    Test.Cardano.Api.IO.Compat
     Test.Cardano.Api.Json
     Test.Cardano.Api.KeysByron
     Test.Cardano.Api.Ledger

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -350,7 +350,7 @@ library gen
     text,
 
 test-suite cardano-api-test
-  import: project-config, maybe-unix
+  import: project-config
   hs-source-dirs: test/cardano-api-test
   main-is: cardano-api-test.hs
   type: exitcode-stdio-1.0
@@ -385,6 +385,7 @@ test-suite cardano-api-test
     containers,
     data-default,
     directory,
+    filepath,
     hedgehog >=1.1,
     hedgehog-extras,
     hedgehog-quickcheck,
@@ -397,6 +398,7 @@ test-suite cardano-api-test
     tasty-quickcheck,
     text,
     time,
+    unix-compat,
 
   other-modules:
     Test.Cardano.Api.Address

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -350,7 +350,7 @@ library gen
     text,
 
 test-suite cardano-api-test
-  import: project-config
+  import: project-config, maybe-unix
   hs-source-dirs: test/cardano-api-test
   main-is: cardano-api-test.hs
   type: exitcode-stdio-1.0

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -111,9 +111,10 @@ writeByteStringFile fp bs =
 -- @writeFileTextEnvelopeWithOwnerPermissions@ in
 -- "Cardano.Api.Serialise.TextEnvelope".
 writeByteStringFileWithOwnerPermissions
-  :: FilePath
+  :: MonadIO m
+  => FilePath
   -> BS.ByteString
-  -> IO (Either (FileError e) ())
+  -> m (Either (FileError e) ())
 writeByteStringFileWithOwnerPermissions fp bs =
   handleFileForWritingWithOwnerPermission fp $ \h ->
     BS.hPut h bs
@@ -144,9 +145,10 @@ writeLazyByteStringFile fp bs =
 -- permissions and atomic replacement as
 -- 'writeByteStringFileWithOwnerPermissions'.
 writeLazyByteStringFileWithOwnerPermissions
-  :: File content Out
+  :: MonadIO m
+  => File content Out
   -> LBS.ByteString
-  -> IO (Either (FileError e) ())
+  -> m (Either (FileError e) ())
 writeLazyByteStringFileWithOwnerPermissions fp lbs =
   handleFileForWritingWithOwnerPermission (unFile fp) $ \h ->
     LBS.hPut h lbs
@@ -176,9 +178,10 @@ writeTextFile fp t =
 -- | Like 'writeTextFile', but with the same owner-only permissions and
 -- atomic replacement as 'writeByteStringFileWithOwnerPermissions'.
 writeTextFileWithOwnerPermissions
-  :: File content Out
+  :: MonadIO m
+  => File content Out
   -> Text
-  -> IO (Either (FileError e) ())
+  -> m (Either (FileError e) ())
 writeTextFileWithOwnerPermissions fp t =
   handleFileForWritingWithOwnerPermission (unFile fp) $ \h ->
     Text.hPutStr h t

--- a/cardano-api/src/Cardano/Api/IO.hs
+++ b/cardano-api/src/Cardano/Api/IO.hs
@@ -103,6 +103,13 @@ writeByteStringFile fp bs =
     handleIOExceptT (FileIOError (unFile fp)) $
       BS.writeFile (unFile fp) bs
 
+-- | Like 'writeByteStringFile', but the file is created readable and
+-- writable only by its owner (@0600@ on POSIX), and it is replaced
+-- atomically: the contents are written to a temporary file which is then
+-- renamed over the target path, so a failed write never destroys the
+-- previous contents. The detailed per-platform guarantees are documented on
+-- @writeFileTextEnvelopeWithOwnerPermissions@ in
+-- "Cardano.Api.Serialise.TextEnvelope".
 writeByteStringFileWithOwnerPermissions
   :: FilePath
   -> BS.ByteString
@@ -133,6 +140,9 @@ writeLazyByteStringFile fp bs =
     handleIOExceptT (FileIOError (unFile fp)) $
       LBS.writeFile (unFile fp) bs
 
+-- | Like 'writeLazyByteStringFile', but with the same owner-only
+-- permissions and atomic replacement as
+-- 'writeByteStringFileWithOwnerPermissions'.
 writeLazyByteStringFileWithOwnerPermissions
   :: File content Out
   -> LBS.ByteString
@@ -163,6 +173,8 @@ writeTextFile fp t =
     handleIOExceptT (FileIOError (unFile fp)) $
       Text.writeFile (unFile fp) t
 
+-- | Like 'writeTextFile', but with the same owner-only permissions and
+-- atomic replacement as 'writeByteStringFileWithOwnerPermissions'.
 writeTextFileWithOwnerPermissions
   :: File content Out
   -> Text

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
@@ -30,7 +30,18 @@ handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissio
 -- (the contents go to a temporary file which is then renamed into place) and
 -- ends up readable only by its owner.
 writeSecrets
-  :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
+  :: HasCallStack
+  => FilePath
+  -- ^ Output directory
+  -> [Char]
+  -- ^ Filename prefix
+  -> [Char]
+  -- ^ Filename suffix
+  -> (a -> ByteString)
+  -- ^ Serialisation function for the secrets
+  -> [a]
+  -- ^ Secrets to write, one file each
+  -> IO ()
 writeSecrets = writeSecretsImpl
 
 checkVrfFilePermissions :: File content direction -> ExceptT VRFPrivateKeyFilePermissionError IO ()

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
@@ -25,6 +25,10 @@ handleFileForWritingWithOwnerPermission
   -> IO (Either (FileError e) ())
 handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissionImpl
 
+-- | Write a list of secrets to individual files in the given directory, as
+-- @\<prefix\>.\<3-digit index\>.\<suffix\>@. Each file is written atomically
+-- (the contents go to a temporary file which is then renamed into place) and
+-- ends up readable only by its owner.
 writeSecrets
   :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> ByteString) -> [a] -> IO ()
 writeSecrets = writeSecretsImpl

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat.hs
@@ -15,15 +15,18 @@ import Cardano.Api.IO.Internal.Compat.Wasm
 import Cardano.Api.IO.Internal.Compat.Win32
 
 import Control.Monad.Except (ExceptT)
+import Control.Monad.IO.Class (MonadIO (..))
 import Data.ByteString (ByteString)
 import GHC.Stack (HasCallStack)
 import System.IO
 
 handleFileForWritingWithOwnerPermission
-  :: FilePath
+  :: MonadIO m
+  => FilePath
   -> (Handle -> IO ())
-  -> IO (Either (FileError e) ())
-handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissionImpl
+  -> m (Either (FileError e) ())
+handleFileForWritingWithOwnerPermission path f =
+  liftIO $ handleFileForWritingWithOwnerPermissionImpl path f
 
 -- | Write a list of secrets to individual files in the given directory, as
 -- @\<prefix\>.\<3-digit index\>.\<suffix\>@. Each file is written atomically
@@ -31,6 +34,7 @@ handleFileForWritingWithOwnerPermission = handleFileForWritingWithOwnerPermissio
 -- ends up readable only by its owner.
 writeSecrets
   :: HasCallStack
+  => MonadIO m
   => FilePath
   -- ^ Output directory
   -> [Char]
@@ -41,8 +45,9 @@ writeSecrets
   -- ^ Serialisation function for the secrets
   -> [a]
   -- ^ Secrets to write, one file each
-  -> IO ()
-writeSecrets = writeSecretsImpl
+  -> m ()
+writeSecrets outDir prefix suffix secretOp xs =
+  liftIO $ writeSecretsImpl outDir prefix suffix secretOp xs
 
 checkVrfFilePermissions :: File content direction -> ExceptT VRFPrivateKeyFilePermissionError IO ()
 checkVrfFilePermissions = checkVrfFilePermissionsImpl

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -33,10 +33,11 @@ import           System.FilePath (splitFileName, (<.>), (</>))
 import qualified System.IO as IO
 import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
-                   nullFileMode, otherModes, ownerReadMode, setFileMode)
+                   nullFileMode, otherModes, ownerReadMode, setFdOwnerAndGroup, setFileMode)
 import           System.Posix.IO (closeFd, handleToFd)
 import           System.Posix.Types (FileMode)
 import           System.Posix.Unistd (fileSynchronise)
+import           System.Posix.User (getRealUserID)
 import           Text.Printf (printf)
 
 handleFileForWritingWithOwnerPermissionImpl
@@ -48,6 +49,7 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
   -- 'IO.openTempFile' creates with owner-only permissions) and rename it over
   -- the target path once the contents are safely on disk. The target path thus
   -- always holds either its previous contents or the complete new contents.
+  user <- getRealUserID
   result <-
     try $
       bracketOnError
@@ -59,10 +61,14 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
         ( \(tmpPath, h) -> do
             f h
             -- 'handleToFd' flushes the handle's buffers and closes it, handing
-            -- us the raw file descriptor. Syncing the descriptor before the
-            -- rename ensures a power failure cannot leave an empty file at the
-            -- target path.
-            bracket (handleToFd h) closeFd fileSynchronise
+            -- us the raw file descriptor. Before the rename, we set the file's
+            -- ownership to the real user (which can differ from the effective
+            -- user in setuid programs) and sync the descriptor, so a power
+            -- failure cannot leave an empty file at the target path.
+            bracket
+              (handleToFd h)
+              closeFd
+              (\fd -> setFdOwnerAndGroup fd user (-1) >> fileSynchronise fd)
             IO.renameFile tmpPath path
         )
   case result of

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -21,11 +21,12 @@ where
 import           Cardano.Api.Error (FileError (..), throwErrorM)
 import           Cardano.Api.IO.Internal.Base
 
-import           Control.Exception (IOException, bracket, bracketOnError, try)
+import           Control.Exception (bracket, bracketOnError, try)
 import           Control.Monad (forM_, when)
 import           Control.Monad.Except (ExceptT)
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except.Extra (left)
+import           Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import           GHC.Stack (HasCallStack)
 import qualified System.Directory as IO
@@ -50,7 +51,7 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
   -- the target path once the contents are safely on disk. The target path thus
   -- always holds either its previous contents or the complete new contents.
   user <- getRealUserID
-  result <-
+  fmap (first $ FileIOError path) $
     try $
       bracketOnError
         (IO.openTempFile targetDir $ targetFile <.> "tmp")
@@ -71,9 +72,6 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
               (\fd -> setFdOwnerAndGroup fd user (-1) >> fileSynchronise fd)
             IO.renameFile tmpPath path
         )
-  case result of
-    Left (err :: IOException) -> pure $ Left $ FileIOError path err
-    Right () -> pure $ Right ()
  where
   (targetDir, targetFile) = splitFileName path
 

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -23,22 +23,20 @@ import           Cardano.Api.IO.Internal.Base
 
 import           Control.Exception (IOException, bracket, bracketOnError, try)
 import           Control.Monad (forM_, when)
-import           Control.Monad.Except (ExceptT, runExceptT)
+import           Control.Monad.Except (ExceptT)
 import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
+import           Control.Monad.Trans.Except.Extra (left)
 import qualified Data.ByteString as BS
 import           GHC.Stack (HasCallStack)
-import           System.Directory ()
-import           System.FilePath ((</>))
+import qualified System.Directory as IO
+import           System.FilePath (splitFileName, (<.>), (</>))
 import qualified System.IO as IO
 import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
-                   nullFileMode, otherModes, ownerReadMode, ownerWriteMode, setFdOwnerAndGroup,
-                   setFileMode, stdFileMode, unionFileModes)
-import           System.Posix.IO (OpenFileFlags (..), OpenMode (..), closeFd, defaultFileFlags,
-                   fdToHandle, openFd)
-import           System.Posix.Types (Fd, FileMode)
-import           System.Posix.User (getRealUserID)
+                   nullFileMode, otherModes, ownerReadMode, setFileMode)
+import           System.Posix.IO (closeFd, handleToFd)
+import           System.Posix.Types (FileMode)
+import           System.Posix.Unistd (fileSynchronise)
 import           Text.Printf (printf)
 
 handleFileForWritingWithOwnerPermissionImpl
@@ -46,27 +44,32 @@ handleFileForWritingWithOwnerPermissionImpl
   -> (Handle -> IO ())
   -> IO (Either (FileError e) ())
 handleFileForWritingWithOwnerPermissionImpl path f = do
-  -- On a unix based system, we grab a file descriptor and set ourselves as owner.
-  -- Since we're holding the file descriptor at this point, we can be sure that
-  -- what we're about to write to is owned by us if an error didn't occur.
-  user <- getRealUserID
-  ownedFile <-
+  -- On a unix based system, we write to a fresh temporary file (which
+  -- 'IO.openTempFile' creates with owner-only permissions) and rename it over
+  -- the target path once the contents are safely on disk. The target path thus
+  -- always holds either its previous contents or the complete new contents.
+  result <-
     try $
-      -- We only close the FD on error here, otherwise we let it leak out, since
-      -- it will be immediately turned into a Handle (which will be closed when
-      -- the Handle is closed)
       bracketOnError
-        (openFileDescriptor path WriteOnly)
-        closeFd
-        (\fd -> setFdOwnerAndGroup fd user (-1) >> pure fd)
-  case ownedFile of
-    Left (err :: IOException) -> do
-      pure $ Left $ FileIOError path err
-    Right fd -> do
-      bracket
-        (fdToHandle fd)
-        IO.hClose
-        (runExceptT . handleIOExceptT (FileIOError path) . f)
+        (IO.openTempFile targetDir $ targetFile <.> "tmp")
+        ( \(tmpPath, h) -> do
+            IO.hClose h
+            IO.removeFile tmpPath
+        )
+        ( \(tmpPath, h) -> do
+            f h
+            -- 'handleToFd' flushes the handle's buffers and closes it, handing
+            -- us the raw file descriptor. Syncing the descriptor before the
+            -- rename ensures a power failure cannot leave an empty file at the
+            -- target path.
+            bracket (handleToFd h) closeFd fileSynchronise
+            IO.renameFile tmpPath path
+        )
+  case result of
+    Left (err :: IOException) -> pure $ Left $ FileIOError path err
+    Right () -> pure $ Right ()
+ where
+  (targetDir, targetFile) = splitFileName path
 
 writeSecretsImpl
   :: HasCallStack => FilePath -> [Char] -> [Char] -> (a -> BS.ByteString) -> [a] -> IO ()
@@ -104,46 +107,4 @@ checkVrfFilePermissionsImpl (File vrfPrivKey) = do
 
   hasGroupPermissions :: FileMode -> Bool
   hasGroupPermissions fm' = fm' `hasPermission` groupModes
-
--- | Read and write permissions for the file owner only (@0600@). Files
--- created for writing are data files, so the execute bit is not set.
-ownerReadWriteMode :: FileMode
-ownerReadWriteMode = ownerReadMode `unionFileModes` ownerWriteMode
-
--- | Opens a file from disk. In 'WriteOnly' mode, the file is truncated if
--- it already exists.
-openFileDescriptor :: FilePath -> OpenMode -> IO Fd
-# if MIN_VERSION_unix(2,8,0)
-openFileDescriptor fp openMode =
-  openFd fp openMode fileFlags
- where
-  fileFlags =
-    case openMode of
-      ReadOnly ->
-        defaultFileFlags
-      ReadWrite ->
-        defaultFileFlags{creat = Just stdFileMode}
-      WriteOnly ->
-        defaultFileFlags{creat = Just ownerReadWriteMode, trunc = True}
-
-# else
-openFileDescriptor fp openMode =
-  openFd fp openMode fMode fileFlags
- where
-  (fMode, fileFlags) =
-    case openMode of
-      ReadOnly ->
-        ( Nothing
-        , defaultFileFlags
-        )
-      ReadWrite ->
-        ( Just stdFileMode
-        , defaultFileFlags
-        )
-      WriteOnly ->
-        ( Just ownerReadWriteMode
-        , defaultFileFlags{trunc = True}
-        )
-
-# endif
 #endif

--- a/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
+++ b/cardano-api/src/Cardano/Api/IO/Internal/Compat/Posix.hs
@@ -35,7 +35,7 @@ import qualified System.IO as IO
 import           System.IO (Handle)
 import           System.Posix.Files (fileMode, getFileStatus, groupModes, intersectFileModes,
                    nullFileMode, otherModes, ownerReadMode, setFdOwnerAndGroup, setFileMode)
-import           System.Posix.IO (closeFd, handleToFd)
+import           System.Posix.IO (OpenMode (..), closeFd, defaultFileFlags, handleToFd, openFd)
 import           System.Posix.Types (FileMode)
 import           System.Posix.Unistd (fileSynchronise)
 import           System.Posix.User (getRealUserID)
@@ -71,6 +71,12 @@ handleFileForWritingWithOwnerPermissionImpl path f = do
               closeFd
               (\fd -> setFdOwnerAndGroup fd user (-1) >> fileSynchronise fd)
             IO.renameFile tmpPath path
+            -- Sync the directory as well, so the rename itself (and not just
+            -- the file contents) survives a power failure.
+            bracket
+              (openFd targetDir ReadOnly defaultFileFlags)
+              closeFd
+              fileSynchronise
         )
  where
   (targetDir, targetFile) = splitFileName path

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -298,18 +298,25 @@ writeFileTextEnvelope outputFile mbDescr a =
   writeLazyByteStringFile outputFile (textEnvelopeToJSON mbDescr a)
 
 -- | Like 'writeFileTextEnvelope', but the file is created so that only its
--- owner has access to it, to the extent the platform allows it:
+-- owner has access to it, to the extent the platform allows it.
+--
+-- On POSIX and Windows, the contents are written to a freshly created
+-- temporary file which is then renamed over the target path. The target file
+-- therefore never exists in a partially written state: if writing fails
+-- midway (e.g. on a crash or a full disk), its previous contents are left
+-- untouched. A pre-existing file is replaced wholesale: its previous
+-- permission bits are not preserved, and a symlink is replaced by a regular
+-- file rather than written through.
 --
 -- * On POSIX systems, the file is created with @0600@ permissions (read
 --   and write for the file owner only, further filtered by the process's
---   @umask@), and its ownership is set to the current (real) user. If the
---   file already exists, it is truncated, but its permission bits are
---   left unchanged.
+--   @umask@) and is owned by the current user. The contents are synced to
+--   disk before the rename, so a power failure doesn't leave an empty file
+--   at the target path.
 --
--- * On Windows, the contents are written to a freshly created temporary
---   file which is then renamed to the target path. This guarantees the
---   file is owned by the current user, but no explicit ACL is set: the
---   file inherits the access control list of the target directory.
+-- * On Windows, the file is owned by the current user, but no explicit
+--   ACL is set: the file inherits the access control list of the target
+--   directory.
 --
 -- * On WASM, this is currently a no-op: no file is written at all.
 --

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -310,9 +310,9 @@ writeFileTextEnvelope outputFile mbDescr a =
 --
 -- * On POSIX systems, the file is created with @0600@ permissions (read
 --   and write for the file owner only, further filtered by the process's
---   @umask@) and is owned by the current user. The contents are synced to
---   disk before the rename, so a power failure doesn't leave an empty file
---   at the target path.
+--   @umask@), and its ownership is set to the current (real) user. The
+--   contents are synced to disk before the rename, so a power failure
+--   doesn't leave an empty file at the target path.
 --
 -- * On Windows, the file is owned by the current user, but no explicit
 --   ACL is set: the file inherits the access control list of the target

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -311,8 +311,9 @@ writeFileTextEnvelope outputFile mbDescr a =
 -- * On POSIX systems, the file is created with @0600@ permissions (read
 --   and write for the file owner only, further filtered by the process's
 --   @umask@), and its ownership is set to the current (real) user. The
---   contents are synced to disk before the rename, so a power failure
---   doesn't leave an empty file at the target path.
+--   contents are synced to disk before the rename and the directory after
+--   it, so a power failure can neither leave an empty file at the target
+--   path nor undo a completed write.
 --
 -- * On Windows, the file is owned by the current user, but no explicit
 --   ACL is set: the file inherits the access control list of the target

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -52,6 +52,7 @@ import Cardano.Api.Pretty
 import Cardano.Api.Serialise.Cbor
 
 import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.=))
@@ -324,10 +325,11 @@ writeFileTextEnvelope outputFile mbDescr a =
 -- Use this when writing sensitive data such as signing keys.
 writeFileTextEnvelopeWithOwnerPermissions
   :: HasTextEnvelope a
+  => MonadIO m
   => File content Out
   -> Maybe TextEnvelopeDescr
   -> a
-  -> IO (Either (FileError ()) ())
+  -> m (Either (FileError ()) ())
 writeFileTextEnvelopeWithOwnerPermissions outputFile mbDescr a =
   writeLazyByteStringFileWithOwnerPermissions outputFile (textEnvelopeToJSON mbDescr a)
 

--- a/cardano-api/test/cardano-api-test-compat/posix/Test/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/test/cardano-api-test-compat/posix/Test/Cardano/Api/IO/Compat.hs
@@ -1,0 +1,11 @@
+module Test.Cardano.Api.IO.Compat
+  ( makeGroupOtherReadable
+  )
+where
+
+import System.Posix.Files (setFileMode)
+
+-- | Make the file group\/other readable (@0644@), establishing the loose
+-- permissions the overwrite test starts from.
+makeGroupOtherReadable :: FilePath -> IO ()
+makeGroupOtherReadable file = setFileMode file 0o644

--- a/cardano-api/test/cardano-api-test-compat/windows/Test/Cardano/Api/IO/Compat.hs
+++ b/cardano-api/test/cardano-api-test-compat/windows/Test/Cardano/Api/IO/Compat.hs
@@ -1,0 +1,10 @@
+module Test.Cardano.Api.IO.Compat
+  ( makeGroupOtherReadable
+  )
+where
+
+-- | Windows has no group\/other permission bits, and the overwrite test
+-- skips its permission precondition at runtime there, so this is never
+-- called.
+makeGroupOtherReadable :: FilePath -> IO ()
+makeGroupOtherReadable _ = pure ()

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Api.IO
@@ -8,14 +7,16 @@ where
 
 import Cardano.Api
 
+import Control.Monad (unless)
 import Data.ByteString qualified as BS
+import Data.Either (isLeft)
 import System.Directory (removeFile)
-#ifndef mingw32_HOST_OS
-import System.Posix.Files (setFileMode)
-#endif
+import System.FilePath ((</>))
+import System.PosixCompat.Files (setFileMode)
 
 import Hedgehog
 import Hedgehog.Extras qualified as H
+import Hedgehog.Extras.Stock.OS (isWin32)
 import Hedgehog.Internal.Property
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog
@@ -46,40 +47,49 @@ prop_overwriteFileWithOwnerPermissions =
     -- replaces them.
     firstResult <- liftIO $ writeByteStringFile (File file) "old contents"
 
-    case firstResult of
-      Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
-      Right () -> return ()
+    H.leftFail (firstResult :: Either (FileError ()) ())
 
-#ifndef mingw32_HOST_OS
     -- 'writeByteStringFile' creates the file with umask-dependent permissions,
     -- so loosen them explicitly and verify the file really is group/other
     -- readable: otherwise the owner-only assertion below could pass vacuously
-    -- (e.g. under umask 077). Windows has no group/other permission bits, so
-    -- there is no precondition to establish there.
-    liftIO $ setFileMode file 0o644
+    -- (e.g. under umask 077). Skipped at runtime on Windows, which has no
+    -- group/other permission bits to loosen.
+    unless isWin32 $ do
+      liftIO $ setFileMode file 0o644
 
-    preResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
+      preResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
 
-    case preResult of
-      Left _ -> return ()
-      Right () ->
+      unless (isLeft preResult) $
         failWith Nothing "precondition failed: file is not group/other readable before the overwrite"
-#endif
 
     result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) "new contents"
 
-    case result of
-      Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
-      Right () -> return ()
+    H.leftFail (result :: Either (FileError ()) ())
 
     contents <- liftIO $ BS.readFile file
     contents === "new contents"
 
     fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
 
-    case fResult of
-      Left err -> failWith Nothing $ show err
-      Right () -> liftIO (removeFile file) >> success
+    H.leftFail fResult
+
+    liftIO $ removeFile file
+
+prop_writeSecretsOverwritesItsOwnOutput :: Property
+prop_writeSecretsOverwritesItsOwnOutput =
+  H.propertyOnce . H.moduleWorkspace "help" $ \ws ->
+    -- Windows sets the read-only attribute on the secret files, which blocks
+    -- replacing them there (pre-existing behaviour): the rerun-overwrite
+    -- guarantee is POSIX-only.
+    unless isWin32 $ do
+      -- The first run leaves 0400, owner-read-only files behind.
+      liftIO $ writeSecrets ws "secret" "key" id ["old"]
+
+      -- The second run must replace them regardless.
+      liftIO $ writeSecrets ws "secret" "key" id ["new"]
+
+      contents <- liftIO $ BS.readFile (ws </> "secret.000.key")
+      contents === "new"
 
 tests :: TestTree
 tests =
@@ -87,4 +97,5 @@ tests =
     "Test.Cardano.Api.IO"
     [ testProperty "Create VRF File with Owner Permissions" prop_createVrfFileWithOwnerPermissions
     , testProperty "Overwrite file with Owner Permissions" prop_overwriteFileWithOwnerPermissions
+    , testProperty "writeSecrets overwrites its own output" prop_writeSecretsOverwritesItsOwnOutput
     ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Api.IO
@@ -7,7 +8,11 @@ where
 
 import Cardano.Api
 
+import Data.ByteString qualified as BS
 import System.Directory (removeFile)
+#ifndef mingw32_HOST_OS
+import System.Posix.Files (setFileMode)
+#endif
 
 import Hedgehog
 import Hedgehog.Extras qualified as H
@@ -32,9 +37,54 @@ prop_createVrfFileWithOwnerPermissions =
       Left err -> failWith Nothing $ show err
       Right () -> liftIO (removeFile file) >> success
 
+prop_overwriteFileWithOwnerPermissions :: Property
+prop_overwriteFileWithOwnerPermissions =
+  H.propertyOnce . H.moduleWorkspace "help" $ \ws -> do
+    file <- H.noteTempFile ws "file"
+
+    -- Create the target with different contents, to check that overwriting
+    -- replaces them.
+    firstResult <- liftIO $ writeByteStringFile (File file) "old contents"
+
+    case firstResult of
+      Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
+      Right () -> return ()
+
+#ifndef mingw32_HOST_OS
+    -- 'writeByteStringFile' creates the file with umask-dependent permissions,
+    -- so loosen them explicitly and verify the file really is group/other
+    -- readable: otherwise the owner-only assertion below could pass vacuously
+    -- (e.g. under umask 077). Windows has no group/other permission bits, so
+    -- there is no precondition to establish there.
+    liftIO $ setFileMode file 0o644
+
+    preResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
+
+    case preResult of
+      Left _ -> return ()
+      Right () ->
+        failWith Nothing "precondition failed: file is not group/other readable before the overwrite"
+#endif
+
+    result <- liftIO $ writeLazyByteStringFileWithOwnerPermissions (File file) "new contents"
+
+    case result of
+      Left err -> failWith Nothing $ docToString $ prettyError @(FileError ()) err
+      Right () -> return ()
+
+    contents <- liftIO $ BS.readFile file
+    contents === "new contents"
+
+    fResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
+
+    case fResult of
+      Left err -> failWith Nothing $ show err
+      Right () -> liftIO (removeFile file) >> success
+
 tests :: TestTree
 tests =
   testGroup
     "Test.Cardano.Api.IO"
     [ testProperty "Create VRF File with Owner Permissions" prop_createVrfFileWithOwnerPermissions
+    , testProperty "Overwrite file with Owner Permissions" prop_overwriteFileWithOwnerPermissions
     ]

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/IO.hs
@@ -12,7 +12,8 @@ import Data.ByteString qualified as BS
 import Data.Either (isLeft)
 import System.Directory (removeFile)
 import System.FilePath ((</>))
-import System.PosixCompat.Files (setFileMode)
+
+import Test.Cardano.Api.IO.Compat (makeGroupOtherReadable)
 
 import Hedgehog
 import Hedgehog.Extras qualified as H
@@ -55,7 +56,7 @@ prop_overwriteFileWithOwnerPermissions =
     -- (e.g. under umask 077). Skipped at runtime on Windows, which has no
     -- group/other permission bits to loosen.
     unless isWin32 $ do
-      liftIO $ setFileMode file 0o644
+      liftIO $ makeGroupOtherReadable file
 
       preResult <- liftIO . runExceptT $ checkVrfFilePermissions (File file)
 


### PR DESCRIPTION
# Context

Fixes #1254.

Old: the target was opened with O_TRUNC, so a crash or a full disk mid-write destroyed the previous contents and left a truncated file.

New: contents go to a fresh 0600 temp file in the target directory, which is fsynced and renamed over the target - the same approach the Windows implementation already uses. Readers see the old file or the new file, never a partial one.

Behaviour changes on POSIX:
- A pre-existing target no longer keeps its permission bits: the result is always owner-only (0600 filtered by umask).
- A symlink at the target path is replaced by a regular file instead of being written through.
- Overwriting needs a writable directory instead of a writable file, so writeSecrets can now overwrite its own read-only output.

Also: haddocks updated for all five affected functions, and a new test pins the overwrite semantics (contents replaced, permissions re-tightened to owner-only).

# How to trust this PR

  Same temp+rename pattern as the existing `Win32.hs`; temp file is a sibling of the target, so the rename is atomic.
  Added new test that checks the permission changing behaviour works.
  Behaviour changes (always 0600, symlinks replaced) are documented in haddocks and changelog.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
