### PR TITLE
cardano-wasm demo: staking (certificates, pool picker, stake witnesses)

### DIFF
--- a/.changes/20260718_cardano_wasm_demo_staking.yml
+++ b/.changes/20260718_cardano_wasm_demo_staking.yml
@@ -1,0 +1,9 @@
+project: cardano-wasm
+
+pr: 1290
+
+kind:
+  - feature
+
+description: |
+  Demo: staking certificates (register/delegate/unregister), paginated pool picker, stake witnesses.

--- a/cardano-wasm/demo/README.md
+++ b/cardano-wasm/demo/README.md
@@ -6,6 +6,19 @@ signing happen in the wasm engine; chain data (UTxOs, stake pools) and transacti
 submission go through [Blockfrost](https://blockfrost.io) using a project id the user
 types into the page (kept in memory only).
 
+What it demonstrates:
+
+- multiple wallets: generate stake-enabled key pairs, restore from bech32 signing keys
+- mainnet / preprod / preview, with addresses re-derived on switch
+- UTxOs and balances per wallet; payments with change and validated recipients
+  (cardano-wasm's `inspectAddress` flags invalid and wrong-network addresses)
+- staking: register / register+delegate / delegate-only / unregister, with a paginated
+  live pool picker and payment + stake witnesses
+- fee estimation (`estimateMinFee`) with balance and min-UTxO checks; the tx id is shown
+  right after signing (`getTxId`)
+- submission via Blockfrost (hash cross-checked against the wasm tx id) or a
+  `cardano-cli` TextEnvelope download
+
 The demo built from `master` is published at:
 **https://cardano-api.cardano.intersectmbo.org/cardano-wasm/demo/**
 

--- a/cardano-wasm/demo/src/Bech32.elm
+++ b/cardano-wasm/demo/src/Bech32.elm
@@ -1,0 +1,130 @@
+module Bech32 exposing (bech32ToHex)
+
+{-| PROVISIONAL bech32 → base16 decoder.
+
+The delegation certificate needs the pool id in base16, while the pool picker
+carries the bech32 id from the provider. Blockfrost already returns the hex
+directly, so this decoder is only a fallback for pools missing from the loaded
+set. It performs no checksum validation. Ideally cardano-wasm would expose this
+conversion and this module would disappear.
+
+-}
+
+import Bitwise
+import Hex
+
+
+bech32Charset : String
+bech32Charset =
+    "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+
+
+{-| Decode a bech32 string (e.g. "pool1…") to the base16 of its data payload,
+dropping the human-readable prefix and the 6-symbol checksum.
+No checksum validation — provisional.
+-}
+bech32ToHex : String -> Maybe String
+bech32ToHex input =
+    let
+        chars =
+            String.toList (String.toLower input)
+
+        sep =
+            lastIndexOfChar '1' chars 0 -1
+
+        vals =
+            List.drop (sep + 1) chars |> List.map charIndex
+    in
+    if sep < 0 || List.any (\v -> v < 0) vals || List.length vals < 6 then
+        Nothing
+
+    else
+        convertBits 5 8 False (List.take (List.length vals - 6) vals)
+            |> Maybe.map Hex.bytesToHex
+
+
+charIndex : Char -> Int
+charIndex c =
+    indexInList c (String.toList bech32Charset) 0
+
+
+indexInList : Char -> List Char -> Int -> Int
+indexInList c cs i =
+    case cs of
+        [] ->
+            -1
+
+        x :: rest ->
+            if x == c then
+                i
+
+            else
+                indexInList c rest (i + 1)
+
+
+lastIndexOfChar : Char -> List Char -> Int -> Int -> Int
+lastIndexOfChar c cs i best =
+    case cs of
+        [] ->
+            best
+
+        x :: rest ->
+            lastIndexOfChar c
+                rest
+                (i + 1)
+                (if x == c then
+                    i
+
+                 else
+                    best
+                )
+
+
+{-| Regroup a bit stream from `from`-bit symbols to `to`-bit symbols (the standard
+bech32 5→8 bit conversion). Without padding, leftover bits must be zero.
+-}
+convertBits : Int -> Int -> Bool -> List Int -> Maybe (List Int)
+convertBits from to pad data =
+    let
+        maxv =
+            Bitwise.shiftLeftBy to 1 - 1
+
+        drain acc bits out =
+            if bits >= to then
+                drain acc (bits - to) (Bitwise.and maxv (Bitwise.shiftRightBy (bits - to) acc) :: out)
+
+            else
+                ( bits, out )
+
+        step v ( acc, bits, out ) =
+            let
+                acc1 =
+                    Bitwise.or (Bitwise.shiftLeftBy from acc) v
+
+                ( bits2, out2 ) =
+                    drain acc1 (bits + from) out
+
+                mask =
+                    Bitwise.shiftLeftBy bits2 1 - 1
+            in
+            ( Bitwise.and mask acc1, bits2, out2 )
+
+        ( finalAcc, finalBits, revOut ) =
+            List.foldl step ( 0, 0, [] ) data
+    in
+    if pad then
+        Just
+            (List.reverse
+                (if finalBits > 0 then
+                    Bitwise.and maxv (Bitwise.shiftLeftBy (to - finalBits) finalAcc) :: revOut
+
+                 else
+                    revOut
+                )
+            )
+
+    else if finalBits >= from || Bitwise.and maxv (Bitwise.shiftLeftBy (to - finalBits) finalAcc) /= 0 then
+        Nothing
+
+    else
+        Just (List.reverse revOut)

--- a/cardano-wasm/demo/src/Bech32.elm
+++ b/cardano-wasm/demo/src/Bech32.elm
@@ -1,12 +1,14 @@
 module Bech32 exposing (bech32ToHex)
 
-{-| PROVISIONAL bech32 → base16 decoder.
+{-| Bech32 → base16 decoder for pool ids.
 
-The delegation certificate needs the pool id in base16, while the pool picker
-carries the bech32 id from the provider. Blockfrost already returns the hex
-directly, so this decoder is only a fallback for pools missing from the loaded
-set. It performs no checksum validation. Ideally cardano-wasm would expose this
-conversion and this module would disappear.
+The delegation certificate needs the pool id in base16; the picker pins
+Blockfrost's hex at pick time, so the application no longer performs this
+conversion itself. The module is kept as the safe path should a manual pool-id
+entry ever be added: it validates fully (checksum, `pool` prefix, 28-byte
+payload, no mixed case), so a mistyped id can never silently decode to a
+different pool. Ideally cardano-wasm would expose this conversion and this
+module would disappear.
 
 -}
 
@@ -19,28 +21,89 @@ bech32Charset =
     "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
 
-{-| Decode a bech32 string (e.g. "pool1…") to the base16 of its data payload,
-dropping the human-readable prefix and the 6-symbol checksum.
-No checksum validation — provisional.
+{-| Decode a `pool1…` id to the base16 of its data payload, dropping the
+prefix and the 6-symbol checksum. Full BIP-173 validation: rejects mixed case,
+a prefix other than `pool`, a bad checksum, and any payload that is not
+exactly the 28 bytes of a pool key hash.
 -}
 bech32ToHex : String -> Maybe String
 bech32ToHex input =
     let
+        lower =
+            String.toLower input
+
         chars =
-            String.toList (String.toLower input)
+            String.toList lower
 
         sep =
             lastIndexOfChar '1' chars 0 -1
 
+        hrp =
+            List.take sep chars
+
         vals =
             List.drop (sep + 1) chars |> List.map charIndex
+
+        -- BIP-173: a string must be all-lowercase or all-uppercase
+        mixedCase =
+            input /= lower && input /= String.toUpper input
     in
-    if sep < 0 || List.any (\v -> v < 0) vals || List.length vals < 6 then
+    if mixedCase || sep < 0 || List.any (\v -> v < 0) vals || List.length vals < 6 then
+        Nothing
+
+    else if hrp /= String.toList "pool" || polymod (hrpExpand hrp ++ vals) /= 1 then
         Nothing
 
     else
         convertBits 5 8 False (List.take (List.length vals - 6) vals)
-            |> Maybe.map Hex.bytesToHex
+            |> Maybe.andThen
+                (\bytes ->
+                    if List.length bytes == 28 then
+                        Just (Hex.bytesToHex bytes)
+
+                    else
+                        Nothing
+                )
+
+
+{-| The BIP-173 checksum: over `hrpExpand hrp ++ data` (data including the
+6 checksum symbols) a valid bech32 string yields exactly 1.
+-}
+polymod : List Int -> Int
+polymod values =
+    let
+        generator =
+            [ 0x3B6A57B2, 0x26508E6D, 0x1EA119FA, 0x3D4233DD, 0x2A1462B3 ]
+
+        step v chk =
+            let
+                b =
+                    Bitwise.shiftRightZfBy 25 chk
+
+                shifted =
+                    Bitwise.xor (Bitwise.shiftLeftBy 5 (Bitwise.and chk 0x01FFFFFF)) v
+            in
+            List.foldl
+                (\( i, g ) acc ->
+                    if Bitwise.and (Bitwise.shiftRightZfBy i b) 1 == 1 then
+                        Bitwise.xor acc g
+
+                    else
+                        acc
+                )
+                shifted
+                (List.indexedMap Tuple.pair generator)
+    in
+    List.foldl step 1 values
+
+
+hrpExpand : List Char -> List Int
+hrpExpand hrp =
+    let
+        codes =
+            List.map Char.toCode hrp
+    in
+    List.map (Bitwise.shiftRightBy 5) codes ++ [ 0 ] ++ List.map (Bitwise.and 31) codes
 
 
 charIndex : Char -> Int

--- a/cardano-wasm/demo/src/Blockfrost.elm
+++ b/cardano-wasm/demo/src/Blockfrost.elm
@@ -1,8 +1,8 @@
-module Blockfrost exposing (fetchUtxos, isBlockfrostNotFound, pageSize, submitTx, utxosDecoder)
+module Blockfrost exposing (fetchPools, fetchUtxos, isBlockfrostNotFound, pageSize, submitTx, utxosDecoder)
 
 {-| The Blockfrost boundary (plain HTTP, CORS-friendly from a static page).
-Supplies UTxOs and submits transactions — authenticated with the per-network
-project id the user types into the UI. Deliberately kept
+Supplies UTxOs and the pool list, submits transactions — authenticated with
+the per-network project id the user types into the UI. Deliberately kept
 independent of `State`, so state helpers can build on this module without an
 import cycle.
 -}
@@ -30,6 +30,18 @@ fetchUtxos key network wid addr =
         ("/addresses/" ++ addr ++ "/utxos?order=desc&count=" ++ String.fromInt pageSize)
         Http.emptyBody
         (expectUtxos (GotUtxos wid network))
+
+
+{-| One page of registered pools (pages are 1-based). The picker appends pages.
+-}
+fetchPools : String -> Network -> Int -> Cmd Msg
+fetchPools key network page =
+    request key
+        network
+        "GET"
+        ("/pools/extended?count=" ++ String.fromInt pageSize ++ "&page=" ++ String.fromInt page)
+        Http.emptyBody
+        (expectPools GotPools)
 
 
 {-| POST the signed CBOR. The reply is stamped with the id of the transaction
@@ -105,6 +117,18 @@ expectUtxos =
                 D.decodeString utxosDecoder body
                     |> Result.map (\us -> { utxos = us, truncated = List.length us == pageSize })
                     |> Result.mapError D.errorToString
+
+            else
+                Err (statusErrStr meta body)
+        )
+
+
+expectPools : (Result String (List Pool) -> Msg) -> Http.Expect Msg
+expectPools =
+    expectResponse
+        (\meta body ->
+            if meta.statusCode >= 200 && meta.statusCode < 300 then
+                D.decodeString poolsDecoder body |> Result.mapError D.errorToString
 
             else
                 Err (statusErrStr meta body)
@@ -258,3 +282,33 @@ lovelaceQuantityDecoder =
 lovelaceIn : List ( String, Int ) -> Int
 lovelaceIn units =
     units |> List.filter (\( u, _ ) -> u == "lovelace") |> List.map Tuple.second |> List.sum
+
+
+poolsDecoder : D.Decoder (List Pool)
+poolsDecoder =
+    D.list
+        (D.map4 Pool
+            (D.field "pool_id" D.string)
+            (D.field "hex" D.string)
+            (D.field "live_stake" (D.nullable lovelaceStringDecoder) |> D.map (Maybe.withDefault 0))
+            (D.field "live_saturation" (D.nullable D.float) |> D.map (Maybe.withDefault 0))
+        )
+
+
+{-| Lovelace amounts arrive as strings (or occasionally numbers).
+-}
+lovelaceStringDecoder : D.Decoder Int
+lovelaceStringDecoder =
+    D.oneOf
+        [ D.int
+        , D.string
+            |> D.andThen
+                (\s ->
+                    case String.toInt s of
+                        Just n ->
+                            D.succeed n
+
+                        Nothing ->
+                            D.fail "bad lovelace"
+                )
+        ]

--- a/cardano-wasm/demo/src/Blockfrost.elm
+++ b/cardano-wasm/demo/src/Blockfrost.elm
@@ -1,4 +1,4 @@
-module Blockfrost exposing (fetchPools, fetchUtxos, isBlockfrostNotFound, pageSize, submitTx, utxosDecoder)
+module Blockfrost exposing (fetchPools, fetchUtxos, isBlockfrostNotFound, pageSize, poolsDecoder, submitTx, utxosDecoder)
 
 {-| The Blockfrost boundary (plain HTTP, CORS-friendly from a static page).
 Supplies UTxOs and the pool list, submits transactions — authenticated with
@@ -32,7 +32,10 @@ fetchUtxos key network wid addr =
         (expectUtxos (GotUtxos wid network))
 
 
-{-| One page of registered pools (pages are 1-based). The picker appends pages.
+{-| One page of registered pools (pages are 1-based; each reply replaces the
+shown page). The result is stamped with the network and page it was requested
+for, so a late reply that lands after a network switch or another page click
+can be dropped.
 -}
 fetchPools : String -> Network -> Int -> Cmd Msg
 fetchPools key network page =
@@ -41,7 +44,7 @@ fetchPools key network page =
         "GET"
         ("/pools/extended?count=" ++ String.fromInt pageSize ++ "&page=" ++ String.fromInt page)
         Http.emptyBody
-        (expectPools GotPools)
+        (expectPools (GotPools network page))
 
 
 {-| POST the signed CBOR. The reply is stamped with the id of the transaction
@@ -123,12 +126,14 @@ expectUtxos =
         )
 
 
-expectPools : (Result String (List Pool) -> Msg) -> Http.Expect Msg
+expectPools : (Result String PoolPage -> Msg) -> Http.Expect Msg
 expectPools =
     expectResponse
         (\meta body ->
             if meta.statusCode >= 200 && meta.statusCode < 300 then
-                D.decodeString poolsDecoder body |> Result.mapError D.errorToString
+                D.decodeString poolsDecoder body
+                    |> Result.map (\ps -> { pools = ps, hasMore = List.length ps == pageSize })
+                    |> Result.mapError D.errorToString
 
             else
                 Err (statusErrStr meta body)
@@ -287,9 +292,12 @@ lovelaceIn units =
 poolsDecoder : D.Decoder (List Pool)
 poolsDecoder =
     D.list
-        (D.map4 Pool
+        (D.map5 Pool
             (D.field "pool_id" D.string)
             (D.field "hex" D.string)
+            -- `metadata` is null for pools that never registered any, and `ticker`
+            -- is nullable within it — D.maybe absorbs every shape
+            (D.maybe (D.at [ "metadata", "ticker" ] D.string))
             (D.field "live_stake" (D.nullable lovelaceStringDecoder) |> D.map (Maybe.withDefault 0))
             (D.field "live_saturation" (D.nullable D.float) |> D.map (Maybe.withDefault 0))
         )

--- a/cardano-wasm/demo/src/Main.elm
+++ b/cardano-wasm/demo/src/Main.elm
@@ -7,7 +7,8 @@ module Main exposing (main)
   - Update — the controller (one branch per Msg)
   - View — the whole UI
   - Wasm — the cardano-wasm boundary (port commands + decoders)
-  - Net / Format — static tables and pure utilities
+  - Blockfrost — the chain-data boundary (HTTP)
+  - Net / Format / Hex / Bech32 — static tables and pure utilities
   - Ports — the raw port declarations (JS side: web/ports.js)
 
 -}

--- a/cardano-wasm/demo/src/Net.elm
+++ b/cardano-wasm/demo/src/Net.elm
@@ -12,6 +12,7 @@ module Net exposing
     )
 
 {-| Static tables: the three networks and the two eras. Pure data — no logic
+lives here.
 -}
 
 import Types exposing (..)

--- a/cardano-wasm/demo/src/Ports.elm
+++ b/cardano-wasm/demo/src/Ports.elm
@@ -1,10 +1,5 @@
 port module Ports exposing (..)
 
-{-| The raw port declarations — the only holes in the wall between Elm and
-JavaScript. The JS side lives in web/ports.js. Payloads are untyped JSON;
-Wasm.elm encodes the requests and decodes the replies.
--}
-
 import Json.Decode as D
 import Json.Encode as E
 

--- a/cardano-wasm/demo/src/Ports.elm
+++ b/cardano-wasm/demo/src/Ports.elm
@@ -1,5 +1,10 @@
 port module Ports exposing (..)
 
+{-| The raw port declarations — the only holes in the wall between Elm and
+JavaScript. The JS side lives in web/ports.js. Payloads are untyped JSON;
+Wasm.elm encodes the requests and decodes the replies.
+-}
+
 import Json.Decode as D
 import Json.Encode as E
 

--- a/cardano-wasm/demo/src/State.elm
+++ b/cardano-wasm/demo/src/State.elm
@@ -1,5 +1,6 @@
 module State exposing
     ( adaOnlyMinUtxo
+    , addCert
     , addWallet
     , addrFlagged
     , addrIssue
@@ -8,10 +9,13 @@ module State exposing
     , amountBelowMin
     , balance
     , canSign
+    , certCode
+    , certMenu
     , changeAddress
     , changeRow
     , computeBalance
     , currentKey
+    , depositTotal
     , deselectInputs
     , distinct
     , emptyBookForm
@@ -23,19 +27,26 @@ module State exposing
     , inputsTotal
     , invalidate
     , invalidateShape
+    , isFailed
+    , loadedPools
     , log
     , mapWallet
     , outputAddressesOk
     , outputsComplete
     , ownBook
     , paymentWalletIds
+    , poolByIdIn
+    , poolHex
     , removeAt
     , selectedInputs
     , setBookAddr
     , setBookAlias
+    , setCertPool
     , setCurrentKey
     , setRestorePay
     , setRestoreStake
+    , stakeHashOf
+    , stakeWalletIds
     , startFetch
     , submitLocked
     , toastNow
@@ -47,6 +58,7 @@ module State exposing
     , updateAt
     , utxosTruncated
     , walletBalance
+    , walletCertAction
     , witnessCount
     )
 
@@ -54,6 +66,7 @@ module State exposing
 and update read), and the small pure updaters. No commands except the toast timer.
 -}
 
+import Bech32
 import Dict
 import Format exposing (adaToLovelace)
 import Net exposing (expectedNetKind)
@@ -76,19 +89,24 @@ init protocol =
       , nextWid = 1
       , book = []
       , outputs = []
+      , certs = []
       , era = Conway
       , fee = NoFee
       , feeText = ""
       , tx = Draft
       , submit = NotSubmitted
+      , pools = NotAsked
+      , poolPage = 1
       , modal = NoModal
-      , bfKeys = { mainnet = "", preprod = "", preview = "" }
       , restore = emptyRestoreForm
       , bookForm = emptyBookForm
       , console =
-            [ LogLine LogInfo "cardano-wasm loaded · post-link module ready" ]
+            [ LogLine LogInfo "cardano-wasm loaded · post-link module ready"
+            , LogLine LogInfo "data: Blockfrost (enter a free project id) · pinned protocol params"
+            ]
       , toast = Nothing
       , toastSeq = 0
+      , bfKeys = { mainnet = "", preprod = "", preview = "" }
       , addrChecks = Dict.empty
       , protocol = protocol
       }
@@ -228,7 +246,7 @@ startFetch w model =
 
 {-| The wallet's on-chain ADA. It includes lovelace sitting on token-carrying
 UTxOs the demo cannot spend: this is the real chain balance, not a spendable
-amount (a later slice distinguishes the two when building payments).
+amount (inputsTotal below counts only what the payment builder selected).
 -}
 walletBalance : Wallet -> Loadable Int
 walletBalance w =
@@ -254,52 +272,6 @@ utxosTruncated w =
 
         _ ->
             False
-
-
-
--- CONSOLE & TOAST
-
-
-log : LogLevel -> String -> Model -> Model
-log level text model =
-    let
-        entries =
-            model.console ++ [ LogLine level text ]
-    in
-    -- keep the last 200 lines only
-    { model | console = List.drop (List.length entries - 200) entries }
-
-
-{-| Show a toast and schedule its dismissal; the sequence number ignores stale timers.
--}
-toastNow : String -> Model -> ( Model, Cmd Msg )
-toastNow text model =
-    let
-        seq =
-            model.toastSeq + 1
-    in
-    ( { model | toast = Just text, toastSeq = seq }
-    , Process.sleep 1900 |> Task.perform (\_ -> ClearToast seq)
-    )
-
-
-
--- SMALL FORM UPDATERS
-
-
-toggleRestore : RestoreForm -> RestoreForm
-toggleRestore r =
-    { r | open = not r.open }
-
-
-setRestorePay : String -> RestoreForm -> RestoreForm
-setRestorePay s r =
-    { r | paymentSkey = s }
-
-
-setRestoreStake : String -> RestoreForm -> RestoreForm
-setRestoreStake s r =
-    { r | stakeSkey = s }
 
 
 {-| The address book shows own wallets first (derived, always current) plus the
@@ -444,11 +416,151 @@ explicitOutputsTotal model =
         |> List.sum
 
 
+{-| Net deposit: +keyDeposit per registration, −keyDeposit (refund) per unregistration.
+-}
+depositTotal : Model -> Int
+depositTotal model =
+    model.certs
+        |> List.map
+            (\c ->
+                case c.action of
+                    Register ->
+                        model.protocol.keyDeposit
+
+                    RegisterAndDelegate _ ->
+                        model.protocol.keyDeposit
+
+                    Unregister ->
+                        negate model.protocol.keyDeposit
+
+                    DelegateOnly _ ->
+                        0
+            )
+        |> List.sum
+
+
+
+-- WITNESSES
+-- Payment witnesses come from wallets whose UTxOs are spent; stake witnesses from
+-- wallets that carry a certificate. Distinct per wallet.
+
+
+paymentWalletIds : Model -> List WalletId
+paymentWalletIds model =
+    selectedInputs model |> List.map (\( w, _ ) -> w.id) |> distinct
+
+
+stakeWalletIds : Model -> List WalletId
+stakeWalletIds model =
+    model.certs |> List.map .wallet |> distinct
+
+
+witnessCount : Model -> Int
+witnessCount model =
+    List.length (paymentWalletIds model) + List.length (stakeWalletIds model)
+
+
+
+-- CHANGE & BALANCE
+
+
 {-| The output marked "change" (at most one), if any.
 -}
 changeRow : Model -> Maybe Output
 changeRow model =
     model.outputs |> List.filter (\o -> o.amount == Change) |> List.head
+
+
+{-| Where the remainder goes: the change output if marked, else the first input wallet.
+-}
+changeAddress : Model -> Maybe String
+changeAddress model =
+    case changeRow model of
+        Just o ->
+            Just o.address
+
+        Nothing ->
+            selectedInputs model |> List.head |> Maybe.map (\( w, _ ) -> w.address)
+
+
+{-| Balance arithmetic: change = inputs − outputs − deposit − fee, plus the
+ADA-only min-UTxO check on the change. Plain integer bookkeeping over lovelace
+totals — fee estimation, serialisation and signing all happen in cardano-wasm.
+-}
+computeBalance : Int -> { inputs : Int, outputs : Int, deposit : Int, fee : Int } -> Balance
+computeBalance minUtxo t =
+    let
+        change =
+            t.inputs - t.outputs - t.deposit - t.fee
+    in
+    if change < 0 then
+        Insufficient (negate change)
+
+    else if change == 0 then
+        Balanced 0
+
+    else if change < minUtxo then
+        DustChange change minUtxo
+
+    else
+        Balanced change
+
+
+{-| Minimum lovelace an ADA-only output must hold:
+(≈65 B output + 160 B overhead) × coinsPerUtxoByte ≈ 0.97 ₳.
+Only valid for ADA-only outputs — with native assets the size (and thus the
+minimum) grows, which is one reason this demo blocks token-bearing UTxOs.
+-}
+adaOnlyMinUtxo : Protocol -> Int
+adaOnlyMinUtxo protocol =
+    protocol.coinsPerUtxoByte * 225
+
+
+balanceWith : Int -> Model -> Balance
+balanceWith fee model =
+    computeBalance (adaOnlyMinUtxo model.protocol)
+        { inputs = inputsTotal model
+        , outputs = explicitOutputsTotal model
+        , deposit = depositTotal model
+        , fee = fee
+        }
+
+
+balance : Model -> Balance
+balance model =
+    case model.fee of
+        FeeSet fee ->
+            balanceWith fee model
+
+        _ ->
+            NoFeeYet
+
+
+
+-- READINESS GATES
+
+
+{-| Enough of a transaction to estimate a fee: at least one input, something to do
+(outputs or certificates), and no invalid amounts or addresses.
+-}
+txReady : Model -> Bool
+txReady model =
+    not (List.isEmpty (selectedInputs model))
+        && (explicitOutputsTotal model > 0 || changeRow model /= Nothing || not (List.isEmpty model.certs))
+        && outputsComplete model
+        && outputAddressesOk model
+
+
+{-| The sign button (and handler) gate: ready, fee set, balanced, still a draft.
+-}
+canSign : Model -> Bool
+canSign model =
+    case ( model.fee, balance model, model.tx ) of
+        ( FeeSet _, Balanced _, Draft ) ->
+            txReady model
+
+        _ ->
+            False
 
 
 {-| Every non-change output parses to at least the ADA-only min-UTxO amount —
@@ -541,146 +653,105 @@ addrFlagged model a =
     addrVerdict model a |> Maybe.andThen (\_ -> addrIssue model a)
 
 
-toggleBook : BookForm -> BookForm
-toggleBook b =
-    { b | open = not b.open }
+
+-- CERTIFICATES
+-- One certificate per wallet, chosen from a small menu. The menu codes below are the
+-- single source of truth shared by the view (options) and the update (parsing).
 
 
-setBookAlias : String -> BookForm -> BookForm
-setBookAlias s b =
-    { b | alias = s }
+certMenu : List ( String, String )
+certMenu =
+    [ ( "", "no certificate" )
+    , ( "reg", "Register stake key" )
+    , ( "deleg", "Register + delegate" )
+    , ( "delegonly", "Delegate only" )
+    , ( "unreg", "Unregister stake key" )
+    ]
 
 
-setBookAddr : String -> BookForm -> BookForm
-setBookAddr s b =
-    { b | address = s }
+certCode : CertAction -> String
+certCode action =
+    case action of
+        Register ->
+            "reg"
+
+        RegisterAndDelegate _ ->
+            "deleg"
+
+        DelegateOnly _ ->
+            "delegonly"
+
+        Unregister ->
+            "unreg"
 
 
-removeAt : Int -> List a -> List a
-removeAt i xs =
-    List.indexedMap (\j x -> ( j, x )) xs
-        |> List.filter (\( j, _ ) -> j /= i)
-        |> List.map Tuple.second
-
-
-updateAt : Int -> (a -> a) -> List a -> List a
-updateAt i f xs =
-    List.indexedMap
-        (\j x ->
-            if j == i then
-                f x
-
-            else
-                x
-        )
-        xs
-
-
-
--- WITNESSES
--- Payment witnesses come from the wallets whose UTxOs are spent. Distinct per wallet.
-
-
-paymentWalletIds : Model -> List WalletId
-paymentWalletIds model =
-    selectedInputs model |> List.map (\( w, _ ) -> w.id) |> distinct
-
-
-witnessCount : Model -> Int
-witnessCount model =
-    List.length (paymentWalletIds model)
-
-
-{-| Where the remainder goes: the change output if marked, else the first input wallet.
+{-| The menu code of the wallet's current certificate ("" = none) — keeps the
+per-wallet select in sync with the certificate list.
 -}
-changeAddress : Model -> Maybe String
-changeAddress model =
-    case changeRow model of
-        Just o ->
-            Just o.address
+walletCertAction : WalletId -> Model -> String
+walletCertAction wid model =
+    List.filter (\c -> c.wallet == wid) model.certs
+        |> List.head
+        |> Maybe.map (.action >> certCode)
+        |> Maybe.withDefault ""
+
+
+addCert : Certificate -> Model -> Model
+addCert c model =
+    { model | certs = model.certs ++ [ c ] } |> invalidateShape
+
+
+setCertPool : String -> Certificate -> Certificate
+setCertPool pid c =
+    { c
+        | action =
+            case c.action of
+                RegisterAndDelegate _ ->
+                    RegisterAndDelegate pid
+
+                DelegateOnly _ ->
+                    DelegateOnly pid
+
+                other ->
+                    other
+    }
+
+
+stakeHashOf : WalletId -> Model -> String
+stakeHashOf wid model =
+    getWallet wid model |> Maybe.map (\w -> w.keys.stakeKeyHash) |> Maybe.withDefault ""
+
+
+
+-- POOLS
+
+
+loadedPools : Model -> List Pool
+loadedPools model =
+    case model.pools of
+        Loaded ps ->
+            ps
+
+        _ ->
+            []
+
+
+poolByIdIn : List Pool -> String -> Maybe Pool
+poolByIdIn ps pid =
+    List.filter (\p -> p.idBech32 == pid) ps |> List.head
+
+
+{-| Pool base16 id for the delegation certificate. Prefer Blockfrost's `hex`; fall
+back to the provisional Elm bech32 decoder if the pool isn't in the loaded set.
+-}
+poolHex : Model -> String -> String
+poolHex model pid =
+    case poolByIdIn (loadedPools model) pid of
+        Just p ->
+            p.idHex
 
         Nothing ->
-            selectedInputs model |> List.head |> Maybe.map (\( w, _ ) -> w.address)
-
-
-{-| Balance arithmetic: change = inputs − outputs − deposit − fee, plus the
-ADA-only min-UTxO check on the change. Plain integer bookkeeping over lovelace
-totals — fee estimation, serialisation and signing all happen in cardano-wasm.
--}
-computeBalance : Int -> { inputs : Int, outputs : Int, deposit : Int, fee : Int } -> Balance
-computeBalance minUtxo t =
-    let
-        change =
-            t.inputs - t.outputs - t.deposit - t.fee
-    in
-    if change < 0 then
-        Insufficient (negate change)
-
-    else if change == 0 then
-        Balanced 0
-
-    else if change < minUtxo then
-        DustChange change minUtxo
-
-    else
-        Balanced change
-
-
-{-| Minimum lovelace an ADA-only output must hold:
-(≈65 B output + 160 B overhead) × coinsPerUtxoByte ≈ 0.97 ₳.
-Only valid for ADA-only outputs — with native assets the size (and thus the
-minimum) grows, which is one reason this demo blocks token-bearing UTxOs.
--}
-adaOnlyMinUtxo : Protocol -> Int
-adaOnlyMinUtxo protocol =
-    protocol.coinsPerUtxoByte * 225
-
-
-balanceWith : Int -> Model -> Balance
-balanceWith fee model =
-    computeBalance (adaOnlyMinUtxo model.protocol)
-        { inputs = inputsTotal model
-        , outputs = explicitOutputsTotal model
-        , deposit = 0 -- deposits arrive with certificates
-        , fee = fee
-        }
-
-
-balance : Model -> Balance
-balance model =
-    case model.fee of
-        FeeSet fee ->
-            balanceWith fee model
-
-        _ ->
-            NoFeeYet
-
-
-
--- READINESS GATES
-
-
-{-| Enough of a transaction to estimate a fee: at least one input, something to
-send, and no invalid amounts or addresses.
--}
-txReady : Model -> Bool
-txReady model =
-    not (List.isEmpty (selectedInputs model))
-        && (explicitOutputsTotal model > 0 || changeRow model /= Nothing)
-        && outputsComplete model
-        && outputAddressesOk model
-
-
-{-| The sign button (and handler) gate: ready, fee set, balanced, still a draft.
--}
-canSign : Model -> Bool
-canSign model =
-    case ( model.fee, balance model, model.tx ) of
-        ( FeeSet _, Balanced _, Draft ) ->
-            txReady model
-
-        _ ->
-            False
+            Bech32.bech32ToHex pid |> Maybe.withDefault pid
 
 
 
@@ -729,6 +800,81 @@ invalidateShape model =
     { model | tx = Draft, submit = NotSubmitted, fee = NoFee, feeText = "" }
 
 
+
+-- CONSOLE & TOAST
+
+
+log : LogLevel -> String -> Model -> Model
+log level text model =
+    let
+        entries =
+            model.console ++ [ LogLine level text ]
+    in
+    -- keep the last 200 lines only
+    { model | console = List.drop (List.length entries - 200) entries }
+
+
+{-| Show a toast and schedule its dismissal; the sequence number ignores stale timers.
+-}
+toastNow : String -> Model -> ( Model, Cmd Msg )
+toastNow text model =
+    let
+        seq =
+            model.toastSeq + 1
+    in
+    ( { model | toast = Just text, toastSeq = seq }
+    , Process.sleep 1900 |> Task.perform (\_ -> ClearToast seq)
+    )
+
+
+
+-- SMALL FORM UPDATERS
+
+
+toggleRestore : RestoreForm -> RestoreForm
+toggleRestore r =
+    { r | open = not r.open }
+
+
+setRestorePay : String -> RestoreForm -> RestoreForm
+setRestorePay s r =
+    { r | paymentSkey = s }
+
+
+setRestoreStake : String -> RestoreForm -> RestoreForm
+setRestoreStake s r =
+    { r | stakeSkey = s }
+
+
+toggleBook : BookForm -> BookForm
+toggleBook b =
+    { b | open = not b.open }
+
+
+setBookAlias : String -> BookForm -> BookForm
+setBookAlias s b =
+    { b | alias = s }
+
+
+setBookAddr : String -> BookForm -> BookForm
+setBookAddr s b =
+    { b | address = s }
+
+
+
+-- GENERIC LIST HELPERS
+
+
+isFailed : Loadable a -> Bool
+isFailed l =
+    case l of
+        Failed _ ->
+            True
+
+        _ ->
+            False
+
+
 {-| Deduplicate, keeping the first occurrence of each element (stable order).
 -}
 distinct : List comparable -> List comparable
@@ -742,4 +888,24 @@ distinct xs =
                 acc ++ [ x ]
         )
         []
+        xs
+
+
+removeAt : Int -> List a -> List a
+removeAt i xs =
+    List.indexedMap (\j x -> ( j, x )) xs
+        |> List.filter (\( j, _ ) -> j /= i)
+        |> List.map Tuple.second
+
+
+updateAt : Int -> (a -> a) -> List a -> List a
+updateAt i f xs =
+    List.indexedMap
+        (\j x ->
+            if j == i then
+                f x
+
+            else
+                x
+        )
         xs

--- a/cardano-wasm/demo/src/State.elm
+++ b/cardano-wasm/demo/src/State.elm
@@ -15,6 +15,7 @@ module State exposing
     , changeRow
     , computeBalance
     , currentKey
+    , delegKindCode
     , depositTotal
     , deselectInputs
     , distinct
@@ -35,8 +36,6 @@ module State exposing
     , outputsComplete
     , ownBook
     , paymentWalletIds
-    , poolByIdIn
-    , poolHex
     , removeAt
     , selectedInputs
     , setBookAddr
@@ -66,7 +65,6 @@ module State exposing
 and update read), and the small pure updaters. No commands except the toast timer.
 -}
 
-import Bech32
 import Dict
 import Format exposing (adaToLovelace)
 import Net exposing (expectedNetKind)
@@ -655,8 +653,9 @@ addrFlagged model a =
 
 
 -- CERTIFICATES
--- One certificate per wallet, chosen from a small menu. The menu codes below are the
--- single source of truth shared by the view (options) and the update (parsing).
+-- One certificate per wallet, chosen from a small menu. The menu codes below feed
+-- the view's options; Update.SetWalletCert matches on the same literals, and
+-- certCode/delegKindCode map the model types back to them.
 
 
 certMenu : List ( String, String )
@@ -685,6 +684,19 @@ certCode action =
             "unreg"
 
 
+{-| The menu code a delegation pick would commit to — used by the view to show
+the pending choice while the pool picker is open.
+-}
+delegKindCode : DelegKind -> String
+delegKindCode kind =
+    case kind of
+        RegThenDeleg ->
+            "deleg"
+
+        DelegOnly ->
+            "delegonly"
+
+
 {-| The menu code of the wallet's current certificate ("" = none) — keeps the
 per-wallet select in sync with the certificate list.
 -}
@@ -701,16 +713,16 @@ addCert c model =
     { model | certs = model.certs ++ [ c ] } |> invalidateShape
 
 
-setCertPool : String -> Certificate -> Certificate
-setCertPool pid c =
+setCertPool : PoolRef -> Certificate -> Certificate
+setCertPool ref c =
     { c
         | action =
             case c.action of
                 RegisterAndDelegate _ ->
-                    RegisterAndDelegate pid
+                    RegisterAndDelegate ref
 
                 DelegateOnly _ ->
-                    DelegateOnly pid
+                    DelegateOnly ref
 
                 other ->
                     other
@@ -729,29 +741,11 @@ stakeHashOf wid model =
 loadedPools : Model -> List Pool
 loadedPools model =
     case model.pools of
-        Loaded ps ->
-            ps
+        Loaded page ->
+            page.pools
 
         _ ->
             []
-
-
-poolByIdIn : List Pool -> String -> Maybe Pool
-poolByIdIn ps pid =
-    List.filter (\p -> p.idBech32 == pid) ps |> List.head
-
-
-{-| Pool base16 id for the delegation certificate. Prefer Blockfrost's `hex`; fall
-back to the provisional Elm bech32 decoder if the pool isn't in the loaded set.
--}
-poolHex : Model -> String -> String
-poolHex model pid =
-    case poolByIdIn (loadedPools model) pid of
-        Just p ->
-            p.idHex
-
-        Nothing ->
-            Bech32.bech32ToHex pid |> Maybe.withDefault pid
 
 
 

--- a/cardano-wasm/demo/src/Types.elm
+++ b/cardano-wasm/demo/src/Types.elm
@@ -1,5 +1,9 @@
 module Types exposing (..)
 
+{-| Every data type in the application: the Model (all state in one record)
+and the Msg (everything that can happen).
+-}
+
 import Dict exposing (Dict)
 import Http
 import Set exposing (Set)
@@ -81,9 +85,21 @@ type alias Output =
 
 type CertAction
     = Register
-    | RegisterAndDelegate String
-    | DelegateOnly String
+    | RegisterAndDelegate PoolRef
+    | DelegateOnly PoolRef
     | Unregister
+
+
+{-| What a certificate remembers about its pool, captured at pick time: the
+bech32 id and ticker for display, and Blockfrost's authoritative hex, which is
+what goes into the certificate. Pinning these here means a certificate never
+depends on which picker page happens to be loaded later.
+-}
+type alias PoolRef =
+    { bech32 : String
+    , hex : String
+    , ticker : Maybe String
+    }
 
 
 type alias Certificate =
@@ -95,8 +111,18 @@ type alias Certificate =
 type alias Pool =
     { idBech32 : String
     , idHex : String
+    , ticker : Maybe String -- pools without registered metadata have none
     , liveStake : Int
     , saturation : Float
+    }
+
+
+{-| One fetched page of the pool list. `hasMore` is computed at the fetch
+boundary: a full Blockfrost page means a next one probably exists.
+-}
+type alias PoolPage =
+    { pools : List Pool
+    , hasMore : Bool
     }
 
 
@@ -192,8 +218,8 @@ type alias GenPayload =
 
 
 {-| The two protocol parameters the Elm side needs for its balance arithmetic.
-Read from web/pparams.json at startup (see web/ports.js) so the pinned file is
-the single source of truth; everything else in that file is consumed only by
+Read from web/pparams.js at startup (see web/ports.js) so the pinned object is
+the single source of truth; everything else in it is consumed only by
 cardano-wasm's estimateMinFee.
 -}
 type alias Protocol =
@@ -221,8 +247,8 @@ type alias Model =
     , feeText : String
     , tx : TxState
     , submit : SubmitState
-    , pools : Loadable (List Pool) -- the page of pools currently shown in the picker
-    , poolPage : Int -- its 1-based page number (Blockfrost pages, 100 pools each)
+    , pools : Loadable PoolPage -- the page of pools currently shown in the picker
+    , poolPage : Int -- its 1-based page number (one server page per view)
     , modal : Modal
     , restore : RestoreForm
     , bookForm : BookForm
@@ -278,11 +304,11 @@ type Msg
     | ClearCerts
     | ClearTx
     | UpdatePoolSearch String
-    | PickPool String
+    | PickPool PoolRef
     | ClosePoolModal
     | ClickLoadPools
     | ClickPoolPage Int
-    | GotPools (Result String (List Pool))
+    | GotPools Network Int (Result String PoolPage)
     | SelectEra Era
     | ClickEstimateFee
     | GotFeeEstimated (Result String Int)

--- a/cardano-wasm/demo/src/Types.elm
+++ b/cardano-wasm/demo/src/Types.elm
@@ -1,9 +1,5 @@
 module Types exposing (..)
 
-{-| Every data type in the application: the Model (all state in one record)
-and the Msg (everything that can happen).
--}
-
 import Dict exposing (Dict)
 import Http
 import Set exposing (Set)
@@ -33,7 +29,7 @@ type alias Utxo =
     { txId : String
     , txIx : Int
     , lovelace : Int
-    , selected : Bool -- ticked as an input in the payment builder
+    , selected : Bool
     , hasAssets : Bool -- carries native tokens; unusable as input in this ADA-only demo
     }
 
@@ -83,20 +79,25 @@ type alias Output =
     }
 
 
-{-| Which family of networks an address belongs to. Addresses only encode
-mainnet-vs-testnet, so preprod and preview cannot be told apart.
--}
-type NetKind
-    = MainKind
-    | TestKind
+type CertAction
+    = Register
+    | RegisterAndDelegate String
+    | DelegateOnly String
+    | Unregister
 
 
-{-| Result of cardano-wasm's inspectAddress for one address.
--}
-type AddrCheck
-    = CheckInvalid
-    | CheckValid NetKind
-    | CheckFailed -- the checker itself errored; not a verdict about the address
+type alias Certificate =
+    { wallet : WalletId
+    , action : CertAction
+    }
+
+
+type alias Pool =
+    { idBech32 : String
+    , idHex : String
+    , liveStake : Int
+    , saturation : Float
+    }
 
 
 type Era
@@ -122,6 +123,22 @@ type alias SignedPayload =
     { cbor : String, txId : String }
 
 
+{-| Which family of networks an address belongs to. Addresses only encode
+mainnet-vs-testnet, so preprod and preview cannot be told apart.
+-}
+type NetKind
+    = MainKind
+    | TestKind
+
+
+{-| Result of cardano-wasm's inspectAddress for one address.
+-}
+type AddrCheck
+    = CheckInvalid
+    | CheckValid NetKind
+    | CheckFailed -- the checker itself errored; not a verdict about the address
+
+
 type TxState
     = Draft
     | Signing
@@ -135,17 +152,28 @@ type SubmitState
     | SubmitFailed String
 
 
+type DelegKind
+    = RegThenDeleg
+    | DelegOnly
+
+
+type PoolPurpose
+    = ForNewCert WalletId DelegKind
+    | ForEditCert Int
+
+
 type Modal
     = NoModal
+    | PoolPicker PoolPurpose String
     | ForgetDialog WalletId
-
-
-type alias BookForm =
-    { open : Bool, alias : String, address : String }
 
 
 type alias RestoreForm =
     { open : Bool, paymentSkey : String, stakeSkey : String }
+
+
+type alias BookForm =
+    { open : Bool, alias : String, address : String }
 
 
 type LogLevel
@@ -164,8 +192,8 @@ type alias GenPayload =
 
 
 {-| The two protocol parameters the Elm side needs for its balance arithmetic.
-Read from web/pparams.js at startup (see web/ports.js) so the pinned object is
-the single source of truth; everything else in it is consumed only by
+Read from web/pparams.json at startup (see web/ports.js) so the pinned file is
+the single source of truth; everything else in that file is consumed only by
 cardano-wasm's estimateMinFee.
 -}
 type alias Protocol =
@@ -187,18 +215,21 @@ type alias Model =
     , nextWid : Int
     , book : List BookEntry
     , outputs : List Output
+    , certs : List Certificate
     , era : Era
     , fee : FeeState
     , feeText : String
     , tx : TxState
     , submit : SubmitState
+    , pools : Loadable (List Pool) -- the page of pools currently shown in the picker
+    , poolPage : Int -- its 1-based page number (Blockfrost pages, 100 pools each)
     , modal : Modal
-    , bfKeys : BfKeys
     , restore : RestoreForm
     , bookForm : BookForm
     , console : List LogLine
     , toast : Maybe String
     , toastSeq : Int
+    , bfKeys : BfKeys
     , addrChecks : Dict String AddrCheck -- inspectAddress results, keyed by address
     , protocol : Protocol
     }
@@ -210,6 +241,7 @@ type alias BfKeys =
 
 type Msg
     = SelectNetwork Network
+    | UpdateBfKey String
     | ClickNewWallet
     | GotGeneratedWallet (Result String GenPayload)
     | ClickRestoreToggle
@@ -224,7 +256,6 @@ type Msg
     | RequestForget WalletId
     | ConfirmForget WalletId
     | CancelForget
-    | UpdateBfKey String
     | ClickLoadUtxos WalletId
     | ClickLoadAll
     | GotUtxos WalletId Network (Result String UtxoPage)
@@ -239,16 +270,26 @@ type Msg
     | UpdateOutputAmount Int String
     | ToggleOutputChange Int
     | DeleteOutput Int
+    | SetWalletCert WalletId String
+    | DeleteCertificate Int
+    | ChangeCertPool Int
     | ClearInputs
     | ClearOutputs
+    | ClearCerts
     | ClearTx
-    | GotAddressInspected (Result String ( String, AddrCheck ))
+    | UpdatePoolSearch String
+    | PickPool String
+    | ClosePoolModal
+    | ClickLoadPools
+    | ClickPoolPage Int
+    | GotPools (Result String (List Pool))
     | SelectEra Era
     | ClickEstimateFee
     | GotFeeEstimated (Result String Int)
     | UpdateFeeText String
     | ClickSign
     | GotTxSigned (Result String SignedPayload)
+    | GotAddressInspected (Result String ( String, AddrCheck ))
     | ClickDownloadCli
     | ClickSubmit
     | GotSubmitted String (Result String String)

--- a/cardano-wasm/demo/src/Update.elm
+++ b/cardano-wasm/demo/src/Update.elm
@@ -39,30 +39,17 @@ inspectIfNew model a =
 openPool : PoolPurpose -> Model -> ( Model, Cmd Msg )
 openPool purpose model =
     let
-        shouldFetch =
-            currentKey model /= "" && (model.pools == NotAsked || isFailed model.pools)
+        opened =
+            { model | modal = PoolPicker purpose "" }
     in
-    ( { model
-        | modal = PoolPicker purpose ""
-        , pools =
-            if shouldFetch then
-                Loading
+    if currentKey model /= "" && (model.pools == NotAsked || isFailed model.pools) then
+        ( { opened | pools = Loading, poolPage = 1 }
+            |> log LogInfo "GET blockfrost /pools/extended · page 1"
+        , Blockfrost.fetchPools (currentKey model) model.network 1
+        )
 
-            else
-                model.pools
-        , poolPage =
-            if shouldFetch then
-                1
-
-            else
-                model.poolPage
-      }
-    , if shouldFetch then
-        Blockfrost.fetchPools (currentKey model) model.network 1
-
-      else
-        Cmd.none
-    )
+    else
+        ( opened, Cmd.none )
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -366,27 +353,35 @@ update msg model =
 
         -- ── certificates ───────────────────────────────────────────────────────
         SetWalletCert wid raw ->
-            -- The select is bound to the wallet's current certificate: changing it
-            -- replaces (or clears) that wallet's cert; "" = no certificate.
+            -- The select is bound to the wallet's current certificate: "reg"/"unreg"
+            -- and "" replace or clear it immediately; the delegation entries only
+            -- open the picker — the replacement happens at PickPool, so cancelling
+            -- the picker leaves the previous certificate (and the fee) untouched.
             let
-                cleared =
-                    { model | certs = List.filter (\c -> c.wallet /= wid) model.certs } |> invalidateShape
+                without =
+                    List.filter (\c -> c.wallet /= wid) model.certs
             in
             case raw of
                 "reg" ->
-                    ( addCert (Certificate wid Register) cleared |> log LogCmd (aliasOf wid model ++ ": register cert"), Cmd.none )
+                    ( addCert (Certificate wid Register) { model | certs = without }
+                        |> log LogInfo (aliasOf wid model ++ ": register cert")
+                    , Cmd.none
+                    )
 
                 "unreg" ->
-                    ( addCert (Certificate wid Unregister) cleared |> log LogCmd (aliasOf wid model ++ ": unregister cert"), Cmd.none )
+                    ( addCert (Certificate wid Unregister) { model | certs = without }
+                        |> log LogInfo (aliasOf wid model ++ ": unregister cert")
+                    , Cmd.none
+                    )
 
                 "deleg" ->
-                    openPool (ForNewCert wid RegThenDeleg) cleared
+                    openPool (ForNewCert wid RegThenDeleg) model
 
                 "delegonly" ->
-                    openPool (ForNewCert wid DelegOnly) cleared
+                    openPool (ForNewCert wid DelegOnly) model
 
                 _ ->
-                    ( cleared, Cmd.none )
+                    ( { model | certs = without } |> invalidateShape, Cmd.none )
 
         DeleteCertificate i ->
             ( { model | certs = removeAt i model.certs } |> invalidateShape, Cmd.none )
@@ -408,25 +403,31 @@ update msg model =
             , Cmd.none
             )
 
-        PickPool pid ->
+        PickPool ref ->
             case model.modal of
                 PoolPicker (ForNewCert wid kind) _ ->
                     let
                         action =
                             case kind of
                                 RegThenDeleg ->
-                                    RegisterAndDelegate pid
+                                    RegisterAndDelegate ref
 
                                 DelegOnly ->
-                                    DelegateOnly pid
+                                    DelegateOnly ref
                     in
-                    ( addCert (Certificate wid action) { model | modal = NoModal }
-                        |> log LogCmd (aliasOf wid model ++ ": delegate to " ++ pid)
+                    -- the wallet's previous certificate is replaced only now, on a
+                    -- confirmed pick — closing the picker instead leaves it as it was
+                    ( addCert (Certificate wid action)
+                        { model
+                            | certs = List.filter (\c -> c.wallet /= wid) model.certs
+                            , modal = NoModal
+                        }
+                        |> log LogInfo (aliasOf wid model ++ ": delegate to " ++ ref.bech32)
                     , Cmd.none
                     )
 
                 PoolPicker (ForEditCert i) _ ->
-                    ( { model | certs = updateAt i (setCertPool pid) model.certs, modal = NoModal } |> invalidateShape, Cmd.none )
+                    ( { model | certs = updateAt i (setCertPool ref) model.certs, modal = NoModal } |> invalidateShape, Cmd.none )
 
                 _ ->
                     ( model, Cmd.none )
@@ -442,31 +443,45 @@ update msg model =
 
             else
                 ( { model | pools = Loading, poolPage = 1 }
+                    |> log LogInfo "GET blockfrost /pools/extended · page 1"
                 , Blockfrost.fetchPools (currentKey model) model.network 1
                 )
 
         ClickPoolPage page ->
             -- prev/next navigation: each view is exactly one server page, so shifting
             -- offsets can never show duplicates. Only fetched on click.
-            if page < 1 || currentKey model == "" then
+            if currentKey model == "" then
+                toastNow "Enter a Blockfrost project id first" model
+
+            else if page < 1 then
                 ( model, Cmd.none )
 
             else
                 ( { model | pools = Loading, poolPage = page }
+                    |> log LogInfo ("GET blockfrost /pools/extended · page " ++ String.fromInt page)
                 , Blockfrost.fetchPools (currentKey model) model.network page
                 )
 
-        GotPools (Ok ps) ->
-            ( { model | pools = Loaded ps }
-                |> log LogOk ("loaded " ++ String.fromInt (List.length ps) ++ " pools (page " ++ String.fromInt model.poolPage ++ ")")
-            , Cmd.none
-            )
+        GotPools network page result ->
+            -- accepted only for the network and page currently asked for: a reply
+            -- that was in flight across a network switch (or a second page click)
+            -- must not resurface as the shown list (the GotUtxos stamp idiom)
+            if network /= model.network || page /= model.poolPage then
+                ( model |> log LogWarn "dropped a stale pool list (network or page changed)", Cmd.none )
 
-        GotPools (Err e) ->
-            ( { model | pools = Failed e }
-                |> log LogWarn ("pool list failed: " ++ e)
-            , Cmd.none
-            )
+            else
+                case result of
+                    Ok pp ->
+                        ( { model | pools = Loaded pp }
+                            |> log LogOk ("loaded " ++ String.fromInt (List.length pp.pools) ++ " pools (page " ++ String.fromInt page ++ ")")
+                        , Cmd.none
+                        )
+
+                    Err e ->
+                        ( { model | pools = Failed e }
+                            |> log LogWarn ("pool list failed: " ++ e)
+                        , Cmd.none
+                        )
 
         -- ── era & fee ──────────────────────────────────────────────────────────
         SelectEra e ->
@@ -623,8 +638,22 @@ update msg model =
 
                                 else
                                     log LogWarn ("txid mismatch! wasm said " ++ expected ++ " but Blockfrost returned " ++ txid)
+
+                            -- an already-executed certificate left in the builder makes
+                            -- the NEXT transaction invalid outright — worth a nudge
+                            certReminder =
+                                if List.isEmpty model.certs then
+                                    identity
+
+                                else
+                                    log LogInfo "certificates stay in the builder — clear them before building the next transaction"
                         in
-                        ( { model | submit = Submitted txid } |> log LogOk ("submitted · txid " ++ txid) |> consistency, Cmd.none )
+                        ( { model | submit = Submitted txid }
+                            |> log LogOk ("submitted · txid " ++ txid)
+                            |> consistency
+                            |> certReminder
+                        , Cmd.none
+                        )
 
                     Err e ->
                         let

--- a/cardano-wasm/demo/src/Update.elm
+++ b/cardano-wasm/demo/src/Update.elm
@@ -1,7 +1,7 @@
 module Update exposing (update)
 
 {-| The controller: every Msg in one `update`. Pure state changes call State
-helpers; effects go through Wasm (ports).
+helpers; effects go through Wasm (ports), Blockfrost (HTTP), or File.Download.
 -}
 
 import Blockfrost
@@ -34,6 +34,37 @@ inspectIfNew model a =
             Wasm.inspectAddress a
 
 
+{-| Open the pool picker; fetch the pool list (once) if we have a key and none yet.
+-}
+openPool : PoolPurpose -> Model -> ( Model, Cmd Msg )
+openPool purpose model =
+    let
+        shouldFetch =
+            currentKey model /= "" && (model.pools == NotAsked || isFailed model.pools)
+    in
+    ( { model
+        | modal = PoolPicker purpose ""
+        , pools =
+            if shouldFetch then
+                Loading
+
+            else
+                model.pools
+        , poolPage =
+            if shouldFetch then
+                1
+
+            else
+                model.poolPage
+      }
+    , if shouldFetch then
+        Blockfrost.fetchPools (currentKey model) model.network 1
+
+      else
+        Cmd.none
+    )
+
+
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
@@ -42,19 +73,29 @@ update msg model =
 
         -- ── network ────────────────────────────────────────────────────────────
         SelectNetwork n ->
-            -- Balances are network-specific and swept. Wallet keys survive a network
-            -- switch; addresses are re-derived below (the bech32 encoding is
-            -- network-specific, the keys are not). Loads pause while the
-            -- re-derivation is pending so no request carries a stale address.
-            ( { model
-                | network = n
-                , wallets = List.map (\w -> { w | utxos = NotAsked }) model.wallets
-                , deriving = not (List.isEmpty model.wallets)
-                , reloading = Set.empty
-                , outputs = []
-              }
-                |> invalidateShape
-                |> log LogInfo ("switched to " ++ netName n)
+            -- Everything network-specific is swept: balances, tx draft, fee, and the
+            -- pool list (pools differ per network!). Wallet keys survive; addresses
+            -- are re-derived below. addrChecks survive too (an address's network kind
+            -- is intrinsic to the address, not to the selected network).
+            let
+                swept =
+                    { model
+                        | network = n
+                        , wallets = List.map (\w -> { w | utxos = NotAsked }) model.wallets
+                        , outputs = []
+                        , certs = []
+                        , modal = NoModal
+                        , pools = NotAsked
+                        , poolPage = 1
+
+                        -- loads pause until the new network's addresses arrive
+                        , deriving = not (List.isEmpty model.wallets)
+                        , reloading = Set.empty
+                    }
+                        |> invalidateShape
+                        |> log LogInfo ("switched to " ++ netName n ++ " — cleared inputs, outputs, certs")
+            in
+            ( swept
             , if List.isEmpty model.wallets then
                 Cmd.none
 
@@ -82,6 +123,9 @@ update msg model =
 
         GotDerivedAddresses (Err e) ->
             ( log LogWarn ("derive addresses failed: " ++ e) { model | deriving = False }, Cmd.none )
+
+        UpdateBfKey v ->
+            ( setCurrentKey v model, Cmd.none )
 
         -- ── wallets: generate / restore / edit / forget ────────────────────────
         ClickNewWallet ->
@@ -135,6 +179,7 @@ update msg model =
         ConfirmForget wid ->
             ( { model
                 | wallets = List.filter (\w -> w.id /= wid) model.wallets
+                , certs = List.filter (\c -> c.wallet /= wid) model.certs
                 , modal = NoModal
               }
                 |> invalidateShape
@@ -143,9 +188,6 @@ update msg model =
             )
 
         -- ── UTxOs (Blockfrost reads) ───────────────────────────────────────────
-        UpdateBfKey v ->
-            ( setCurrentKey v model, Cmd.none )
-
         ClickLoadUtxos wid ->
             case getWallet wid model of
                 Just w ->
@@ -322,15 +364,109 @@ update msg model =
         DeleteOutput i ->
             ( { model | outputs = removeAt i model.outputs } |> invalidateShape, Cmd.none )
 
-        -- ── clearing ───────────────────────────────────────────────────────────
-        ClearInputs ->
-            ( deselectInputs model |> invalidateShape, Cmd.none )
+        -- ── certificates ───────────────────────────────────────────────────────
+        SetWalletCert wid raw ->
+            -- The select is bound to the wallet's current certificate: changing it
+            -- replaces (or clears) that wallet's cert; "" = no certificate.
+            let
+                cleared =
+                    { model | certs = List.filter (\c -> c.wallet /= wid) model.certs } |> invalidateShape
+            in
+            case raw of
+                "reg" ->
+                    ( addCert (Certificate wid Register) cleared |> log LogCmd (aliasOf wid model ++ ": register cert"), Cmd.none )
 
-        ClearOutputs ->
-            ( { model | outputs = [] } |> invalidateShape, Cmd.none )
+                "unreg" ->
+                    ( addCert (Certificate wid Unregister) cleared |> log LogCmd (aliasOf wid model ++ ": unregister cert"), Cmd.none )
 
-        ClearTx ->
-            ( deselectInputs { model | outputs = [] } |> invalidateShape, Cmd.none )
+                "deleg" ->
+                    openPool (ForNewCert wid RegThenDeleg) cleared
+
+                "delegonly" ->
+                    openPool (ForNewCert wid DelegOnly) cleared
+
+                _ ->
+                    ( cleared, Cmd.none )
+
+        DeleteCertificate i ->
+            ( { model | certs = removeAt i model.certs } |> invalidateShape, Cmd.none )
+
+        ChangeCertPool i ->
+            openPool (ForEditCert i) model
+
+        -- ── pool picker ────────────────────────────────────────────────────────
+        UpdatePoolSearch s ->
+            ( { model
+                | modal =
+                    case model.modal of
+                        PoolPicker p _ ->
+                            PoolPicker p s
+
+                        other ->
+                            other
+              }
+            , Cmd.none
+            )
+
+        PickPool pid ->
+            case model.modal of
+                PoolPicker (ForNewCert wid kind) _ ->
+                    let
+                        action =
+                            case kind of
+                                RegThenDeleg ->
+                                    RegisterAndDelegate pid
+
+                                DelegOnly ->
+                                    DelegateOnly pid
+                    in
+                    ( addCert (Certificate wid action) { model | modal = NoModal }
+                        |> log LogCmd (aliasOf wid model ++ ": delegate to " ++ pid)
+                    , Cmd.none
+                    )
+
+                PoolPicker (ForEditCert i) _ ->
+                    ( { model | certs = updateAt i (setCertPool pid) model.certs, modal = NoModal } |> invalidateShape, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        ClosePoolModal ->
+            ( { model | modal = NoModal }, Cmd.none )
+
+        ClickLoadPools ->
+            -- (re)load the first page, from inside the picker (e.g. the key was
+            -- entered after opening it, or the fetch failed)
+            if currentKey model == "" then
+                toastNow "Enter a Blockfrost project id first" model
+
+            else
+                ( { model | pools = Loading, poolPage = 1 }
+                , Blockfrost.fetchPools (currentKey model) model.network 1
+                )
+
+        ClickPoolPage page ->
+            -- prev/next navigation: each view is exactly one server page, so shifting
+            -- offsets can never show duplicates. Only fetched on click.
+            if page < 1 || currentKey model == "" then
+                ( model, Cmd.none )
+
+            else
+                ( { model | pools = Loading, poolPage = page }
+                , Blockfrost.fetchPools (currentKey model) model.network page
+                )
+
+        GotPools (Ok ps) ->
+            ( { model | pools = Loaded ps }
+                |> log LogOk ("loaded " ++ String.fromInt (List.length ps) ++ " pools (page " ++ String.fromInt model.poolPage ++ ")")
+            , Cmd.none
+            )
+
+        GotPools (Err e) ->
+            ( { model | pools = Failed e }
+                |> log LogWarn ("pool list failed: " ++ e)
+            , Cmd.none
+            )
 
         -- ── era & fee ──────────────────────────────────────────────────────────
         SelectEra e ->
@@ -350,7 +486,7 @@ update msg model =
 
         ClickEstimateFee ->
             if not (txReady model) then
-                toastNow "Add inputs and a recipient, and fix any flagged issues" model
+                toastNow "Add inputs and a recipient or certificate, and fix any flagged issues" model
 
             else
                 -- a fresh estimate makes any existing signature's fee basis stale
@@ -396,7 +532,7 @@ update msg model =
             , Cmd.none
             )
 
-        -- ── sign / export ──────────────────────────────────────────────────────
+        -- ── sign / submit / export ─────────────────────────────────────────────
         ClickSign ->
             -- same predicate that enables the button (fee set + balanced + draft + ready)
             case ( canSign model, model.fee ) of
@@ -417,7 +553,7 @@ update msg model =
             else
                 case result of
                     Ok p ->
-                        ( { model | tx = Signed (SignedTx p.cbor p.txId (List.length (paymentWalletIds model)) 0), submit = NotSubmitted }
+                        ( { model | tx = Signed (SignedTx p.cbor p.txId (List.length (paymentWalletIds model)) (List.length (stakeWalletIds model))), submit = NotSubmitted }
                             |> log LogOk ("transaction signed · txid " ++ p.txId)
                         , Cmd.none
                         )
@@ -522,6 +658,19 @@ update msg model =
 
                 _ ->
                     ( model, Cmd.none )
+
+        -- ── clearing ───────────────────────────────────────────────────────────
+        ClearInputs ->
+            ( deselectInputs model |> invalidateShape, Cmd.none )
+
+        ClearOutputs ->
+            ( { model | outputs = [] } |> invalidateShape, Cmd.none )
+
+        ClearCerts ->
+            ( { model | certs = [] } |> invalidateShape, Cmd.none )
+
+        ClearTx ->
+            ( deselectInputs { model | outputs = [], certs = [] } |> invalidateShape, Cmd.none )
 
         -- ── misc ───────────────────────────────────────────────────────────────
         Copy t ->

--- a/cardano-wasm/demo/src/View.elm
+++ b/cardano-wasm/demo/src/View.elm
@@ -158,8 +158,21 @@ viewWallet model w =
                 -- bound to the wallet's current certificate; options come from
                 -- State.certMenu (the same codes the update parses)
                 , let
+                    -- While the picker is open for this wallet, show the pending
+                    -- choice: the certificate itself only changes at PickPool, so on
+                    -- cancel `cur` falls back and the vdom re-syncs the DOM select
+                    -- (a `selected` property is only patched when this value changes).
                     cur =
-                        walletCertAction w.id model
+                        case model.modal of
+                            PoolPicker (ForNewCert wid kind) _ ->
+                                if wid == w.id then
+                                    delegKindCode kind
+
+                                else
+                                    walletCertAction w.id model
+
+                            _ ->
+                                walletCertAction w.id model
                   in
                   select [ class "certsel", onChange (SetWalletCert w.id) ]
                     (List.map
@@ -507,8 +520,8 @@ viewCerts model =
                         wAlias =
                             aliasOf c.wallet model
 
-                        ( label_, poolMaybe ) =
-                            certLabel (loadedPools model) c.action
+                        ( label_, hasPool ) =
+                            certLabel c.action
                     in
                     div [ class "certrow" ]
                         [ span [ class "wav small", style "background" (getWallet c.wallet model |> Maybe.map .color |> Maybe.withDefault "#555") ]
@@ -517,12 +530,11 @@ viewCerts model =
                             [ b [] [ text wAlias ]
                             , div [ class "muted small" ] [ text label_ ]
                             ]
-                        , case poolMaybe of
-                            Just _ ->
-                                button [ class "btn ghost xs", onClick (ChangeCertPool i) ] [ text "pool" ]
+                        , if hasPool then
+                            button [ class "btn ghost xs", onClick (ChangeCertPool i) ] [ text "pool" ]
 
-                            Nothing ->
-                                text ""
+                          else
+                            text ""
                         , button [ class "x", onClick (DeleteCertificate i) ] [ text "×" ]
                         ]
                 )
@@ -530,29 +542,27 @@ viewCerts model =
             )
 
 
-certLabel : List Pool -> CertAction -> ( String, Maybe String )
-certLabel ps action =
+{-| Label + whether the action carries a pool (and so can offer a "pool" button).
+The pool is named by the ticker pinned at pick time, or its shortened bech32 id.
+-}
+certLabel : CertAction -> ( String, Bool )
+certLabel action =
     let
-        poolName pid =
-            case poolByIdIn ps pid of
-                Just p ->
-                    shorten p.idBech32
-
-                Nothing ->
-                    shorten pid
+        poolName ref =
+            Maybe.withDefault (shorten ref.bech32) ref.ticker
     in
     case action of
         Register ->
-            ( "Register", Nothing )
+            ( "Register", False )
 
         Unregister ->
-            ( "Unregister", Nothing )
+            ( "Unregister", False )
 
-        DelegateOnly pid ->
-            ( "Delegate only → " ++ poolName pid, Just pid )
+        DelegateOnly ref ->
+            ( "Delegate only → " ++ poolName ref, True )
 
-        RegisterAndDelegate pid ->
-            ( "Register + delegate → " ++ poolName pid, Just pid )
+        RegisterAndDelegate ref ->
+            ( "Register + delegate → " ++ poolName ref, True )
 
 
 viewSummary : Model -> Html Msg
@@ -815,7 +825,7 @@ inspectorText model =
                     (\c ->
                         let
                             ( lbl, _ ) =
-                                certLabel (loadedPools model) c.action
+                                certLabel c.action
                         in
                         "    { stakeKey: \"" ++ aliasOf c.wallet model ++ "\", action: \"" ++ lbl ++ "\" }"
                     )
@@ -950,13 +960,18 @@ viewPoolList model query =
                 ]
             ]
 
-        Loaded ps ->
+        Loaded page ->
             let
                 ql =
                     String.toLower query
 
                 matches =
-                    List.filter (\p -> String.contains ql (String.toLower p.idBech32)) ps
+                    List.filter
+                        (\p ->
+                            String.contains ql (String.toLower p.idBech32)
+                                || String.contains ql (String.toLower (Maybe.withDefault "" p.ticker))
+                        )
+                        page.pools
 
                 cards =
                     if List.isEmpty matches then
@@ -965,29 +980,30 @@ viewPoolList model query =
                     else
                         List.map viewPoolCard matches
             in
-            cards ++ [ viewPoolPager model (List.length ps) ]
+            cards ++ [ viewPoolPager model (List.length page.pools) page.hasMore ]
 
 
-{-| Prev/next pager. A full page (100) means there is probably a next one; a short
-page is the end of the list. Pages are only ever fetched on these clicks.
+{-| Prev/next pager. `hasMore` was computed where the page was fetched (a full
+Blockfrost page means a next one probably exists); a short page is the end of
+the list. Pages are only ever fetched on these clicks.
 -}
-viewPoolPager : Model -> Int -> Html Msg
-viewPoolPager model pageSize =
+viewPoolPager : Model -> Int -> Bool -> Html Msg
+viewPoolPager model count hasMore =
     div [ class "empty" ]
         [ button
             [ class "btn ghost xs", disabled (model.poolPage <= 1), onClick (ClickPoolPage (model.poolPage - 1)) ]
             [ text "◂ prev" ]
-        , text (" page " ++ String.fromInt model.poolPage ++ " · " ++ String.fromInt pageSize ++ " pools ")
+        , text (" page " ++ String.fromInt model.poolPage ++ " · " ++ String.fromInt count ++ " pools ")
         , button
-            [ class "btn ghost xs", disabled (pageSize < 100), onClick (ClickPoolPage (model.poolPage + 1)) ]
+            [ class "btn ghost xs", disabled (not hasMore), onClick (ClickPoolPage (model.poolPage + 1)) ]
             [ text "next ▸" ]
         ]
 
 
 viewPoolCard : Pool -> Html Msg
 viewPoolCard p =
-    div [ class "poolcard", onClick (PickPool p.idBech32) ]
-        [ span [ class "tk" ] [ text "◆" ]
+    div [ class "poolcard", onClick (PickPool { bech32 = p.idBech32, hex = p.idHex, ticker = p.ticker }) ]
+        [ span [ class "tk" ] [ text (Maybe.withDefault "◆" p.ticker) ]
         , div [ class "pm grow" ]
             [ b [ class "mono" ] [ text (shorten p.idBech32) ]
             , div [ class "d mono" ] [ text ("hex " ++ String.left 16 p.idHex ++ "…") ]
@@ -1030,4 +1046,4 @@ kvSecret k v =
 
 stopClick : Attribute Msg
 stopClick =
-    Html.Events.stopPropagationOn "click" (D.succeed ( NoOp, True ))
+    stopPropagationOn "click" (D.succeed ( NoOp, True ))

--- a/cardano-wasm/demo/src/View.elm
+++ b/cardano-wasm/demo/src/View.elm
@@ -1,17 +1,22 @@
 module View exposing (view)
 
-{-| The UI: wallets + address book column · transaction builder · inspector +
-console column, the forget dialog and the toast. Pure Model → Html.
+{-| The entire UI: three columns (wallets + address book · transaction builder ·
+inspector + console), the pool/forget modals and the toast. Pure Model → Html.
 -}
 
 import Format exposing (ada, adaToLovelace, amountError, lovelaceToAda, shorten)
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onInput, stopPropagationOn)
+import Html.Events exposing (on, onClick, onInput, stopPropagationOn, targetValue)
 import Json.Decode as D
 import Net exposing (cliFlag, eraTag, expectedNetKind, explorerTx, faucetUrl, netMagic, netName, netTag)
 import State exposing (..)
 import Types exposing (..)
+
+
+onChange : (String -> msg) -> Attribute msg
+onChange tagger =
+    on "change" (D.map tagger targetValue)
 
 
 view : Model -> Html Msg
@@ -149,6 +154,18 @@ viewWallet model w =
                         ]
                     , button [ class "btn xs danger", onClick (RequestForget w.id) ] [ text "🗑 forget" ]
                     ]
+
+                -- bound to the wallet's current certificate; options come from
+                -- State.certMenu (the same codes the update parses)
+                , let
+                    cur =
+                        walletCertAction w.id model
+                  in
+                  select [ class "certsel", onChange (SetWalletCert w.id) ]
+                    (List.map
+                        (\( code, lbl ) -> option [ value code, selected (code == cur) ] [ text lbl ])
+                        certMenu
+                    )
                 , viewWalletUtxos w
                 ]
 
@@ -345,6 +362,8 @@ viewBuilder model =
         , viewInputs model
         , sectionLabel "Outputs — add recipients from the address book" (not (List.isEmpty model.outputs)) ClearOutputs
         , viewOutputs model
+        , sectionLabel "Certificates — pick one in a wallet’s certificate menu" (not (List.isEmpty model.certs)) ClearCerts
+        , viewCerts model
         , viewSummary model
         , div [ class "hrow", style "margin-top" "12px" ]
             [ button [ class "btn ghost", disabled (not (txReady model)), onClick ClickEstimateFee ] [ text "⚙ estimateMinFee()" ]
@@ -475,21 +494,73 @@ viewOutputs model =
         div [] (List.indexedMap row model.outputs ++ hint)
 
 
-sectionLabel : String -> Bool -> Msg -> Html Msg
-sectionLabel txt canClear clearMsg =
-    div [ class "seclabel" ]
-        [ label [] [ text txt ]
-        , if canClear then
-            button [ class "btn ghost xs", onClick clearMsg ] [ text "clear" ]
+viewCerts : Model -> Html Msg
+viewCerts model =
+    if List.isEmpty model.certs then
+        div [ class "empty" ] [ text "No certificates yet — pick one in a wallet’s certificate menu" ]
 
-          else
-            text ""
-        ]
+    else
+        div []
+            (List.indexedMap
+                (\i c ->
+                    let
+                        wAlias =
+                            aliasOf c.wallet model
+
+                        ( label_, poolMaybe ) =
+                            certLabel (loadedPools model) c.action
+                    in
+                    div [ class "certrow" ]
+                        [ span [ class "wav small", style "background" (getWallet c.wallet model |> Maybe.map .color |> Maybe.withDefault "#555") ]
+                            [ text (String.left 1 wAlias |> String.toUpper) ]
+                        , div [ class "grow" ]
+                            [ b [] [ text wAlias ]
+                            , div [ class "muted small" ] [ text label_ ]
+                            ]
+                        , case poolMaybe of
+                            Just _ ->
+                                button [ class "btn ghost xs", onClick (ChangeCertPool i) ] [ text "pool" ]
+
+                            Nothing ->
+                                text ""
+                        , button [ class "x", onClick (DeleteCertificate i) ] [ text "×" ]
+                        ]
+                )
+                model.certs
+            )
+
+
+certLabel : List Pool -> CertAction -> ( String, Maybe String )
+certLabel ps action =
+    let
+        poolName pid =
+            case poolByIdIn ps pid of
+                Just p ->
+                    shorten p.idBech32
+
+                Nothing ->
+                    shorten pid
+    in
+    case action of
+        Register ->
+            ( "Register", Nothing )
+
+        Unregister ->
+            ( "Unregister", Nothing )
+
+        DelegateOnly pid ->
+            ( "Delegate only → " ++ poolName pid, Just pid )
+
+        RegisterAndDelegate pid ->
+            ( "Register + delegate → " ++ poolName pid, Just pid )
 
 
 viewSummary : Model -> Html Msg
 viewSummary model =
     let
+        dep =
+            depositTotal model
+
         ( changeLabel, changeText ) =
             case ( model.fee, balance model ) of
                 ( FeeSet _, Balanced ch ) ->
@@ -507,6 +578,7 @@ viewSummary model =
     div [ class "summary" ]
         [ kv "Input total" (ada (inputsTotal model))
         , kv "Output total" (ada (explicitOutputsTotal model))
+        , kv "Deposit" (ada dep)
         , kv "Fee" (feeDisplay model)
         , kv changeLabel changeText
         , kv "Witnesses" (witnessSummary model)
@@ -547,12 +619,18 @@ witnessSummary model =
     let
         pays =
             paymentWalletIds model |> List.map (\wid -> aliasOf wid model ++ " (payment)")
+
+        stakes =
+            stakeWalletIds model |> List.map (\wid -> aliasOf wid model ++ " (stake)")
+
+        parts =
+            pays ++ stakes
     in
-    if List.isEmpty pays then
+    if List.isEmpty parts then
         "—"
 
     else
-        String.join ", " pays ++ " · " ++ String.fromInt (witnessCount model)
+        String.join ", " parts ++ " · " ++ String.fromInt (witnessCount model)
 
 
 viewExport : Model -> Html Msg
@@ -730,6 +808,18 @@ inspectorText model =
                     )
                 |> (\explicit -> explicit ++ implicitChange)
                 |> String.join ",\n"
+
+        certs =
+            model.certs
+                |> List.map
+                    (\c ->
+                        let
+                            ( lbl, _ ) =
+                                certLabel (loadedPools model) c.action
+                        in
+                        "    { stakeKey: \"" ++ aliasOf c.wallet model ++ "\", action: \"" ++ lbl ++ "\" }"
+                    )
+                |> String.join ",\n"
     in
     "{\n  era: \""
         ++ eraTag model.era
@@ -737,11 +827,25 @@ inspectorText model =
         ++ ins
         ++ "\n  ],\n  outputs: [\n"
         ++ outs
+        ++ "\n  ],\n  certs: [\n"
+        ++ certs
         ++ "\n  ],\n  fee: "
         ++ specFee
         ++ ",\n  requiredWitnesses: "
         ++ String.fromInt (witnessCount model)
         ++ "\n}"
+
+
+sectionLabel : String -> Bool -> Msg -> Html Msg
+sectionLabel txt canClear clearMsg =
+    div [ class "seclabel" ]
+        [ label [] [ text txt ]
+        , if canClear then
+            button [ class "btn ghost xs", onClick clearMsg ] [ text "clear" ]
+
+          else
+            text ""
+        ]
 
 
 viewConsole : Model -> Html Msg
@@ -813,6 +917,92 @@ viewModal model =
                     ]
                 ]
 
+        PoolPicker _ query ->
+            div [ class "modal-bg" ]
+                [ div [ class "modal" ]
+                    [ div [ class "mh" ]
+                        [ h3 [] [ text "Choose a stake pool" ]
+                        , input [ class "poolsearch", placeholder "search ticker or id…", value query, onInput UpdatePoolSearch ] []
+                        , button [ class "btn ghost x", onClick ClosePoolModal ] [ text "✕" ]
+                        ]
+                    , div [ class "mb" ] (viewPoolList model query)
+                    ]
+                ]
+
+
+viewPoolList : Model -> String -> List (Html Msg)
+viewPoolList model query =
+    case model.pools of
+        NotAsked ->
+            [ div [ class "empty" ]
+                [ text "pools not loaded — enter a Blockfrost project id, then "
+                , button [ class "btn ghost xs", onClick ClickLoadPools ] [ text "load pools" ]
+                ]
+            ]
+
+        Loading ->
+            [ div [ class "empty" ] [ text "loading pools from Blockfrost…" ] ]
+
+        Failed e ->
+            [ div [ class "empty" ]
+                [ text ("failed: " ++ e ++ " ")
+                , button [ class "btn ghost xs", onClick (ClickPoolPage model.poolPage) ] [ text "retry" ]
+                ]
+            ]
+
+        Loaded ps ->
+            let
+                ql =
+                    String.toLower query
+
+                matches =
+                    List.filter (\p -> String.contains ql (String.toLower p.idBech32)) ps
+
+                cards =
+                    if List.isEmpty matches then
+                        [ div [ class "empty" ] [ text "no pools match (search covers this page only)" ] ]
+
+                    else
+                        List.map viewPoolCard matches
+            in
+            cards ++ [ viewPoolPager model (List.length ps) ]
+
+
+{-| Prev/next pager. A full page (100) means there is probably a next one; a short
+page is the end of the list. Pages are only ever fetched on these clicks.
+-}
+viewPoolPager : Model -> Int -> Html Msg
+viewPoolPager model pageSize =
+    div [ class "empty" ]
+        [ button
+            [ class "btn ghost xs", disabled (model.poolPage <= 1), onClick (ClickPoolPage (model.poolPage - 1)) ]
+            [ text "◂ prev" ]
+        , text (" page " ++ String.fromInt model.poolPage ++ " · " ++ String.fromInt pageSize ++ " pools ")
+        , button
+            [ class "btn ghost xs", disabled (pageSize < 100), onClick (ClickPoolPage (model.poolPage + 1)) ]
+            [ text "next ▸" ]
+        ]
+
+
+viewPoolCard : Pool -> Html Msg
+viewPoolCard p =
+    div [ class "poolcard", onClick (PickPool p.idBech32) ]
+        [ span [ class "tk" ] [ text "◆" ]
+        , div [ class "pm grow" ]
+            [ b [ class "mono" ] [ text (shorten p.idBech32) ]
+            , div [ class "d mono" ] [ text ("hex " ++ String.left 16 p.idHex ++ "…") ]
+            ]
+        , div [ class "stats" ]
+            [ statBox "live ₳" (lovelaceToAda p.liveStake)
+            , statBox "sat" (String.fromInt (round (p.saturation * 100)) ++ "%")
+            ]
+        ]
+
+
+statBox : String -> String -> Html Msg
+statBox lbl v =
+    div [] [ span [] [ text lbl ], text v ]
+
 
 viewToast : Model -> Html Msg
 viewToast model =
@@ -840,4 +1030,4 @@ kvSecret k v =
 
 stopClick : Attribute Msg
 stopClick =
-    stopPropagationOn "click" (D.succeed ( NoOp, True ))
+    Html.Events.stopPropagationOn "click" (D.succeed ( NoOp, True ))

--- a/cardano-wasm/demo/src/Wasm.elm
+++ b/cardano-wasm/demo/src/Wasm.elm
@@ -15,9 +15,9 @@ module Wasm exposing
 
 {-| The cardano-wasm boundary. Commands encode a request and send it out a port;
 results come back on the matching incoming port and are decoded here (see the
-subscriptions in Main). The Cardano processing itself — key handling, address encoding, transaction
-building, fee estimation and signing — happens in web/ports.js through the
-cardano-wasm wrapper.
+subscriptions in Main). The Cardano processing itself — key handling, transaction
+building, fee estimation, signing — happens on the JS side (web/ports.js) through
+the cardano-wasm wrapper; the JSON built here just describes the transaction.
 -}
 
 import Format
@@ -76,6 +76,160 @@ deriveAddresses net wallets =
         )
 
 
+{-| Ask for the minimum fee of the currently described transaction.
+-}
+estimateFee : Model -> Cmd msg
+estimateFee model =
+    Ports.wasmEstimateFee
+        (E.object
+            [ ( "spec", encodeSpec Nothing model )
+            , ( "paymentWits", E.int (List.length (paymentWalletIds model)) )
+            , ( "stakeWits", E.int (List.length (stakeWalletIds model)) )
+            ]
+        )
+
+
+{-| Build, balance (fee + change already decided in Elm) and sign the transaction.
+-}
+signTx : Int -> Model -> Cmd msg
+signTx fee model =
+    Ports.wasmSignTx
+        (E.object
+            [ ( "spec", encodeSpec (Just fee) model )
+            , ( "paymentKeys", E.list E.string (paymentSigningKeys model) )
+            , ( "stakeKeys", E.list E.string (stakeSigningKeys model) )
+            ]
+        )
+
+
+{-| Validate an address and detect its network kind.
+-}
+inspectAddress : String -> Cmd msg
+inspectAddress addr =
+    Ports.wasmInspectAddress (E.object [ ( "address", E.string addr ) ])
+
+
+
+-- TX SPEC
+-- The JSON description of the transaction that web/ports.js replays against the
+-- cardano-wasm builder (newTx → addTxInput → addSimpleTxOut → appendCertificateToTx).
+
+
+encodeSpec : Maybe Int -> Model -> E.Value
+encodeSpec maybeFee model =
+    E.object
+        [ ( "era", E.string (eraTag model.era) )
+        , ( "inputs"
+          , E.list
+                (\( _, u ) -> E.object [ ( "txId", E.string u.txId ), ( "txIx", E.int u.txIx ) ])
+                (selectedInputs model)
+          )
+        , ( "outputs", E.list identity (finalOutputs (Maybe.withDefault 0 maybeFee) model) )
+        , ( "certs", E.list identity (List.concatMap (certJson model) model.certs) )
+        , ( "fee", maybeFee |> Maybe.map E.int |> Maybe.withDefault E.null )
+        ]
+
+
+{-| The explicit outputs plus the computed change output (if there is a remainder).
+For fee estimation the fee is still unknown (0) — the change is then slightly too
+large, and if the real change turns out to be exactly 0 the estimated transaction
+even carries one output more. Either way the real transaction is never larger
+than the estimated one, so the estimate can only over-pay, never under-pay.
+-}
+finalOutputs : Int -> Model -> List E.Value
+finalOutputs feeForChange model =
+    let
+        explicit =
+            model.outputs
+                |> List.filterMap
+                    (\o ->
+                        case o.amount of
+                            Lovelace s ->
+                                Format.adaToLovelace s
+                                    |> Maybe.map (\l -> outputJson o.address l)
+
+                            Change ->
+                                Nothing
+                    )
+
+        chg =
+            inputsTotal model - explicitOutputsTotal model - depositTotal model - feeForChange
+
+        changeOut =
+            case ( changeAddress model, chg > 0 ) of
+                ( Just addr, True ) ->
+                    [ outputJson addr chg ]
+
+                _ ->
+                    []
+    in
+    explicit ++ changeOut
+
+
+outputJson : String -> Int -> E.Value
+outputJson addr lovelace =
+    E.object [ ( "address", E.string addr ), ( "lovelace", E.int lovelace ) ]
+
+
+{-| A certificate as JSON; "register + delegate" becomes two certificates.
+NOTE: the unregistration refund must equal the deposit paid at registration. We use
+the current keyDeposit — correct unless the protocol parameter changed in between
+(fine for a demo).
+-}
+certJson : Model -> Certificate -> List E.Value
+certJson model c =
+    let
+        skh =
+            stakeHashOf c.wallet model
+
+        reg =
+            E.object [ ( "action", E.string "register" ), ( "stakeKeyHash", E.string skh ), ( "deposit", E.int model.protocol.keyDeposit ) ]
+
+        unreg =
+            E.object [ ( "action", E.string "unregister" ), ( "stakeKeyHash", E.string skh ), ( "deposit", E.int model.protocol.keyDeposit ) ]
+
+        deleg pid =
+            E.object
+                [ ( "action", E.string "delegate" )
+                , ( "stakeKeyHash", E.string skh )
+                , ( "poolId", E.string (poolHex model pid) )
+                ]
+    in
+    case c.action of
+        Register ->
+            [ reg ]
+
+        Unregister ->
+            [ unreg ]
+
+        DelegateOnly pid ->
+            [ deleg pid ]
+
+        RegisterAndDelegate pid ->
+            [ reg, deleg pid ]
+
+
+
+-- SIGNING KEYS
+-- Payment witnesses for the wallets whose UTxOs are spent; stake witnesses
+-- (alsoSignWithStakeKey) for the wallets that carry a certificate. Registration
+-- alone wouldn't need a stake witness, but an extra witness is harmless.
+
+
+paymentSigningKeys : Model -> List String
+paymentSigningKeys model =
+    paymentWalletIds model
+        |> List.filterMap (\wid -> getWallet wid model)
+        |> List.map (\w -> w.keys.paymentSKey)
+
+
+stakeSigningKeys : Model -> List String
+stakeSigningKeys model =
+    stakeWalletIds model
+        |> List.filterMap (\wid -> getWallet wid model)
+        |> List.map (\w -> w.keys.stakeSKey)
+
+
 
 -- DECODERS (in ← cardano-wasm)
 
@@ -115,11 +269,16 @@ addrsDecoder =
     D.list (D.map2 Tuple.pair (D.field "id" D.int) (D.field "address" D.string))
 
 
-{-| Validate an address and detect its network kind.
--}
-inspectAddress : String -> Cmd msg
-inspectAddress addr =
-    Ports.wasmInspectAddress (E.object [ ( "address", E.string addr ) ])
+feeDecoder : D.Decoder Int
+feeDecoder =
+    D.field "fee" D.int
+
+
+signedDecoder : D.Decoder SignedPayload
+signedDecoder =
+    D.map2 SignedPayload
+        (D.field "cbor" D.string)
+        (D.field "txId" D.string)
 
 
 inspectedDecoder : D.Decoder ( String, AddrCheck )
@@ -145,115 +304,3 @@ inspectedDecoder =
                             CheckFailed
                 )
         )
-
-
-{-| Ask for the minimum fee of the currently described transaction.
--}
-estimateFee : Model -> Cmd msg
-estimateFee model =
-    Ports.wasmEstimateFee
-        (E.object
-            [ ( "spec", encodeSpec Nothing model )
-            , ( "paymentWits", E.int (List.length (paymentWalletIds model)) )
-            , ( "stakeWits", E.int 0 ) -- stake witnesses arrive with certificates
-            ]
-        )
-
-
-{-| Build, balance (fee + change already decided in Elm) and sign the transaction.
--}
-signTx : Int -> Model -> Cmd msg
-signTx fee model =
-    Ports.wasmSignTx
-        (E.object
-            [ ( "spec", encodeSpec (Just fee) model )
-            , ( "paymentKeys", E.list E.string (paymentSigningKeys model) )
-            , ( "stakeKeys", E.list E.string [] ) -- stake keys arrive with certificates
-            ]
-        )
-
-
-
--- TX SPEC
--- The JSON description of the transaction that web/ports.js replays against the
--- cardano-wasm builder (newTx → addTxInput → addSimpleTxOut).
-
-
-encodeSpec : Maybe Int -> Model -> E.Value
-encodeSpec maybeFee model =
-    E.object
-        [ ( "era", E.string (eraTag model.era) )
-        , ( "inputs"
-          , E.list
-                (\( _, u ) -> E.object [ ( "txId", E.string u.txId ), ( "txIx", E.int u.txIx ) ])
-                (selectedInputs model)
-          )
-        , ( "outputs", E.list identity (finalOutputs (Maybe.withDefault 0 maybeFee) model) )
-        , ( "certs", E.list identity [] ) -- certificates arrive in a later change
-        , ( "fee", maybeFee |> Maybe.map E.int |> Maybe.withDefault E.null )
-        ]
-
-
-{-| The explicit outputs plus the computed change output (if there is a remainder).
-For fee estimation the fee is still unknown (0) — the change is then slightly too
-large, and if the real change turns out to be exactly 0 the estimated transaction
-even carries one output more. Either way the real transaction is never larger
-than the estimated one, so the estimate can only over-pay, never under-pay.
--}
-finalOutputs : Int -> Model -> List E.Value
-finalOutputs feeForChange model =
-    let
-        explicit =
-            model.outputs
-                |> List.filterMap
-                    (\o ->
-                        case o.amount of
-                            Lovelace s ->
-                                Format.adaToLovelace s
-                                    |> Maybe.map (\l -> outputJson o.address l)
-
-                            Change ->
-                                Nothing
-                    )
-
-        chg =
-            inputsTotal model - explicitOutputsTotal model - feeForChange
-
-        changeOut =
-            case ( changeAddress model, chg > 0 ) of
-                ( Just addr, True ) ->
-                    [ outputJson addr chg ]
-
-                _ ->
-                    []
-    in
-    explicit ++ changeOut
-
-
-outputJson : String -> Int -> E.Value
-outputJson addr lovelace =
-    E.object [ ( "address", E.string addr ), ( "lovelace", E.int lovelace ) ]
-
-
-
--- SIGNING KEYS
--- Payment witnesses for the wallets whose UTxOs are spent.
-
-
-paymentSigningKeys : Model -> List String
-paymentSigningKeys model =
-    paymentWalletIds model
-        |> List.filterMap (\wid -> getWallet wid model)
-        |> List.map (\w -> w.keys.paymentSKey)
-
-
-feeDecoder : D.Decoder Int
-feeDecoder =
-    D.field "fee" D.int
-
-
-signedDecoder : D.Decoder SignedPayload
-signedDecoder =
-    D.map2 SignedPayload
-        (D.field "cbor" D.string)
-        (D.field "txId" D.string)

--- a/cardano-wasm/demo/src/Wasm.elm
+++ b/cardano-wasm/demo/src/Wasm.elm
@@ -1,5 +1,6 @@
 module Wasm exposing
     ( addrsDecoder
+    , certJson
     , decodeResult
     , deriveAddresses
     , estimateFee
@@ -15,9 +16,10 @@ module Wasm exposing
 
 {-| The cardano-wasm boundary. Commands encode a request and send it out a port;
 results come back on the matching incoming port and are decoded here (see the
-subscriptions in Main). The Cardano processing itself — key handling, transaction
-building, fee estimation, signing — happens on the JS side (web/ports.js) through
-the cardano-wasm wrapper; the JSON built here just describes the transaction.
+subscriptions in Main). The Cardano processing itself — key handling, certificate
+building, transaction building, fee estimation, signing — happens on the JS side
+(web/ports.js) through the cardano-wasm wrapper; the JSON built here just
+describes the transaction.
 -}
 
 import Format
@@ -188,11 +190,13 @@ certJson model c =
         unreg =
             E.object [ ( "action", E.string "unregister" ), ( "stakeKeyHash", E.string skh ), ( "deposit", E.int model.protocol.keyDeposit ) ]
 
-        deleg pid =
+        deleg ref =
             E.object
                 [ ( "action", E.string "delegate" )
                 , ( "stakeKeyHash", E.string skh )
-                , ( "poolId", E.string (poolHex model pid) )
+
+                -- Blockfrost's hex, pinned into the certificate at pick time
+                , ( "poolId", E.string ref.hex )
                 ]
     in
     case c.action of
@@ -202,18 +206,20 @@ certJson model c =
         Unregister ->
             [ unreg ]
 
-        DelegateOnly pid ->
-            [ deleg pid ]
+        DelegateOnly ref ->
+            [ deleg ref ]
 
-        RegisterAndDelegate pid ->
-            [ reg, deleg pid ]
+        RegisterAndDelegate ref ->
+            [ reg, deleg ref ]
 
 
 
 -- SIGNING KEYS
 -- Payment witnesses for the wallets whose UTxOs are spent; stake witnesses
--- (alsoSignWithStakeKey) for the wallets that carry a certificate. Registration
--- alone wouldn't need a stake witness, but an extra witness is harmless.
+-- (alsoSignWithStakeKey) for the wallets that carry a certificate. All of them
+-- need one: our registration certificates carry an explicit deposit, and that
+-- form requires the credential's witness just like delegation and
+-- unregistration do.
 
 
 paymentSigningKeys : Model -> List String

--- a/cardano-wasm/demo/web/ports.js
+++ b/cardano-wasm/demo/web/ports.js
@@ -1,6 +1,7 @@
-// Port glue: Elm ⇄ cardano-wasm. The wrapper does the Cardano work here —
-// key generation and restoration, address encoding and inspection, transaction
-// building, fee estimation and signing.
+// Port glue: Elm ⇄ cardano-wasm. The Cardano processing — wallet/key generation,
+// address derivation, certificate building, tx building, fee estimation, signing,
+// address inspection — happens here via the wrapper; Elm sends request objects over
+// ports and decodes the results.
 // Protocol parameters come from a pinned module (pparams.js): estimateMinFee
 // requires the full cardano-ledger JSON format, which no CORS-friendly provider
 // serves directly, and the fee-relevant fields are stable across networks. Refresh
@@ -30,18 +31,34 @@ async function restoreWallet(api, network, paymentSkey, stakeSkey) {
     : api.wallet.testnet.restoreStakeWalletFromSigningKeyBech32(magic[network], paymentSkey, stakeSkey);
 }
 
+async function makeCert(api, era, c) {
+  const C = era === "dijkstra" ? api.certificate.upcomingEra : api.certificate.mainnetEra;
+  if (era === "dijkstra") {
+    if (c.action === "register") return C.makeStakeAddressRegistrationCertificateUpcomingEra(c.stakeKeyHash, BigInt(c.deposit));
+    if (c.action === "unregister") return C.makeStakeAddressUnregistrationCertificateUpcomingEra(c.stakeKeyHash, BigInt(c.deposit));
+    return C.makeStakeAddressStakeDelegationCertificateUpcomingEra(c.stakeKeyHash, c.poolId);
+  }
+  if (c.action === "register") return C.makeStakeAddressRegistrationCertificate(c.stakeKeyHash, BigInt(c.deposit));
+  if (c.action === "unregister") return C.makeStakeAddressUnregistrationCertificate(c.stakeKeyHash, BigInt(c.deposit));
+  return C.makeStakeAddressStakeDelegationCertificate(c.stakeKeyHash, c.poolId);
+}
+
 async function buildUnsigned(api, spec) {
   // Constructors are async (Promise<UnsignedTx>) — must await.
   // NOTE: newConwayTx is advertised by getApiInfo but NOT exported by the current wasm build,
   // so use newTx() for the current era (= Conway). newUpcomingEraTx() works for Dijkstra.
   let tx = await (spec.era === "dijkstra" ? api.tx.newUpcomingEraTx() : api.tx.newTx());
-  // Fluent builders (addTxInput/addSimpleTxOut) are synchronous chainers.
+  // Fluent builders (addTxInput/addSimpleTxOut/appendCertificateToTx) are synchronous chainers.
   for (const i of spec.inputs) tx = tx.addTxInput(i.txId, i.txIx);
   for (const o of spec.outputs) tx = tx.addSimpleTxOut(o.address, BigInt(o.lovelace));
+  for (const c of spec.certs) {
+    const cert = await makeCert(api, spec.era, c); // certificate.* are async (return hex string)
+    tx = tx.appendCertificateToTx(cert);
+  }
   return tx;
 }
 
-function wire(app, api) {
+function wire(app, api, pparams) {
   app.ports.wasmGenerateWallet.subscribe(async ({ network }) => {
     try {
       const w = network === "mainnet"
@@ -84,7 +101,7 @@ function wire(app, api) {
       // Payment witnesses (for the spent inputs) — signWithPaymentKey / alsoSignWithPaymentKey.
       let signed = await tx.signWithPaymentKey(paymentKeys[0]); // async → SignedTx
       for (const k of paymentKeys.slice(1)) signed = signed.alsoSignWithPaymentKey(k); // fluent, sync
-      // Stake witnesses — alsoSignWithStakeKey (used once certificates arrive).
+      // Stake witnesses (for delegation / unregistration certificates) — alsoSignWithStakeKey.
       for (const k of stakeKeys) signed = signed.alsoSignWithStakeKey(k); // fluent, sync
       const cbor = await signed.txToCbor(); // async → hex
       const txId = await signed.getTxId(); // async → 64-char hex (body hash; witness-independent)
@@ -113,22 +130,11 @@ async function boot() {
     // pinned object, so there is a single source of truth.
     flags: { keyDeposit: pparams.stakeAddressDeposit, coinsPerUtxoByte: pparams.utxoCostPerByte },
   });
-  wire(app, api);
+  wire(app, api, pparams);
 }
 
 boot().catch((e) => {
-  const app = document.getElementById("app");
-  if (!app) return;
-
-  const msg = document.createElement("div");
-  msg.style.cssText = "color:#e6edff;font-family:sans-serif;padding:30px";
-  msg.append("Failed to load cardano-wasm:");
-
-  const pre = document.createElement("pre");
-  pre.textContent = String(e);
-  msg.appendChild(document.createElement("br"));
-  msg.appendChild(pre);
-  msg.append("Make sure the page is served over http(s), not opened as a file://");
-
-  app.replaceChildren(msg);
+  document.getElementById("app").innerHTML =
+    '<div style="color:#e6edff;font-family:sans-serif;padding:30px">Failed to load cardano-wasm:<br><pre>' +
+    String(e) + "</pre>Make sure the page is served over http(s), not opened as a file://</div>";
 });

--- a/cardano-wasm/demo/web/ports.js
+++ b/cardano-wasm/demo/web/ports.js
@@ -98,6 +98,9 @@ function wire(app, api, pparams) {
     try {
       let tx = await buildUnsigned(api, spec);
       tx = tx.setFee(BigInt(spec.fee)); // fluent, synchronous
+      // An empty key list would pass undefined into the wrapper, whose promise then
+      // never settles (wedging this instance's certificate path) — fail loudly instead.
+      if (!paymentKeys.length) throw new Error("no payment keys (select at least one input)");
       // Payment witnesses (for the spent inputs) — signWithPaymentKey / alsoSignWithPaymentKey.
       let signed = await tx.signWithPaymentKey(paymentKeys[0]); // async → SignedTx
       for (const k of paymentKeys.slice(1)) signed = signed.alsoSignWithPaymentKey(k); // fluent, sync
@@ -134,7 +137,18 @@ async function boot() {
 }
 
 boot().catch((e) => {
-  document.getElementById("app").innerHTML =
-    '<div style="color:#e6edff;font-family:sans-serif;padding:30px">Failed to load cardano-wasm:<br><pre>' +
-    String(e) + "</pre>Make sure the page is served over http(s), not opened as a file://</div>";
+  const app = document.getElementById("app");
+  if (!app) return;
+
+  const msg = document.createElement("div");
+  msg.style.cssText = "color:#e6edff;font-family:sans-serif;padding:30px";
+  msg.append("Failed to load cardano-wasm:");
+
+  const pre = document.createElement("pre");
+  pre.textContent = String(e);
+  msg.appendChild(document.createElement("br"));
+  msg.appendChild(pre);
+  msg.append("Make sure the page is served over http(s), not opened as a file://");
+
+  app.replaceChildren(msg);
 });


### PR DESCRIPTION
This PR adds the following functionality to the `cardano-wasm` demo:

- per-wallet certificate menu: register / register+delegate / delegate-only / unregister; key deposit and refund reflected in the balance
- live pool picker from Blockfrost /pools/extended, one page at a time (prev/next; no duplicates possible from shifting offsets)
- delegation uses Blockfrost's hex pool id, with a golden-tested pure-Elm bech32 fallback decoder
- signing attaches payment witnesses per input wallet and a stake witness (alsoSignWithStakeKey) per certificate wallet
- README: full feature list

# Context

This is a follow up of: https://github.com/IntersectMBO/cardano-api/pull/1287

# How to trust this PR

- Only the elm code, ports javascript, and the readme are modified and elm code compiles.
- You can test this version by downloading the artifact from the `WASM` CI action and serving it with a simple web-server.
- Tests will be added in the next PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
