### PR TITLE
haskell-wasm CI: add archive.org fallback for the ghc-wasm-meta input

### DIFF
--- a/.changes/20260819_210000_cardano-wasm_palas_wasm_ci_ghc_wasm_meta_mirror_fallback.yml
+++ b/.changes/20260819_210000_cardano-wasm_palas_wasm_ci_ghc_wasm_meta_mirror_fallback.yml
@@ -1,0 +1,6 @@
+description: |
+  Made the WASM CI job resilient to gitlab.haskell.org outages by pre-fetching the ghc-wasm-meta flake input with a fallback to a byte-identical, narHash-verified mirror on archive.org
+kind:
+  - maintenance
+pr: 1304
+project: cardano-wasm

--- a/.github/workflows/haskell-wasm.yml
+++ b/.github/workflows/haskell-wasm.yml
@@ -60,6 +60,29 @@ jobs:
         extra_nix_config: |
           accept-flake-config = true
 
+    # ghc-wasm-meta is the only flake input hosted on gitlab.haskell.org, whose
+    # availability is flaky, and an outage breaks every nix invocation below.
+    # Pre-fetch that input, falling back to a byte-identical mirror on
+    # archive.org. The narHash taken from flake.lock guarantees that whichever
+    # source responds yields exactly the locked content, and the nix
+    # invocations below then resolve the input locally without re-downloading.
+    - name: Fetch ghc-wasm-meta flake input (with archive.org mirror fallback)
+      run: |
+        rev=$(jq -r '.nodes["ghc-wasm-meta"].locked.rev' flake.lock)
+        narHash=$(jq -r '.nodes["ghc-wasm-meta"].locked.narHash' flake.lock)
+        hashQuery=${narHash//=/%3D}
+        if nix flake prefetch --option connect-timeout 60 --option download-attempts 2 \
+            "gitlab:haskell-wasm/ghc-wasm-meta/${rev}?host=gitlab.haskell.org&narHash=${hashQuery}"; then
+          echo "Fetched ghc-wasm-meta@${rev} from gitlab.haskell.org"
+        else
+          echo "::warning::gitlab.haskell.org is unavailable, falling back to the archive.org mirror of ghc-wasm-meta@${rev}"
+          nix flake prefetch \
+            "tarball+https://archive.org/download/ghc-wasm-meta-${rev}/ghc-wasm-meta-${rev}-${rev}.tar.gz?narHash=${hashQuery}" || {
+            echo "::error::The archive.org mirror does not serve ghc-wasm-meta@${rev}. If the flake input was re-pinned, upload the new GitLab archive tarball to an archive.org item named ghc-wasm-meta-${rev} (keeping GitLab's file name), or wait for gitlab.haskell.org to recover."
+            exit 1
+          }
+        fi
+
     - uses: rrbutani/use-nix-shell-action@v1
       with:
         devShell: .#wasm


### PR DESCRIPTION
# Context

gitlab.haskell.org is the only non-GitHub host among our flake inputs, and an outage breaks this workflow at `nix develop` time. Pre-fetch the ghc-wasm-meta input before the first nix invocation; if gitlab.haskell.org does not respond, fetch a byte-identical mirror of the pinned tarball from archive.org instead. The input's narHash from flake.lock is enforced on both sources, so the fallback cannot alter the build inputs; once the content is in the local store, the later nix invocations resolve the locked input without contacting gitlab.

Mirror: https://archive.org/details/ghc-wasm-meta-c662c34d608dc9d2ff599b007f2e3c46138efaab If the input is re-pinned, upload the new GitLab archive tarball to an archive.org item named ghc-wasm-meta-<rev> (keeping GitLab's file name) to keep the fallback working; the step fails with instructions otherwise.

# How to trust this PR

If the CI is still working this clearly did no harm. It should work the same as before except for when gitlab is down.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
