### PR TITLE
Complete the era eons for Dijkstra

### DIFF
--- a/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
+++ b/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
@@ -5,7 +5,7 @@ description: |
 
   Simple scripts are still unsupported in Dijkstra.
 
-  The cardano-api lens `reqSignerHashesTxBodyL` is deprecated: use the same-named ledger lens (or `reqSignerHashesTxBodyG` for reads) from `Cardano.Api.Ledger`.
+  Most `LedgerTxBody` wrapper lenses are deprecated: use the same-named ledger lenses from `Cardano.Api.Ledger` (through `txBodyL`). `coinTxOutL` replaces `valueTxOutAdaAssetL`, and `reqSignerHashesTxBodyG` covers era-generic reads. `Cardano.Api.Ledger` now also re-exports the era tx-body classes and these lenses. The validity-interval lenses, `adaAssetL` and `multiAssetL` stay: the ledger has no equivalent for them.
 
   Breaking: the era constraint bundles (`AllegraEraOnwardsConstraints`, `MaryEraOnwardsConstraints`, `BabbageEraOnwardsConstraints`, `ConwayEraOnwardsConstraints`) no longer provide `ShelleyEraTxCert` or `TxCert era ~ ConwayTxCert era`, because Dijkstra does not support those certificates. If your code needs them, add the constraint explicitly.
 kind:

--- a/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
+++ b/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
@@ -5,7 +5,7 @@ description: |
 
   Simple scripts are still unsupported in Dijkstra.
 
-  Most `LedgerTxBody` wrapper lenses are deprecated: use the same-named ledger lenses from `Cardano.Api.Ledger` (through `txBodyL`). `coinTxOutL` replaces `valueTxOutAdaAssetL`, and `reqSignerHashesTxBodyG` covers era-generic reads. `Cardano.Api.Ledger` now also re-exports the era tx-body classes and these lenses. The validity-interval lenses, `adaAssetL` and `multiAssetL` stay: the ledger has no equivalent for them.
+  Most `LedgerTxBody` wrapper lenses are deprecated: use the same-named ledger lenses from `Cardano.Api.Ledger` (through `txBodyL`). `coinTxOutL` replaces `valueTxOutAdaAssetL`, and `reqSignerHashesTxBodyG` covers era-generic reads. `Cardano.Api.Ledger` now also re-exports the era tx-body classes and these lenses. The validity-interval lenses, `adaAssetL` and `multiAssetL` stay: the ledger has no equivalent for them. `reqSignerHashesTxBodyL` now also carries the ledger's `AtMostEra "Conway"` constraint, so using it in Dijkstra is a compile error.
 
   Breaking: the era constraint bundles (`AllegraEraOnwardsConstraints`, `MaryEraOnwardsConstraints`, `BabbageEraOnwardsConstraints`, `ConwayEraOnwardsConstraints`) no longer provide `ShelleyEraTxCert` or `TxCert era ~ ConwayTxCert era`, because Dijkstra does not support those certificates. If your code needs them, add the constraint explicitly.
 kind:

--- a/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
+++ b/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
@@ -5,6 +5,8 @@ description: |
 
   Simple scripts are still unsupported in Dijkstra.
 
+  The cardano-api lens `reqSignerHashesTxBodyL` is deprecated: use the same-named ledger lens (or `reqSignerHashesTxBodyG` for reads) from `Cardano.Api.Ledger`.
+
   Breaking: the era constraint bundles (`AllegraEraOnwardsConstraints`, `MaryEraOnwardsConstraints`, `BabbageEraOnwardsConstraints`, `ConwayEraOnwardsConstraints`) no longer provide `ShelleyEraTxCert` or `TxCert era ~ ConwayTxCert era`, because Dijkstra does not support those certificates. If your code needs them, add the constraint explicitly.
 kind:
   - feature

--- a/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
+++ b/.changes/20260818_120100_cardano-api_palas_dijkstra_eon_completion.yml
@@ -1,0 +1,13 @@
+description: |
+  `DijkstraEra` now works everywhere the API dispatches on eras: the era helpers and instances that used to error out or not exist for Dijkstra are implemented.
+
+  Extra key witnesses keep working in Dijkstra: the era replaces required signer hashes with guards, so `TxExtraKeyWitnesses` becomes key-hash guards. The effect is the same — those keys must sign.
+
+  Simple scripts are still unsupported in Dijkstra.
+
+  Breaking: the era constraint bundles (`AllegraEraOnwardsConstraints`, `MaryEraOnwardsConstraints`, `BabbageEraOnwardsConstraints`, `ConwayEraOnwardsConstraints`) no longer provide `ShelleyEraTxCert` or `TxCert era ~ ConwayTxCert era`, because Dijkstra does not support those certificates. If your code needs them, add the constraint explicitly.
+kind:
+  - feature
+  - breaking
+pr: 1298
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Case.hs
@@ -36,7 +36,7 @@ caseByronOrShelleyBasedEra l r = \case
   AlonzoEra -> r ShelleyBasedEraAlonzo
   BabbageEra -> r ShelleyBasedEraBabbage
   ConwayEra -> r ShelleyBasedEraConway
-  DijkstraEra -> error "TODO Dijkstra: caseByronOrShelleyBasedEra: era not supported"
+  DijkstraEra -> r ShelleyBasedEraDijkstra
 
 -- | @caseShelleyEraOnlyOrAllegraEraOnwards f g era@ applies @f@ to shelley;
 -- and applies @g@ to allegra and later eras.
@@ -53,7 +53,7 @@ caseShelleyEraOnlyOrAllegraEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> r AllegraEraOnwardsAlonzo
   ShelleyBasedEraBabbage -> r AllegraEraOnwardsBabbage
   ShelleyBasedEraConway -> r AllegraEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyEraOnlyOrAllegraEraOnwards: era not supported"
+  ShelleyBasedEraDijkstra -> r AllegraEraOnwardsDijkstra
 
 -- | @caseShelleyToBabbageOrConwayEraOnwards f g era@ applies @f@ to eras before conway;
 -- and applies @g@ to conway and later eras.
@@ -70,4 +70,4 @@ caseShelleyToBabbageOrConwayEraOnwards l r = \case
   ShelleyBasedEraAlonzo -> l ShelleyToBabbageEraAlonzo
   ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
   ShelleyBasedEraConway -> r ConwayEraOnwardsConway
-  ShelleyBasedEraDijkstra -> error "TODO Dijkstra: caseShelleyToBabbageOrConwayEraOnwards: era not supported"
+  ShelleyBasedEraDijkstra -> r ConwayEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
@@ -304,6 +304,7 @@ instance TestEquality CardanoEra where
   testEquality AlonzoEra AlonzoEra = Just Refl
   testEquality BabbageEra BabbageEra = Just Refl
   testEquality ConwayEra ConwayEra = Just Refl
+  testEquality DijkstraEra DijkstraEra = Just Refl
   testEquality _ _ = Nothing
 
 instance Eon CardanoEra where

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
@@ -97,7 +97,10 @@ type AllegraEraOnwardsConstraints era =
   , L.EraTxOut (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody L.TopTx (ShelleyLedgerEra era)) L.EraIndependentTxBody
   , L.AllegraEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger, so
+    -- Dijkstra cannot satisfy it. Callsites needing Shelley-style certs must
+    -- require ShelleyEraTxCert (ShelleyLedgerEra era) explicitly.
+    L.EraTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -119,7 +122,7 @@ allegraEraOnwardsConstraints = \case
   AllegraEraOnwardsAlonzo -> id
   AllegraEraOnwardsBabbage -> id
   AllegraEraOnwardsConway -> id
-  _ -> const $ error "TODO Dijkstra: allegraEraOnwardsConstraints: era not supported"
+  AllegraEraOnwardsDijkstra -> id
 
 class IsShelleyBasedEra era => IsAllegraBasedEra era where
   allegraBasedEra :: AllegraEraOnwards era
@@ -138,3 +141,6 @@ instance IsAllegraBasedEra BabbageEra where
 
 instance IsAllegraBasedEra ConwayEra where
   allegraBasedEra = AllegraEraOnwardsConway
+
+instance IsAllegraBasedEra DijkstraEra where
+  allegraBasedEra = AllegraEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AllegraEraOnwards.hs
@@ -97,10 +97,7 @@ type AllegraEraOnwardsConstraints era =
   , L.EraTxOut (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody L.TopTx (ShelleyLedgerEra era)) L.EraIndependentTxBody
   , L.AllegraEraTxBody (ShelleyLedgerEra era)
-  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger, so
-    -- Dijkstra cannot satisfy it. Callsites needing Shelley-style certs must
-    -- require ShelleyEraTxCert (ShelleyLedgerEra era) explicitly.
-    L.EraTxCert (ShelleyLedgerEra era)
+  , L.EraTxCert (ShelleyLedgerEra era)
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/AlonzoEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/AlonzoEraOnwards.hs
@@ -141,3 +141,6 @@ instance IsAlonzoBasedEra BabbageEra where
 
 instance IsAlonzoBasedEra ConwayEra where
   alonzoBasedEra = AlonzoEraOnwardsConway
+
+instance IsAlonzoBasedEra DijkstraEra where
+  alonzoBasedEra = AlonzoEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
@@ -115,7 +115,8 @@ type BabbageEraOnwardsConstraints era =
   , L.MaryEraTxBody (ShelleyLedgerEra era)
   , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
   , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger.
+    L.EraTxCert (ShelleyLedgerEra era)
   , L.TxOut (ShelleyLedgerEra era) ~ L.BabbageTxOut (ShelleyLedgerEra era)
   , L.Value (ShelleyLedgerEra era) ~ L.MaryValue
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
@@ -136,7 +137,7 @@ babbageEraOnwardsConstraints
 babbageEraOnwardsConstraints = \case
   BabbageEraOnwardsBabbage -> id
   BabbageEraOnwardsConway -> id
-  BabbageEraOnwardsDijkstra -> const $ error "TODO Dijkstra: babbageEraOnwardsConstraints: era not supported"
+  BabbageEraOnwardsDijkstra -> id
 
 class IsAlonzoBasedEra era => IsBabbageBasedEra era where
   babbageBasedEra :: BabbageEraOnwards era
@@ -146,3 +147,6 @@ instance IsBabbageBasedEra BabbageEra where
 
 instance IsBabbageBasedEra ConwayEra where
   babbageBasedEra = BabbageEraOnwardsConway
+
+instance IsBabbageBasedEra DijkstraEra where
+  babbageBasedEra = BabbageEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/BabbageEraOnwards.hs
@@ -115,8 +115,7 @@ type BabbageEraOnwardsConstraints era =
   , L.MaryEraTxBody (ShelleyLedgerEra era)
   , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
   , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger.
-    L.EraTxCert (ShelleyLedgerEra era)
+  , L.EraTxCert (ShelleyLedgerEra era)
   , L.TxOut (ShelleyLedgerEra era) ~ L.BabbageTxOut (ShelleyLedgerEra era)
   , L.Value (ShelleyLedgerEra era) ~ L.MaryValue
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ConwayEraOnwards.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.BaseTypes qualified as L
 import Cardano.Ledger.Conway.Core qualified as L
 import Cardano.Ledger.Conway.Governance qualified as L
 import Cardano.Ledger.Conway.State qualified as L
-import Cardano.Ledger.Conway.TxCert qualified as L
 import Cardano.Ledger.Mary.Value qualified as L
 import Cardano.Protocol.Crypto qualified as L
 import Ouroboros.Consensus.Protocol.Abstract qualified as Consensus
@@ -123,8 +122,6 @@ type ConwayEraOnwardsConstraints era =
   , L.MaryEraTxBody (ShelleyLedgerEra era)
   , L.Script (ShelleyLedgerEra era) ~ L.AlonzoScript (ShelleyLedgerEra era)
   , L.ScriptsNeeded (ShelleyLedgerEra era) ~ L.AlonzoScriptsNeeded (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.TxCert (ShelleyLedgerEra era) ~ L.ConwayTxCert (ShelleyLedgerEra era)
   , L.Value (ShelleyLedgerEra era) ~ L.MaryValue
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
@@ -143,7 +140,7 @@ conwayEraOnwardsConstraints
   -> a
 conwayEraOnwardsConstraints = \case
   ConwayEraOnwardsConway -> id
-  _ -> const $ error "TODO Dijkstra: conwayEraOnwardsConstraints: era not supported"
+  ConwayEraOnwardsDijkstra -> id
 
 class IsBabbageBasedEra era => IsConwayBasedEra era where
   conwayBasedEra :: ConwayEraOnwards era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
@@ -98,8 +98,9 @@ type MaryEraOnwardsConstraints era =
   , L.EraUTxO (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody L.TopTx (ShelleyLedgerEra era)) L.EraIndependentTxBody
   , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue
+  , -- L.ShelleyEraTxCert dropped: Dijkstra cannot satisfy AtMostEra "Conway".
+    -- Callsites that need it must add it explicitly.
+    L.Value (ShelleyLedgerEra era) ~ L.MaryValue
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era
@@ -120,7 +121,7 @@ maryEraOnwardsConstraints = \case
   MaryEraOnwardsAlonzo -> id
   MaryEraOnwardsBabbage -> id
   MaryEraOnwardsConway -> id
-  MaryEraOnwardsDijkstra -> const $ error "TODO Dijkstra: maryEraOnwardsConstraints: era not supported"
+  MaryEraOnwardsDijkstra -> id
 
 class IsAllegraBasedEra era => IsMaryBasedEra era where
   maryBasedEra :: MaryEraOnwards era
@@ -136,3 +137,6 @@ instance IsMaryBasedEra BabbageEra where
 
 instance IsMaryBasedEra ConwayEra where
   maryBasedEra = MaryEraOnwardsConway
+
+instance IsMaryBasedEra DijkstraEra where
+  maryBasedEra = MaryEraOnwardsDijkstra

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/MaryEraOnwards.hs
@@ -98,9 +98,7 @@ type MaryEraOnwardsConstraints era =
   , L.EraUTxO (ShelleyLedgerEra era)
   , L.HashAnnotated (L.TxBody L.TopTx (ShelleyLedgerEra era)) L.EraIndependentTxBody
   , L.MaryEraTxBody (ShelleyLedgerEra era)
-  , -- L.ShelleyEraTxCert dropped: Dijkstra cannot satisfy AtMostEra "Conway".
-    -- Callsites that need it must add it explicitly.
-    L.Value (ShelleyLedgerEra era) ~ L.MaryValue
+  , L.Value (ShelleyLedgerEra era) ~ L.MaryValue
   , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (DebugLedgerState era)
   , IsCardanoEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
@@ -237,11 +237,7 @@ type ShelleyBasedEraConstraints era =
   , L.EraCertState (ShelleyLedgerEra era)
   , L.EraAccounts (ShelleyLedgerEra era)
   , L.EraGov (ShelleyLedgerEra era)
-  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger, so
-    -- Dijkstra cannot satisfy it. Callsites that construct Shelley-style certs
-    -- must require ShelleyEraTxCert (ShelleyLedgerEra era) explicitly — that
-    -- naturally excludes Dijkstra at the type level.
-    FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (L.TxCert (ShelleyLedgerEra era))
   , HasTypeProxy era
   , IsCardanoEra era

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
@@ -160,6 +160,7 @@ instance TestEquality ShelleyBasedEra where
   testEquality ShelleyBasedEraAlonzo ShelleyBasedEraAlonzo = Just Refl
   testEquality ShelleyBasedEraBabbage ShelleyBasedEraBabbage = Just Refl
   testEquality ShelleyBasedEraConway ShelleyBasedEraConway = Just Refl
+  testEquality ShelleyBasedEraDijkstra ShelleyBasedEraDijkstra = Just Refl
   testEquality _ _ = Nothing
 
 instance Eon ShelleyBasedEra where
@@ -236,8 +237,11 @@ type ShelleyBasedEraConstraints era =
   , L.EraCertState (ShelleyLedgerEra era)
   , L.EraAccounts (ShelleyLedgerEra era)
   , L.EraGov (ShelleyLedgerEra era)
-  , L.ShelleyEraTxCert (ShelleyLedgerEra era)
-  , FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+  , -- L.ShelleyEraTxCert dropped: gated by AtMostEra "Conway" in the ledger, so
+    -- Dijkstra cannot satisfy it. Callsites that construct Shelley-style certs
+    -- must require ShelleyEraTxCert (ShelleyLedgerEra era) explicitly — that
+    -- naturally excludes Dijkstra at the type level.
+    FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
   , FromCBOR (L.TxCert (ShelleyLedgerEra era))
   , HasTypeProxy era
   , IsCardanoEra era
@@ -261,7 +265,7 @@ shelleyBasedEraConstraints = \case
   ShelleyBasedEraAlonzo -> id
   ShelleyBasedEraBabbage -> id
   ShelleyBasedEraConway -> id
-  ShelleyBasedEraDijkstra -> const $ error "TODO Dijkstra: shelleyBasedEraConstraints: era not supported"
+  ShelleyBasedEraDijkstra -> id
 
 data AnyShelleyBasedEra where
   AnyShelleyBasedEra

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -134,6 +134,7 @@ instance Bounded (Some Era) where
 
 instance Enum (Some Era) where
   toEnum 0 = Some ConwayEra
+  toEnum 1 = Some DijkstraEra
   toEnum i = error $ "Enum.toEnum: invalid argument " <> show i <> " - does not correspond to any era"
   fromEnum (Some ConwayEra) = 0
   fromEnum (Some DijkstraEra) = 1

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -160,9 +160,14 @@ instance FromJSON (Some Era) where
 -- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
 instance Eon Era where
   inEonForEra v f = \case
+    Api.ByronEra -> v
+    Api.ShelleyEra -> v
+    Api.AllegraEra -> v
+    Api.MaryEra -> v
+    Api.AlonzoEra -> v
+    Api.BabbageEra -> v
     Api.ConwayEra -> f ConwayEra
     Api.DijkstraEra -> f DijkstraEra
-    _ -> v
 
 -- | A temporary compatibility instance for easier conversion between the experimental and old APIs.
 instance Api.ToCardanoEra Era where

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -160,6 +160,7 @@ instance FromJSON (Some Era) where
 instance Eon Era where
   inEonForEra v f = \case
     Api.ConwayEra -> f ConwayEra
+    Api.DijkstraEra -> f DijkstraEra
     _ -> v
 
 -- | A temporary compatibility instance for easier conversion between the experimental and old APIs.

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Certificate/Compatible.hs
@@ -71,10 +71,14 @@ makeStakeAddressDelegationCertificate sCred delegatee =
     e@ShelleyBasedEraMary -> cert e delegatee
     e@ShelleyBasedEraAllegra -> cert e delegatee
     e@ShelleyBasedEraShelley -> cert e delegatee
-    ShelleyBasedEraDijkstra -> error "TODO Dijkstra: makeStakeAddressDelegationCertificate: era not supported"
+    ShelleyBasedEraDijkstra ->
+      Certificate $
+        Ledger.mkDelegTxCert (toShelleyStakeCredential sCred) delegatee
  where
   cert
-    :: Delegatee era ~ Api.Hash Api.StakePoolKey
+    :: ( Delegatee era ~ Api.Hash Api.StakePoolKey
+       , Ledger.ShelleyEraTxCert (ShelleyLedgerEra era)
+       )
     => ShelleyBasedEra era -> Delegatee era -> Certificate (ShelleyLedgerEra era)
   cert e delegatee' =
     shelleyBasedEraConstraints e $
@@ -125,7 +129,9 @@ makeStakeAddressRegistrationCertificate scred =
 
 makeStakeAddressUnregistrationCertificate
   :: forall era
-   . IsShelleyBasedEra era
+   . ( IsShelleyBasedEra era
+     , Ledger.ShelleyEraTxCert (ShelleyLedgerEra era)
+     )
   => StakeCredential -> Certificate (ShelleyLedgerEra era)
 makeStakeAddressUnregistrationCertificate scred =
   shelleyBasedEraConstraints (shelleyBasedEra @era) $

--- a/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Orphans/Serialisation.hs
@@ -293,6 +293,11 @@ deriving via
     Show (L.DijkstraMempoolPredFailure ledgerera) => ToJSON (L.DijkstraMempoolPredFailure ledgerera)
 
 deriving via
+  ShowOf (L.DijkstraLedgerPredFailure ledgerera)
+  instance
+    Show (L.DijkstraLedgerPredFailure ledgerera) => ToJSON (L.DijkstraLedgerPredFailure ledgerera)
+
+deriving via
   ShowOf (L.ShelleyDelegsPredFailure ledgerera)
   instance
     Show (L.ShelleyDelegsPredFailure ledgerera) => ToJSON (L.ShelleyDelegsPredFailure ledgerera)

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -73,6 +73,8 @@ module Cardano.Api.Ledger.Internal.Reexport
   , castSafeHash
   , getScriptsNeeded
   , mkBasicTxOut
+  , coinTxOutL
+  , valueTxOutL
   , toDeltaCoin
   , toEraCBOR
   , toSLanguage
@@ -119,6 +121,11 @@ module Cardano.Api.Ledger.Internal.Reexport
   , drepAnchorL
   , drepDepositL
   , csCommitteeCredsL
+  , ConwayEraTxBody
+  , votingProceduresTxBodyL
+  , proposalProceduresTxBodyL
+  , currentTreasuryValueTxBodyL
+  , treasuryDonationTxBodyL
   -- Byron
   , Annotated (..)
   , byronProtVer
@@ -136,28 +143,22 @@ module Cardano.Api.Ledger.Internal.Reexport
   , casReservesL
   , NewEpochState (..)
   , ShelleyGenesisStaking (..)
+  , ShelleyEraTxBody
+  , updateTxBodyL
   -- Allegra
   , AllegraEraScript (..)
   , Timelock (..)
+  , AllegraEraTxBody
+  -- Mary
+  , MaryEraTxBody
+  , mintTxBodyL
   -- Babbage
   , CoinPerByte (..)
   , referenceScriptTxOutL
-  , ShelleyEraTxBody
-  , updateTxBodyL
-  , AllegraEraTxBody
-  , MaryEraTxBody
-  , mintTxBodyL
   , BabbageEraTxBody
   , referenceInputsTxBodyL
   , collateralReturnTxBodyL
   , totalCollateralTxBodyL
-  , ConwayEraTxBody
-  , votingProceduresTxBodyL
-  , proposalProceduresTxBodyL
-  , currentTreasuryValueTxBodyL
-  , treasuryDonationTxBodyL
-  , valueTxOutL
-  , coinTxOutL
   -- Alonzo
   , AlonzoEraTxBody (..)
   , AlonzoEraScript (..)

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -142,6 +142,22 @@ module Cardano.Api.Ledger.Internal.Reexport
   -- Babbage
   , CoinPerByte (..)
   , referenceScriptTxOutL
+  , ShelleyEraTxBody
+  , updateTxBodyL
+  , AllegraEraTxBody
+  , MaryEraTxBody
+  , mintTxBodyL
+  , BabbageEraTxBody
+  , referenceInputsTxBodyL
+  , collateralReturnTxBodyL
+  , totalCollateralTxBodyL
+  , ConwayEraTxBody
+  , votingProceduresTxBodyL
+  , proposalProceduresTxBodyL
+  , currentTreasuryValueTxBodyL
+  , treasuryDonationTxBodyL
+  , valueTxOutL
+  , coinTxOutL
   -- Alonzo
   , AlonzoEraTxBody (..)
   , AlonzoEraScript (..)
@@ -249,11 +265,27 @@ import Cardano.Ledger.Alonzo.Scripts
 import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), TxDats (..))
 import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
 import Cardano.Ledger.Api
-  ( BabbageEraTxOut (referenceScriptTxOutL)
+  ( AllegraEraTxBody
+  , BabbageEraTxBody
+  , BabbageEraTxOut (referenceScriptTxOutL)
   , Constitution (..)
+  , ConwayEraTxBody
   , GovAction (..)
   , GovPurposeId (..)
+  , MaryEraTxBody
+  , ShelleyEraTxBody
+  , coinTxOutL
+  , collateralReturnTxBodyL
+  , currentTreasuryValueTxBodyL
+  , mintTxBodyL
+  , proposalProceduresTxBodyL
+  , referenceInputsTxBodyL
+  , totalCollateralTxBodyL
+  , treasuryDonationTxBodyL
   , unRedeemers
+  , updateTxBodyL
+  , valueTxOutL
+  , votingProceduresTxBodyL
   )
 import Cardano.Ledger.Api.Tx.Cert
   ( pattern AuthCommitteeHotKeyTxCert

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -2101,6 +2101,7 @@ nextEpochEligibleLeadershipSlots sbe sGen serCurrEpochState ptclState poolid (Vr
           ShelleyBasedEraAlonzo -> pp ^. Core.ppExtraEntropyL
           ShelleyBasedEraBabbage -> Ledger.NeutralNonce
           ShelleyBasedEraConway -> Ledger.NeutralNonce
+          ShelleyBasedEraDijkstra -> Ledger.NeutralNonce
 
         nextEpochsNonce = candidateNonce ⭒ previousLabNonce ⭒ extraEntropy
 

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1274,7 +1274,7 @@ createTransactionBody sbe bc =
                     | (_, AnyScriptWitness scriptwitness) <-
                         collectTxBodyScriptWitnesses sbe bc
                     ]
-            return (TxBodyNoScriptData, SNothing, scripts)
+            return (TxBodyNoScriptData, SNothing :: StrictMaybe L.ScriptIntegrityHash, scripts)
         )
         ( \aeon -> alonzoEraOnwardsConstraints aeon $ do
             TxScriptWitnessRequirements languages scripts dats redeemers <-

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1313,21 +1313,24 @@ createTransactionBody sbe bc =
         treasuryDonation = maybe 0 unFeatured $ txTreasuryDonation bc
 
     setUpdateProposal <- monoidForEraInEonA era $ \w ->
-      pure . Endo $ A.updateTxBodyL w .~ convTxUpdateProposal sbe (txUpdateProposal bc)
+      pure . Endo $
+        shelleyToBabbageEraConstraints w $
+          A.txBodyL . L.updateTxBodyL .~ convTxUpdateProposal sbe (txUpdateProposal bc)
 
     setInvalidBefore <- monoidForEraInEonA era $ \w ->
       pure $ Endo $ A.invalidBeforeTxBodyL w .~ convValidityLowerBound (txValidityLowerBound bc)
 
     setMint <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.mintTxBodyL w .~ convMintValue apiMintValue
+      pure $ Endo $ maryEraOnwardsConstraints w $ A.txBodyL . L.mintTxBodyL .~ convMintValue apiMintValue
 
     setScriptIntegrityHash <- monoidForEraInEonA era $ \w ->
       pure $
         Endo $
-          A.scriptIntegrityHashTxBodyL w .~ mScriptIntegrityHash
+          alonzoEraOnwardsConstraints w $
+            A.txBodyL . L.scriptIntegrityHashTxBodyL .~ mScriptIntegrityHash
 
     setCollateralInputs <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.collateralInputsTxBodyL w .~ collTxIns
+      pure $ Endo $ alonzoEraOnwardsConstraints w $ A.txBodyL . L.collateralInputsTxBodyL .~ collTxIns
 
     setReqSignerHashes <-
       let keyWits = convExtraKeyWitnesses apiExtraKeyWitnesses
@@ -1347,29 +1350,47 @@ createTransactionBody sbe bc =
               pure $ Endo $ A.txBodyL . L.reqSignerHashesTxBodyL .~ keyWits
 
     setReferenceInputs <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.referenceInputsTxBodyL w .~ refTxIns
+      pure $ Endo $ babbageEraOnwardsConstraints w $ A.txBodyL . L.referenceInputsTxBodyL .~ refTxIns
 
     setCollateralReturn <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.collateralReturnTxBodyL w .~ returnCollateral
+      pure $
+        Endo $
+          babbageEraOnwardsConstraints w $
+            A.txBodyL . L.collateralReturnTxBodyL .~ returnCollateral
 
     setTotalCollateral <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.totalCollateralTxBodyL w .~ totalCollateral
+      pure $
+        Endo $
+          babbageEraOnwardsConstraints w $
+            A.txBodyL . L.totalCollateralTxBodyL .~ totalCollateral
 
     setProposalProcedures <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.proposalProceduresTxBodyL w .~ proposalProcedures
+      pure $
+        Endo $
+          conwayEraOnwardsConstraints w $
+            A.txBodyL . L.proposalProceduresTxBodyL .~ proposalProcedures
 
     setVotingProcedures <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.votingProceduresTxBodyL w .~ votingProcedures
+      pure $
+        Endo $
+          conwayEraOnwardsConstraints w $
+            A.txBodyL . L.votingProceduresTxBodyL .~ votingProcedures
 
     setCurrentTreasuryValue <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.currentTreasuryValueTxBodyL w .~ currentTreasuryValue
+      pure $
+        Endo $
+          conwayEraOnwardsConstraints w $
+            A.txBodyL . L.currentTreasuryValueTxBodyL .~ currentTreasuryValue
 
     setTreasuryDonation <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.treasuryDonationTxBodyL w .~ treasuryDonation
+      pure $
+        Endo $
+          conwayEraOnwardsConstraints w $
+            A.txBodyL . L.treasuryDonationTxBodyL .~ treasuryDonation
 
     let ledgerTxBody =
           mkCommonTxBody sbe (txIns bc) (txOuts bc) (txFee bc) (txWithdrawals bc) txAuxData
-            & A.certsTxBodyL sbe
+            & shelleyBasedEraConstraints sbe (A.txBodyL . L.certsTxBodyL)
               .~ certs
             & A.invalidHereAfterTxBodyL sbe
               .~ convValidityUpperBound sbe (txValidityUpperBound bc)

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1334,13 +1334,17 @@ createTransactionBody sbe bc =
        in monoidForEraInEonA era $ \w -> case w of
             -- Dijkstra replaced required signer hashes with guards, and a key-hash
             -- guard makes the ledger demand that key's signature: translate, appending
-            -- so any other guards stay intact. (The 'A.reqSignerHashesTxBodyL' arm
-            -- fails for Dijkstra, like the ledger lens.)
+            -- so any other guards stay intact.
             AlonzoEraOnwardsDijkstra ->
               pure . Endo $
                 A.txBodyL . L.guardsTxBodyL
                   %~ (<> OSet.fromSet (Set.map Shelley.KeyHashObj keyWits))
-            _ -> pure $ Endo $ A.reqSignerHashesTxBodyL w .~ keyWits
+            AlonzoEraOnwardsAlonzo ->
+              pure $ Endo $ A.txBodyL . L.reqSignerHashesTxBodyL .~ keyWits
+            AlonzoEraOnwardsBabbage ->
+              pure $ Endo $ A.txBodyL . L.reqSignerHashesTxBodyL .~ keyWits
+            AlonzoEraOnwardsConway ->
+              pure $ Endo $ A.txBodyL . L.reqSignerHashesTxBodyL .~ keyWits
 
     setReferenceInputs <- monoidForEraInEonA era $ \w ->
       pure $ Endo $ A.referenceInputsTxBodyL w .~ refTxIns

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -1329,8 +1329,18 @@ createTransactionBody sbe bc =
     setCollateralInputs <- monoidForEraInEonA era $ \w ->
       pure $ Endo $ A.collateralInputsTxBodyL w .~ collTxIns
 
-    setReqSignerHashes <- monoidForEraInEonA era $ \w ->
-      pure $ Endo $ A.reqSignerHashesTxBodyL w .~ convExtraKeyWitnesses apiExtraKeyWitnesses
+    setReqSignerHashes <-
+      let keyWits = convExtraKeyWitnesses apiExtraKeyWitnesses
+       in monoidForEraInEonA era $ \w -> case w of
+            -- Dijkstra replaced required signer hashes with guards, and a key-hash
+            -- guard makes the ledger demand that key's signature: translate, appending
+            -- so any other guards stay intact. (The 'A.reqSignerHashesTxBodyL' arm
+            -- fails for Dijkstra, like the ledger lens.)
+            AlonzoEraOnwardsDijkstra ->
+              pure . Endo $
+                A.txBodyL . L.guardsTxBodyL
+                  %~ (<> OSet.fromSet (Set.map Shelley.KeyHashObj keyWits))
+            _ -> pure $ Endo $ A.reqSignerHashesTxBodyL w .~ keyWits
 
     setReferenceInputs <- monoidForEraInEonA era $ \w ->
       pure $ Endo $ A.referenceInputsTxBodyL w .~ refTxIns

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -166,6 +166,10 @@ collateralInputsTxBodyL
   :: AlonzoEraOnwards era -> Lens' (LedgerTxBody era) (Set L.TxIn)
 collateralInputsTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.collateralInputsTxBodyL
 
+{-# DEPRECATED
+  reqSignerHashesTxBodyL
+  "Use reqSignerHashesTxBodyL from Cardano.Api.Ledger (via txBodyL) instead, or reqSignerHashesTxBodyG for reads. The required-signer-hashes field does not exist in the Dijkstra era, where this lens errors."
+  #-}
 reqSignerHashesTxBodyL
   :: AlonzoEraOnwards era -> Lens' (LedgerTxBody era) (Set (L.KeyHash L.Guard))
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsAlonzo = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -185,16 +185,13 @@ collateralInputsTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.collater
 
 {-# DEPRECATED
   reqSignerHashesTxBodyL
-  "Use reqSignerHashesTxBodyL from Cardano.Api.Ledger (via txBodyL) instead, or reqSignerHashesTxBodyG for reads. The required-signer-hashes field does not exist in the Dijkstra era, where this lens errors."
+  "Use reqSignerHashesTxBodyL from Cardano.Api.Ledger (via txBodyL) instead, or reqSignerHashesTxBodyG for reads. The required-signer-hashes field does not exist in the Dijkstra era, which this lens excludes at the type level."
   #-}
 reqSignerHashesTxBodyL
-  :: AlonzoEraOnwards era -> Lens' (LedgerTxBody era) (Set (L.KeyHash L.Guard))
-reqSignerHashesTxBodyL w@AlonzoEraOnwardsAlonzo = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
-reqSignerHashesTxBodyL w@AlonzoEraOnwardsBabbage = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
-reqSignerHashesTxBodyL w@AlonzoEraOnwardsConway = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
--- Dijkstra replaced required signer hashes with guards; the ledger gates its
--- lens to @AtMostEra "Conway"@ and stubs the instance with 'L.notSupportedInThisEraL'.
-reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = L.notSupportedInThisEraL
+  :: L.AtMostEra "Conway" (ShelleyLedgerEra era)
+  => AlonzoEraOnwards era
+  -> Lens' (LedgerTxBody era) (Set (L.KeyHash L.Guard))
+reqSignerHashesTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
 
 {-# DEPRECATED
   referenceInputsTxBodyL

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -4,7 +4,8 @@
 
 {- HLINT ignore "Eta reduce" -}
 
--- TODO: Deprecate all the lenses that use eons. Explore parameterizing them on `Era era` instead.
+-- TODO: Deprecate the remaining eon lenses (the validity-interval compatibility
+-- lenses, adaAssetL and multiAssetL) once the ledger provides equivalents.
 
 module Cardano.Api.Tx.Internal.Body.Lens
   ( -- * Types
@@ -151,17 +152,33 @@ invalidHereAfterStrictL = lens g s
   s :: L.ValidityInterval -> StrictMaybe SlotNo -> L.ValidityInterval
   s (L.ValidityInterval a _) b = L.ValidityInterval a b
 
+{-# DEPRECATED
+  updateTxBodyL
+  "Use updateTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 updateTxBodyL
   :: ShelleyToBabbageEra era -> Lens' (LedgerTxBody era) (StrictMaybe (L.Update (ShelleyLedgerEra era)))
 updateTxBodyL w = shelleyToBabbageEraConstraints w $ txBodyL . L.updateTxBodyL
 
+{-# DEPRECATED
+  mintTxBodyL
+  "Use mintTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 mintTxBodyL :: MaryEraOnwards era -> Lens' (LedgerTxBody era) L.MultiAsset
 mintTxBodyL w = maryEraOnwardsConstraints w $ txBodyL . L.mintTxBodyL
 
+{-# DEPRECATED
+  scriptIntegrityHashTxBodyL
+  "Use scriptIntegrityHashTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 scriptIntegrityHashTxBodyL
   :: AlonzoEraOnwards era -> Lens' (LedgerTxBody era) (StrictMaybe L.ScriptIntegrityHash)
 scriptIntegrityHashTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.scriptIntegrityHashTxBodyL
 
+{-# DEPRECATED
+  collateralInputsTxBodyL
+  "Use collateralInputsTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 collateralInputsTxBodyL
   :: AlonzoEraOnwards era -> Lens' (LedgerTxBody era) (Set L.TxIn)
 collateralInputsTxBodyL w = alonzoEraOnwardsConstraints w $ txBodyL . L.collateralInputsTxBodyL
@@ -179,33 +196,65 @@ reqSignerHashesTxBodyL w@AlonzoEraOnwardsConway = alonzoEraOnwardsConstraints w 
 -- lens to @AtMostEra "Conway"@ and stubs the instance with 'L.notSupportedInThisEraL'.
 reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = L.notSupportedInThisEraL
 
+{-# DEPRECATED
+  referenceInputsTxBodyL
+  "Use referenceInputsTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 referenceInputsTxBodyL
   :: BabbageEraOnwards era -> Lens' (LedgerTxBody era) (Set L.TxIn)
 referenceInputsTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.referenceInputsTxBodyL
 
+{-# DEPRECATED
+  collateralReturnTxBodyL
+  "Use collateralReturnTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 collateralReturnTxBodyL
   :: BabbageEraOnwards era -> Lens' (LedgerTxBody era) (StrictMaybe (L.TxOut (ShelleyLedgerEra era)))
 collateralReturnTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.collateralReturnTxBodyL
 
+{-# DEPRECATED
+  totalCollateralTxBodyL
+  "Use totalCollateralTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 totalCollateralTxBodyL :: BabbageEraOnwards era -> Lens' (LedgerTxBody era) (StrictMaybe L.Coin)
 totalCollateralTxBodyL w = babbageEraOnwardsConstraints w $ txBodyL . L.totalCollateralTxBodyL
 
+{-# DEPRECATED
+  certsTxBodyL
+  "Use certsTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 certsTxBodyL
   :: ShelleyBasedEra era -> Lens' (LedgerTxBody era) (L.StrictSeq (L.TxCert (ShelleyLedgerEra era)))
 certsTxBodyL w = shelleyBasedEraConstraints w $ txBodyL . L.certsTxBodyL
 
+{-# DEPRECATED
+  votingProceduresTxBodyL
+  "Use votingProceduresTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 votingProceduresTxBodyL
   :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) (L.VotingProcedures (ShelleyLedgerEra era))
 votingProceduresTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.votingProceduresTxBodyL
 
+{-# DEPRECATED
+  proposalProceduresTxBodyL
+  "Use proposalProceduresTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 proposalProceduresTxBodyL
   :: ConwayEraOnwards era
   -> Lens' (LedgerTxBody era) (L.OSet (L.ProposalProcedure (ShelleyLedgerEra era)))
 proposalProceduresTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.proposalProceduresTxBodyL
 
+{-# DEPRECATED
+  currentTreasuryValueTxBodyL
+  "Use currentTreasuryValueTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 currentTreasuryValueTxBodyL :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) (StrictMaybe L.Coin)
 currentTreasuryValueTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.currentTreasuryValueTxBodyL
 
+{-# DEPRECATED
+  treasuryDonationTxBodyL
+  "Use treasuryDonationTxBodyL from Cardano.Api.Ledger (via txBodyL) instead."
+  #-}
 treasuryDonationTxBodyL :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) L.Coin
 treasuryDonationTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.treasuryDonationTxBodyL
 
@@ -245,9 +294,17 @@ multiAssetL w =
       (\(L.MaryValue _ ma) -> ma)
       (\(L.MaryValue c _) ma -> L.MaryValue c ma)
 
+{-# DEPRECATED
+  valueTxOutL
+  "Use valueTxOutL from Cardano.Api.Ledger instead."
+  #-}
 valueTxOutL
   :: ShelleyBasedEra era -> Lens' (L.TxOut (ShelleyLedgerEra era)) (L.Value (ShelleyLedgerEra era))
 valueTxOutL sbe = shelleyBasedEraConstraints sbe L.valueTxOutL
 
+{-# DEPRECATED
+  valueTxOutAdaAssetL
+  "Use coinTxOutL from Cardano.Api.Ledger instead."
+  #-}
 valueTxOutAdaAssetL :: ShelleyBasedEra era -> Lens' (L.TxOut (ShelleyLedgerEra era)) L.Coin
 valueTxOutAdaAssetL sbe = valueTxOutL sbe . adaAssetL sbe

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body/Lens.hs
@@ -48,11 +48,13 @@ import Cardano.Api.Era.Internal.Case
 import Cardano.Api.Era.Internal.Eon.AllegraEraOnwards
 import Cardano.Api.Era.Internal.Eon.AlonzoEraOnwards
 import Cardano.Api.Era.Internal.Eon.BabbageEraOnwards
+import Cardano.Api.Era.Internal.Eon.Convert (Convert (convert))
 import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
 import Cardano.Api.Era.Internal.Eon.MaryEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
 import Cardano.Api.Era.Internal.Eon.ShelleyEraOnly
 import Cardano.Api.Era.Internal.Eon.ShelleyToBabbageEra
+import Cardano.Api.Experimental.Era (obtainCommonConstraints)
 import Cardano.Api.Internal.Orphans ()
 
 import Cardano.Ledger.Allegra.Core qualified as L
@@ -169,7 +171,9 @@ reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsAlonzo = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsBabbage = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
 reqSignerHashesTxBodyL w@AlonzoEraOnwardsConway = alonzoEraOnwardsConstraints w $ txBodyL . L.reqSignerHashesTxBodyL
-reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = error "TODO Dijkstra: reqSignerHashesTxBodyL: era not supported"
+-- Dijkstra replaced required signer hashes with guards; the ledger gates its
+-- lens to @AtMostEra "Conway"@ and stubs the instance with 'L.notSupportedInThisEraL'.
+reqSignerHashesTxBodyL AlonzoEraOnwardsDijkstra = L.notSupportedInThisEraL
 
 referenceInputsTxBodyL
   :: BabbageEraOnwards era -> Lens' (LedgerTxBody era) (Set L.TxIn)
@@ -188,18 +192,18 @@ certsTxBodyL w = shelleyBasedEraConstraints w $ txBodyL . L.certsTxBodyL
 
 votingProceduresTxBodyL
   :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) (L.VotingProcedures (ShelleyLedgerEra era))
-votingProceduresTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.votingProceduresTxBodyL
+votingProceduresTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.votingProceduresTxBodyL
 
 proposalProceduresTxBodyL
   :: ConwayEraOnwards era
   -> Lens' (LedgerTxBody era) (L.OSet (L.ProposalProcedure (ShelleyLedgerEra era)))
-proposalProceduresTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.proposalProceduresTxBodyL
+proposalProceduresTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.proposalProceduresTxBodyL
 
 currentTreasuryValueTxBodyL :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) (StrictMaybe L.Coin)
-currentTreasuryValueTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.currentTreasuryValueTxBodyL
+currentTreasuryValueTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.currentTreasuryValueTxBodyL
 
 treasuryDonationTxBodyL :: ConwayEraOnwards era -> Lens' (LedgerTxBody era) L.Coin
-treasuryDonationTxBodyL w = conwayEraOnwardsConstraints w $ txBodyL . L.treasuryDonationTxBodyL
+treasuryDonationTxBodyL w = obtainCommonConstraints (convert w) $ txBodyL . L.treasuryDonationTxBodyL
 
 mkAdaOnlyTxOut
   :: ShelleyBasedEra era

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -868,7 +868,7 @@ fromShelleyTxOut
   -> L.TxOut (ShelleyLedgerEra era)
   -> TxOut ctx era
 fromShelleyTxOut sbe ledgerTxOut = shelleyBasedEraConstraints sbe $ do
-  let txOutValue = TxOutValueShelleyBased sbe $ ledgerTxOut ^. A.valueTxOutL sbe
+  let txOutValue = TxOutValueShelleyBased sbe $ ledgerTxOut ^. L.valueTxOutL
   let addressInEra = fromShelleyAddr sbe $ ledgerTxOut ^. L.addrTxOutL
 
   case sbe of

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Output.hs
@@ -813,6 +813,12 @@ toShelleyTxOut sbe = shelleyBasedEraConstraints sbe $ \case
                 .~ toBabbageTxOutDatumUTxO txoutdata
               & L.referenceScriptTxOutL
                 .~ refScriptToShelleyScript sbe refScript
+          AlonzoEraOnwardsDijkstra ->
+            L.mkBasicTxOut (toShelleyAddr addr) value
+              & L.datumTxOutL
+                .~ toBabbageTxOutDatumUTxO txoutdata
+              & L.referenceScriptTxOutL
+                .~ refScriptToShelleyScript sbe refScript
       )
 
 -- | A variant of 'toShelleyTxOutAny that is used only internally to this module
@@ -842,6 +848,12 @@ toShelleyTxOutAny sbe = shelleyBasedEraConstraints sbe $ \case
               & L.referenceScriptTxOutL
                 .~ refScriptToShelleyScript sbe refScript
           AlonzoEraOnwardsConway ->
+            L.mkBasicTxOut (toShelleyAddr addr) value
+              & L.datumTxOutL
+                .~ toBabbageTxOutDatum txoutdata
+              & L.referenceScriptTxOutL
+                .~ refScriptToShelleyScript sbe refScript
+          AlonzoEraOnwardsDijkstra ->
             L.mkBasicTxOut (toShelleyAddr addr) value
               & L.datumTxOutL
                 .~ toBabbageTxOutDatum txoutdata
@@ -904,6 +916,23 @@ fromShelleyTxOut sbe ledgerTxOut = shelleyBasedEraConstraints sbe $ do
             SNothing -> ReferenceScriptNone
             SJust refScript ->
               fromShelleyScriptToReferenceScript ShelleyBasedEraConway refScript
+        )
+     where
+      datum = ledgerTxOut ^. L.datumTxOutL
+      mRefScript = ledgerTxOut ^. L.referenceScriptTxOutL
+    ShelleyBasedEraDijkstra ->
+      TxOut
+        addressInEra
+        txOutValue
+        ( fromBabbageTxOutDatum
+            AlonzoEraOnwardsDijkstra
+            BabbageEraOnwardsDijkstra
+            datum
+        )
+        ( case mRefScript of
+            SNothing -> ReferenceScriptNone
+            SJust refScript ->
+              fromShelleyScriptToReferenceScript ShelleyBasedEraDijkstra refScript
         )
      where
       datum = ledgerTxOut ^. L.datumTxOutL


### PR DESCRIPTION
# Context

Make `DijkstraEra` a first-class era in `cardano-api`: everywhere the API dispatches on eras, Dijkstra now takes a real branch instead of hitting a TODO stub.

This is groundwork: it adds no Dijkstra-specific features, it makes them possible to build. Dijkstra stays hidden from era enumeration (maxBound is still Conway); exposing it there comes in a later PR.

One known gap is left on purpose: simple scripts remain unsupported in Dijkstra: they need the era's new guard construct in `SimpleScript` first, which deserves its own design discussion.

# How to trust this PR

Almost all of this is interpolation of the previous eras. Two exceptions:
1. The eon constraint bundles no longer provide `ShelleyEraTxCert/TxCert ~ ConwayTxCert` (Dijkstra dropped those certificates), so a few call sites now require them explicitly. This is the breaking part.
2. Dijkstra replaced required signer hashes with guards, so the tx-body lens has no Dijkstra arm (like the ledger's) and `createTransactionBody` translates `TxExtraKeyWitnesses` into key-hash guards (`Body.hs`, `Body/Lens.hs`).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

