### PR TITLE
cardano-wasm demo: transaction submission via Blockfrost

### DIFF
--- a/.changes/20260718_cardano_wasm_demo_submit.yml
+++ b/.changes/20260718_cardano_wasm_demo_submit.yml
@@ -1,0 +1,9 @@
+project: cardano-wasm
+
+pr: 1287
+
+kind:
+  - feature
+
+description: |
+  Demo: transaction submission via Blockfrost with tx-id cross-check and explorer links.

--- a/cardano-wasm/demo/src/Blockfrost.elm
+++ b/cardano-wasm/demo/src/Blockfrost.elm
@@ -1,12 +1,14 @@
-module Blockfrost exposing (fetchUtxos, isBlockfrostNotFound, pageSize, utxosDecoder)
+module Blockfrost exposing (fetchUtxos, isBlockfrostNotFound, pageSize, submitTx, utxosDecoder)
 
 {-| The Blockfrost boundary (plain HTTP, CORS-friendly from a static page).
-Supplies UTxOs, authenticated with the per-network project id the user types
-into the UI. Deliberately independent of `State`, so state helpers can build
-on this module without an import cycle.
+Supplies UTxOs and submits transactions — authenticated with the per-network
+project id the user types into the UI. Deliberately kept
+independent of `State`, so state helpers can build on this module without an
+import cycle.
 -}
 
 import Format
+import Hex
 import Http
 import Json.Decode as D
 import Net exposing (blockfrostBase)
@@ -30,7 +32,15 @@ fetchUtxos key network wid addr =
         (expectUtxos (GotUtxos wid network))
 
 
-{-| Blockfrost's maximum page size; a full page means more UTxOs may exist.
+{-| POST the signed CBOR. The reply is stamped with the id of the transaction
+it answers, so a superseded submission's late reply can be told apart.
+-}
+submitTx : String -> Network -> String -> String -> Cmd Msg
+submitTx key network txId cborHex =
+    request key network "POST" "/tx/submit" (Http.bytesBody "application/cbor" (Hex.hexToBytes cborHex)) (expectSubmit (GotSubmitted txId))
+
+
+{-| Blockfrost's maximum page size; a full page means more entries may exist.
 -}
 pageSize : Int
 pageSize =
@@ -99,6 +109,64 @@ expectUtxos =
             else
                 Err (statusErrStr meta body)
         )
+
+
+{-| /tx/submit returns the tx hash as a JSON string on success, a JSON error
+otherwise. A 2xx only counts as success when the body actually is a tx hash —
+a proxy's page or an empty body must not become a confident "submitted".
+-}
+expectSubmit : (Result String String -> Msg) -> Http.Expect Msg
+expectSubmit =
+    expectResponse
+        (\meta body ->
+            let
+                parsed =
+                    D.decodeString D.string body |> Result.withDefault (String.trim body)
+            in
+            if meta.statusCode >= 200 && meta.statusCode < 300 then
+                if isTxHash parsed then
+                    Ok parsed
+
+                else
+                    Err ("unexpected response body: " ++ String.left 120 parsed)
+
+            else
+                Err (submitErrStr meta body)
+        )
+
+
+{-| A transaction id: 64 lowercase hex characters.
+-}
+isTxHash : String -> Bool
+isTxHash s =
+    String.length s == 64 && String.all (\c -> Char.isDigit c || (c >= 'a' && c <= 'f')) s
+
+
+{-| Like statusErrStr, but falls back to the raw body when Blockfrost's message
+field is absent (a gateway may answer plain text), and keeps more of it: the
+ledger's rejection reason — the part the user actually needs — can be long.
+Truncation is marked, so a cut message can't pass for a complete one.
+-}
+submitErrStr : Http.Metadata -> String -> String
+submitErrStr meta body =
+    let
+        full =
+            "HTTP "
+                ++ String.fromInt meta.statusCode
+                ++ " — "
+                ++ (case D.decodeString (D.field "message" D.string) body of
+                        Ok message ->
+                            message
+
+                        Err _ ->
+                            String.trim body
+                   )
+    in
+    if String.length full > 500 then
+        String.left 500 full ++ "…"
+
+    else
+        full
 
 
 {-| Exposed for the test suite.

--- a/cardano-wasm/demo/src/Hex.elm
+++ b/cardano-wasm/demo/src/Hex.elm
@@ -1,0 +1,65 @@
+module Hex exposing (bytesToHex, hexToBytes)
+
+{-| Base16 encoding/decoding of raw bytes. Used by Bech32 (pool ids) and by
+Blockfrost submission (the signed tx CBOR travels as hex, the HTTP body as bytes).
+-}
+
+import Bytes
+import Bytes.Encode as BE
+
+
+bytesToHex : List Int -> String
+bytesToHex =
+    List.map byteToHex >> String.concat
+
+
+byteToHex : Int -> String
+byteToHex b =
+    String.fromList [ hexDigit (b // 16), hexDigit (modBy 16 b) ]
+
+
+hexDigit : Int -> Char
+hexDigit n =
+    String.toList "0123456789abcdef" |> List.drop n |> List.head |> Maybe.withDefault '0'
+
+
+{-| Input is always wasm-produced CBOR hex, so invalid characters (mapped to 0)
+cannot occur in practice.
+-}
+hexToBytes : String -> Bytes.Bytes
+hexToBytes hex =
+    String.toList hex
+        |> hexToInts []
+        |> List.reverse
+        |> List.map BE.unsignedInt8
+        |> BE.sequence
+        |> BE.encode
+
+
+hexToInts : List Int -> List Char -> List Int
+hexToInts acc cs =
+    case cs of
+        a :: b :: rest ->
+            hexToInts (hexNibble a * 16 + hexNibble b :: acc) rest
+
+        _ ->
+            acc
+
+
+hexNibble : Char -> Int
+hexNibble c =
+    let
+        n =
+            Char.toCode c
+    in
+    if n >= 48 && n <= 57 then
+        n - 48
+
+    else if n >= 97 && n <= 102 then
+        n - 87
+
+    else if n >= 65 && n <= 70 then
+        n - 55
+
+    else
+        0

--- a/cardano-wasm/demo/src/State.elm
+++ b/cardano-wasm/demo/src/State.elm
@@ -37,6 +37,7 @@ module State exposing
     , setRestorePay
     , setRestoreStake
     , startFetch
+    , submitLocked
     , toastNow
     , toggleBook
     , toggleOutputChange
@@ -79,6 +80,7 @@ init protocol =
       , fee = NoFee
       , feeText = ""
       , tx = Draft
+      , submit = NotSubmitted
       , modal = NoModal
       , bfKeys = { mainnet = "", preprod = "", preview = "" }
       , restore = emptyRestoreForm
@@ -686,7 +688,25 @@ canSign model =
 -- A signed tx is a snapshot: any later edit makes it stale.
 
 
-{-| Drop back to Draft. For edits that do NOT change the transaction body
+{-| In flight or already accepted — states from which the submit button must
+not fire again (re-broadcasting an accepted tx only produces a confusing
+duplicate-rejection). Retrying after SubmitFailed stays allowed.
+-}
+submitLocked : SubmitState -> Bool
+submitLocked s =
+    case s of
+        Submitting ->
+            True
+
+        Submitted _ ->
+            True
+
+        _ ->
+            False
+
+
+{-| Drop back to Draft, forgetting any submission state with it (both referred
+to the previous signature). For edits that do NOT change the transaction body
 (e.g. typing a new fee).
 -}
 invalidate : Model -> Model
@@ -696,16 +716,17 @@ invalidate model =
             model
 
         _ ->
-            { model | tx = Draft }
+            { model | tx = Draft, submit = NotSubmitted }
 
 
 {-| For edits that change the transaction _shape_ (inputs, outputs, certificates,
-era). Those also reset the fee: a previously estimated fee would now be wrong
-(possibly below the minimum, which the node only rejects at submission).
+era). Those also reset the fee — a previously estimated fee would now be wrong
+(possibly below the minimum, which the node only rejects at submission) — and
+the submission state, which referred to the now-stale signed CBOR.
 -}
 invalidateShape : Model -> Model
 invalidateShape model =
-    { model | tx = Draft, fee = NoFee, feeText = "" }
+    { model | tx = Draft, submit = NotSubmitted, fee = NoFee, feeText = "" }
 
 
 {-| Deduplicate, keeping the first occurrence of each element (stable order).

--- a/cardano-wasm/demo/src/Types.elm
+++ b/cardano-wasm/demo/src/Types.elm
@@ -128,6 +128,13 @@ type TxState
     | Signed SignedTx
 
 
+type SubmitState
+    = NotSubmitted
+    | Submitting
+    | Submitted String
+    | SubmitFailed String
+
+
 type Modal
     = NoModal
     | ForgetDialog WalletId
@@ -184,6 +191,7 @@ type alias Model =
     , fee : FeeState
     , feeText : String
     , tx : TxState
+    , submit : SubmitState
     , modal : Modal
     , bfKeys : BfKeys
     , restore : RestoreForm
@@ -242,6 +250,8 @@ type Msg
     | ClickSign
     | GotTxSigned (Result String SignedPayload)
     | ClickDownloadCli
+    | ClickSubmit
+    | GotSubmitted String (Result String String)
     | Copy String
     | ClearConsole
     | ClearToast Int

--- a/cardano-wasm/demo/src/Update.elm
+++ b/cardano-wasm/demo/src/Update.elm
@@ -417,13 +417,89 @@ update msg model =
             else
                 case result of
                     Ok p ->
-                        ( { model | tx = Signed (SignedTx p.cbor p.txId (List.length (paymentWalletIds model)) 0) }
+                        ( { model | tx = Signed (SignedTx p.cbor p.txId (List.length (paymentWalletIds model)) 0), submit = NotSubmitted }
                             |> log LogOk ("transaction signed · txid " ++ p.txId)
                         , Cmd.none
                         )
 
                     Err e ->
                         ( { model | tx = Draft } |> log LogWarn ("sign failed: " ++ e), Cmd.none )
+
+        ClickSubmit ->
+            case model.tx of
+                Signed s ->
+                    if submitLocked model.submit then
+                        -- a request is already in flight, or this tx is already accepted
+                        ( model, Cmd.none )
+
+                    else if currentKey model == "" then
+                        toastNow "Enter a Blockfrost project id first" model
+
+                    else
+                        ( { model | submit = Submitting } |> log LogInfo "POST blockfrost /tx/submit"
+                        , Blockfrost.submitTx (currentKey model) model.network s.txId s.cbor
+                        )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        GotSubmitted expected result ->
+            let
+                -- accepted only while still Submitting AND only for the submission of
+                -- the currently signed transaction: a superseded submit's late reply
+                -- must not masquerade as the live one (the GotUtxos stamp idiom)
+                live =
+                    case ( model.submit, model.tx ) of
+                        ( Submitting, Signed s ) ->
+                            s.txId == expected
+
+                        _ ->
+                            False
+            in
+            if not live then
+                -- the broadcast may still have happened — keep its outcome on record
+                ( log LogWarn
+                    ("dropped a stale submit result for "
+                        ++ Format.shorten expected
+                        ++ " — "
+                        ++ (case result of
+                                Ok txid ->
+                                    "accepted · txid " ++ txid
+
+                                Err e ->
+                                    "failed: " ++ e
+                           )
+                    )
+                    model
+                , Cmd.none
+                )
+
+            else
+                case result of
+                    Ok txid ->
+                        -- Blockfrost returns the tx hash; it must equal the id cardano-wasm
+                        -- computed. A difference means a serialization/hash bug — the view
+                        -- warns next to the accepted id, which is the authoritative one.
+                        let
+                            consistency =
+                                if txid == expected then
+                                    identity
+
+                                else
+                                    log LogWarn ("txid mismatch! wasm said " ++ expected ++ " but Blockfrost returned " ++ txid)
+                        in
+                        ( { model | submit = Submitted txid } |> log LogOk ("submitted · txid " ++ txid) |> consistency, Cmd.none )
+
+                    Err e ->
+                        let
+                            shown =
+                                if e == "timeout" then
+                                    "no answer in 30 s — the transaction may still have been submitted"
+
+                                else
+                                    e
+                        in
+                        ( { model | submit = SubmitFailed shown } |> log LogWarn ("submit failed: " ++ shown), Cmd.none )
 
         ClickDownloadCli ->
             case model.tx of

--- a/cardano-wasm/demo/src/View.elm
+++ b/cardano-wasm/demo/src/View.elm
@@ -9,7 +9,7 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick, onInput, stopPropagationOn)
 import Json.Decode as D
-import Net exposing (cliFlag, eraTag, expectedNetKind, faucetUrl, netMagic, netName, netTag)
+import Net exposing (cliFlag, eraTag, expectedNetKind, explorerTx, faucetUrl, netMagic, netName, netTag)
 import State exposing (..)
 import Types exposing (..)
 
@@ -565,6 +565,8 @@ viewExport model =
                     , span [ class "mono", style "word-break" "break-all" ] [ text s.txId ]
                     , text " "
                     , button [ class "btn ghost xs", onClick (Copy s.txId) ] [ text "copy" ]
+                    , text " "
+                    , a [ href (explorerTx model.network ++ "transaction/" ++ s.txId), target "_blank", rel "noopener noreferrer" ] [ text "↗ explorer" ]
                     ]
                 , div [ class "muted small", style "margin-bottom" "8px" ]
                     [ text
@@ -586,16 +588,64 @@ viewExport model =
                         )
                     ]
                 , div [ class "hrow" ]
-                    [ button [ class "btn good", onClick ClickDownloadCli ] [ text "⤓ download cardano-cli tx file" ]
+                    [ button [ class "btn", onClick ClickSubmit, disabled (submitLocked model.submit) ]
+                        [ text
+                            (case model.submit of
+                                Submitting ->
+                                    "submitting…"
+
+                                Submitted _ ->
+                                    "✓ submitted"
+
+                                _ ->
+                                    "⇪ submit via Blockfrost"
+                            )
+                        ]
+                    , button [ class "btn good", onClick ClickDownloadCli ] [ text "⤓ download cardano-cli tx file" ]
                     , button [ class "btn ghost sm", onClick (Copy s.cbor) ] [ text "copy CBOR" ]
                     ]
+                , viewSubmitStatus model s
                 , -- the era command group matches the envelope's type; for the upcoming
                   -- era this assumes the cardano-cli release that ships it
-                  div [ class "clihint mono" ] [ text ("broadcast yourself: cardano-cli " ++ eraTag model.era ++ " transaction submit --tx-file tx.signed " ++ cliFlag model.network) ]
+                  div [ class "clihint mono" ] [ text ("or broadcast yourself: cardano-cli " ++ eraTag model.era ++ " transaction submit --tx-file tx.signed " ++ cliFlag model.network) ]
+                , div [ class "muted small", style "margin-top" "6px" ]
+                    [ text "the explorer link resolves once the transaction is on-chain" ]
                 ]
 
         _ ->
-            div [ class "empty" ] [ text "sign the transaction to enable export" ]
+            div [ class "empty" ] [ text "sign the transaction to enable submit / export" ]
+
+
+viewSubmitStatus : Model -> SignedTx -> Html Msg
+viewSubmitStatus model s =
+    case model.submit of
+        NotSubmitted ->
+            text ""
+
+        Submitting ->
+            div [ class "muted small", style "margin-top" "6px" ] [ text "submitting to Blockfrost…" ]
+
+        Submitted txid ->
+            -- accepted into the node's mempool; inclusion in a block comes later
+            div [ class "small", style "margin-top" "6px" ]
+                [ span [ class "pill signed" ] [ text "submitted" ]
+                , text " txid "
+                , span [ class "mono" ] [ text txid ]
+                , text " "
+                , a [ href (explorerTx model.network ++ "transaction/" ++ txid), target "_blank", rel "noopener noreferrer" ] [ text "↗ explorer" ]
+                , if txid == s.txId then
+                    text ""
+
+                  else
+                    -- Blockfrost accepted the tx but under a different id than
+                    -- cardano-wasm computed: a serialization/hash bug. The id
+                    -- above is the accepted, authoritative one.
+                    div [ style "color" "var(--bad)", style "margin-top" "4px" ]
+                        [ text "⚠ differs from the id cardano-wasm computed — possible serialization bug" ]
+                ]
+
+        SubmitFailed e ->
+            div [ class "small", style "margin-top" "6px", style "color" "var(--bad)" ] [ text ("submit failed: " ++ e) ]
 
 
 viewInspector : Model -> Html Msg


### PR DESCRIPTION
This PR adds the following functionality to the `cardano-wasm` demo:

- submit the signed CBOR with POST /tx/submit (bytes body); a 2xx only counts once the body is verified to be a 64-char hex tx id
- the reply is stamped with the id of the tx it answers and accepted only for the live submission; dropped replies keep their outcome on record, since the broadcast may still have happened
- the returned hash is cross-checked against the wasm-computed tx id, with an inline warning next to the authoritative accepted id
- submit states (submitting / submitted / failed) with double-submit locking, and network-aware explorer links; submission resets when the tx is edited or re-signed
- submit errors surface Blockfrost's message (marked truncation at 500 chars — the ledger's rejection reason is the part that matters)
- Hex module for the CBOR-hex -> bytes request body

# Context

This is a follow up of: https://github.com/IntersectMBO/cardano-api/pull/1283

# How to trust this PR


- Diff is only `cardano-wasm/demo/` + fragment; CI compiles it and checks `elm-format`.
- Submitted bytes ≡ the displayed CBOR; a signed tx can't outlive a network switch; only the CBOR leaves the page.
- To try: serve the `cardano-wasm-demo` artifact, fund a Preview wallet, submit, follow the explorer link.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
