### PR TITLE
Bump ouroboros-consensus to 4.1.0.0

### DIFF
--- a/.changes/20260811_235500_cardano-api_palas_bump_ouroboros_consensus_4_1_0_0.yml
+++ b/.changes/20260811_235500_cardano-api_palas_bump_ouroboros_consensus_4_1_0_0.yml
@@ -1,0 +1,5 @@
+project: cardano-api
+pr: 1289
+kind:
+  - maintenance
+description: Updated the `ouroboros-consensus` dependency to 4.1.0.0.

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-08-02T17:21:34Z
-  , cardano-haskell-packages 2026-08-01T07:19:24Z
+  , cardano-haskell-packages 2026-08-11T14:53:43Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -177,7 +177,7 @@ library
     network-mux,
     nothunks,
     ordered-containers,
-    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=4.0,
+    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=4.1,
     ouroboros-network:{api, framework, ouroboros-network, protocols} ^>=1.2,
     parsec,
     plutus-core ^>=1.65,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1785570519,
-        "narHash": "sha256-BHS8utevwG8smiRJzgKqk/Y+az2r4r8Zs9dD3PL+oPo=",
+        "lastModified": 1786489982,
+        "narHash": "sha256-T0r6CvdSEDxszlb7uK7mxEVZcCtFNbk8tlr8B1bRKqM=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "3b065389055ced74890b09d772e3b1fe81df49ef",
+        "rev": "13d0f23cf6af9ea55194b91f6947c0a2aeb522d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

# Context

PR https://github.com/IntersectMBO/cardano-haskell-packages/pull/1428 released `ouroboros-consensus-4.1.0.0` and created a revision for `cardano-api` to include it. That made `master` use a less recent version (4.0) than the released version. This PR addresses that by bumping `ouroboros-consensus` in `master` too.

# How to trust this PR

If CI passes it is probably fine, because it is just a version bump for a dependency, and it is a minor one.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
