### PR TITLE
Bump herald to 0.1.2.0 and herald-release action to 0.0.2.0

### DIFF
--- a/.changes/20260818_cardano-api_bump_herald_tooling.yml
+++ b/.changes/20260818_cardano-api_bump_herald_tooling.yml
@@ -1,0 +1,13 @@
+project: cardano-api
+
+pr: 1296
+
+kind:
+  - maintenance
+
+description: |
+  Updated the herald changelog tooling to herald 0.2.0.0.
+  The herald-validate action in check-pr-changelog.yml was bumped to herald-validate-0.0.1.1 and the herald-release action in release.yml to herald-release-0.0.3.0; both now default to herald 0.2.0.0, so no explicit `herald-ref` override is needed.
+  The cardano-dev flake input was updated so the dev shell also provides herald 0.2.0.0.
+  Note that herald 0.2.0.0 requires an explicit version choice for `herald batch`: pass `--version` or `--auto-version` (preview with `--dry-run`).
+  Release PRs now include copy-paste CHaP submission instructions (herald-release's chap-instructions input is enabled).

--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -27,4 +27,4 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
 
-      - uses: input-output-hk/cardano-dev/actions/herald-validate@herald-validate-0.0.1.0
+      - uses: input-output-hk/cardano-dev/actions/herald-validate@herald-validate-0.0.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,9 @@ jobs:
           extra_nix_config: |
             accept-flake-config = true
 
-      - uses: input-output-hk/cardano-dev/actions/herald-release@herald-release-0.0.1.0
+      - uses: input-output-hk/cardano-dev/actions/herald-release@herald-release-0.0.3.0
         with:
           package: ${{ inputs.package }}
           version: ${{ inputs.version }}
           base-branch: ${{ inputs.branch || github.ref_name }}
+          chap-instructions: true

--- a/flake.lock
+++ b/flake.lock
@@ -164,11 +164,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1775053833,
-        "narHash": "sha256-CX81JqTsZLdLo5WDrQTGKH/WkCQSXIZqrGVJNkggH7c=",
+        "lastModified": 1787599162,
+        "narHash": "sha256-hkHFme3QTTycmi9e3nXbwt12rNCrkwqiWWjerJga01I=",
         "owner": "input-output-hk",
         "repo": "cardano-dev",
-        "rev": "543053382386e840ce60574d7f4321b12c0da378",
+        "rev": "1acac1188d189a19264a7a41487505a93de41217",
         "type": "github"
       },
       "original": {
@@ -357,11 +357,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1785398528,
-        "narHash": "sha256-dl5vmLjnVynFaniJ60YNZfDT7m/psLU1P/bj+gwlZt8=",
+        "lastModified": 1778807596,
+        "narHash": "sha256-3QQWTI6Md7aKhc88vb7dg5jvS+lFXbm0IbYAwHEOLkg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "cee34cd6eac747364751d1971080bc72c461506d",
+        "rev": "970dbf08cc174c56fef2522c1d21e04eb969a1bf",
         "type": "github"
       },
       "original": {
@@ -373,11 +373,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1774571863,
-        "narHash": "sha256-iOZRO9gZIRiJ7kdLjZyGVY0ms+xUZvWKMg1gDsx4XY0=",
+        "lastModified": 1778806225,
+        "narHash": "sha256-iy3Juc9g68k2aZTgFQX7kJU1wDUdY2G+YsTRkd+YmIw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "712954158ec8c10c6a8b09cb9de675684df1ebd2",
+        "rev": "db343e074ad11a1431627a8d3817ec574230cd84",
         "type": "github"
       },
       "original": {
@@ -494,16 +494,15 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1774631528,
-        "narHash": "sha256-tYufdrpGh76VBfCBuFzo4TMgJPPAkjOfeM94dJGyC+A=",
-        "owner": "carbolymer",
+        "lastModified": 1778807965,
+        "narHash": "sha256-QWNQB1ZmNk7MA6+WSHkeB7278Ykx0TkCzlY1OMwD8ro=",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "395a7cf54ef9ceedc1a29e9f5055fc148e48cb6f",
+        "rev": "3883823f608fa19fad8c94e0203be37e124b4bed",
         "type": "github"
       },
       "original": {
-        "owner": "carbolymer",
-        "ref": "remove-deprecated-pie-hardening",
+        "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -1149,11 +1148,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1770174258,
-        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -1373,11 +1372,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -1405,11 +1404,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -1645,11 +1644,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1774570839,
-        "narHash": "sha256-tyAzxmjnAtwAux2Dbw5yUOTPhNcFrDjpvQlVtFqA8Ak=",
+        "lastModified": 1778805211,
+        "narHash": "sha256-Nu/V1NuOsz4iteePdkzcufDOY3vhbl7Wl1MhQjUTJc0=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "af474ea91cba204905ee7d2273a0f1782b13ed46",
+        "rev": "6af1a5ac5c3e2ca2261d56696f2d8f8e9220ffdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Context

This updates the herald changelog tooling used by this repository:

- `release.yml`: the `herald-release` action is bumped from `herald-release-0.0.1.0` to `herald-release-0.0.3.0`.
- `check-pr-changelog.yml`: the `herald-validate` action is bumped from `herald-validate-0.0.1.0` to `herald-validate-0.0.1.1`.
- Both action versions default their `herald-ref` input to `herald-0.2.0.0`, so the explicit overrides previously needed to escape the stale `herald-0.1.1.0` default were dropped.
  The pairing matters for correctness: herald 0.2.0.0 makes `herald batch` require an explicit version choice (`--version` or `--auto-version`), and `herald-release-0.0.3.0` is the first action version that always passes one.
- `flake.lock`: the `cardano-dev` input is updated to the latest `main`, so the dev shell provides herald 0.2.0.0 as well.
  This also re-locks cardano-dev's transitive `haskellNix` subtree, because cardano-dev switched its `haskellNix` input from a fork back to `input-output-hk/haskell.nix` between the two pins, and keeping the old transitive entries would fail pure evaluation.
- `release.yml` now passes `chap-instructions: true`, so release PRs for projects with a cabal-file include a copy-paste CHaP submission script in their body.

# How to trust this PR

- The `flake.lock` diff touches only the `cardano-dev` node and nodes scoped under it (`cardano-dev/haskellNix/...`); none of cardano-api's own inputs moved.
- The changelog check on this PR already runs the updated `check-pr-changelog.yml`, so a green "Check changelog fragments" status shows herald 0.2.0.0 validating this repository.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

