### PR TITLE
Skip the DRep state query when balancing needs no DRep deposits

### DIFF
--- a/.changes/20260818_120000_cardano-api_palas_skip_drep_query_when_not_needed.yml
+++ b/.changes/20260818_120000_cardano-api_palas_skip_drep_query_when_not_needed.yml
@@ -1,0 +1,6 @@
+description: |
+  Fixed `queryStateForBalancedTx` to skip the DRepState query when transaction contains no DRep unregistration certificates
+kind:
+  - bugfix
+pr: 1297
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Query/Internal/Convenience.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Convenience.hs
@@ -156,13 +156,17 @@ queryStateForBalancedTx era allTxIns certs = runExceptT $ do
         & onLeft (left . QceUnsupportedNtcVersion)
         & onLeft (left . QueryEraMismatch)
 
+  -- Empty 'drepCreds' to 'queryDRepState' means "every DRep", not a
+  -- no-op, so the short-circuit lives at the caller.
   drepDelegDeposits <-
-    monoidForEraInEonA era $ \con ->
-      Map.map drepDeposit
-        <$> ( lift (queryDRepState con drepCreds)
-                & onLeft (left . QceUnsupportedNtcVersion)
-                & onLeft (left . QueryEraMismatch)
-            )
+    if null drepCreds
+      then pure mempty
+      else monoidForEraInEonA era $ \con ->
+        Map.map drepDeposit
+          <$> ( lift (queryDRepState con drepCreds)
+                  & onLeft (left . QceUnsupportedNtcVersion)
+                  & onLeft (left . QueryEraMismatch)
+              )
 
   featuredTxTreasuryValueM <-
     caseShelleyToBabbageOrConwayEraOnwards


### PR DESCRIPTION

# Context

Empty credentials to `queryDRepState` mean "every DRep", not a no-op, so `queryStateForBalancedTx` used to fetch the entire DRep state for every transaction without DRep unregistrations. Short-circuit at the caller instead.

# How to trust this PR

This only affects the case where `drepCreds` is empty, and it was wrong before this PR because `GetDRepState` query returns the state for every `DRep` when an empty set of credentials is provided, see: https://github.com/IntersectMBO/ouroboros-consensus/blob/cc38ee0d4c4812bca343560eb2220223ef7e8898/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs#L274

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
