### PR TITLE
cardano-rpc: fix ReadGenesis initial funds and stop retaining the genesis in memory

### DIFF
--- a/.changes/20260820_cardano_api_ledgerstate_resolve_initial_funds.yml
+++ b/.changes/20260820_cardano_api_ledgerstate_resolve_initial_funds.yml
@@ -1,0 +1,9 @@
+project: cardano-api
+
+pr: 1305
+
+kind:
+  - compatible
+
+description: |
+  Export resolveShelleyInitialFunds from Cardano.Api.LedgerState. It takes a ShelleyGenesis and resolves its initial funds against its sgExtraConfig the way ledger's own genesis state construction does, including streaming InjectionFromFile sources with content-hash verification.

--- a/.changes/20260820_cardano_rpc_genesis_initial_funds_extraconfig.yml
+++ b/.changes/20260820_cardano_rpc_genesis_initial_funds_extraconfig.yml
@@ -1,0 +1,10 @@
+project: cardano-rpc
+
+pr: 1305
+
+kind:
+  - bugfix
+  - breaking
+
+description: |
+  Fixed the UTxO RPC `ReadGenesis` response reporting no initial funds for networks created with `cardano-cli create-testnet-data`, and stopped the node retaining the parsed genesis in memory for its whole lifetime. The Shelley genesis is now read from disk when `ReadGenesis` is served, verified against the genesis hash computed at node startup, and kept for five minutes after the last request; a genesis file that changed since startup fails the request with `FAILED_PRECONDITION`. Breaking change: `mkNodeKernelAccess` no longer takes `ProtocolInfoArgs` and takes the Shelley genesis file path instead.

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -167,6 +167,7 @@ library
     filepath,
     formatting,
     fs-api ^>=0.4,
+    io-classes,
     iproute,
     memory,
     mempack,

--- a/cardano-api/src/Cardano/Api/Consensus.hs
+++ b/cardano-api/src/Cardano/Api/Consensus.hs
@@ -53,6 +53,7 @@ module Cardano.Api.Consensus
     -- * Reexports from @ouroboros-consensus@
   , BlockComponent (..)
   , ByronBlock
+  , ByronPartialLedgerConfig (..)
   , CardanoBlock
   , ChainDB.ChainDB
   , ChainDB.ChainType (..)
@@ -66,6 +67,7 @@ module Cardano.Api.Consensus
   , ChainDepState
   , GenTx (..)
   , EraMismatch (..)
+  , HardForkLedgerConfig (..)
   , HasHardForkHistory (..)
   , HasHeader
   , Header
@@ -73,16 +75,20 @@ module Cardano.Api.Consensus
   , NodeKernel (..)
   , OneEraHash (..)
   , PastHorizonException
+  , PerEraLedgerConfig (..)
   , PraosProtocolSupportsNode
   , PraosProtocolSupportsNodeCrypto
   , RealPoint (..)
   , ResourceRegistry
   , SecurityParam (..)
   , ShelleyGenesisStaking (..)
+  , ShelleyPartialLedgerConfig (..)
   , StandardCrypto
   , TopLevelConfig
+  , WrapPartialLedgerConfig (..)
   , ledgerState
   , shelleyLedgerGenesis
+  , shelleyLedgerTranslationContext
   , blockHash
   , blockNo
   , blockSlot

--- a/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Consensus/Internal/Reexport.hs
@@ -1,6 +1,7 @@
 module Cardano.Api.Consensus.Internal.Reexport
   ( BlockComponent (..)
   , ByronBlock
+  , ByronPartialLedgerConfig (..)
   , CardanoBlock
   , ChainUpdate (..)
   , ConfigSupportsNode
@@ -12,18 +13,23 @@ module Cardano.Api.Consensus.Internal.Reexport
   , EraMismatch (..)
   , NodeKernel (..)
   , OneEraHash (..)
+  , HardForkLedgerConfig (..)
   , HasHardForkHistory (..)
   , PastHorizonException
+  , PerEraLedgerConfig (..)
   , PraosProtocolSupportsNode
   , PraosProtocolSupportsNodeCrypto
   , RealPoint (..)
   , ResourceRegistry
   , SecurityParam (..)
   , ShelleyGenesisStaking (..)
+  , ShelleyPartialLedgerConfig (..)
   , StandardCrypto
   , TopLevelConfig
+  , WrapPartialLedgerConfig (..)
   , ledgerState
   , shelleyLedgerGenesis
+  , shelleyLedgerTranslationContext
   , blockHash
   , blockNo
   , blockSlot
@@ -52,6 +58,7 @@ import Ouroboros.Consensus.Block
   , blockNo
   , blockSlot
   )
+import Ouroboros.Consensus.Byron.ByronHFC (ByronPartialLedgerConfig (..))
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock (byronBlockRaw), GenTx (..), byronIdTx)
 import Ouroboros.Consensus.Cardano.Block (CardanoBlock, EraMismatch (..))
 import Ouroboros.Consensus.Config
@@ -63,7 +70,12 @@ import Ouroboros.Consensus.Config
 import Ouroboros.Consensus.Config.SecurityParam (SecurityParam (..))
 import Ouroboros.Consensus.Config.SupportsNode (ConfigSupportsNode)
 import Ouroboros.Consensus.HardFork.Abstract (HasHardForkHistory (..))
-import Ouroboros.Consensus.HardFork.Combinator.AcrossEras (OneEraHash (..))
+import Ouroboros.Consensus.HardFork.Combinator.AcrossEras
+  ( OneEraHash (..)
+  , PerEraLedgerConfig (..)
+  )
+import Ouroboros.Consensus.HardFork.Combinator.Basics (HardForkLedgerConfig (..))
+import Ouroboros.Consensus.HardFork.Combinator.PartialConfig (WrapPartialLedgerConfig (..))
 import Ouroboros.Consensus.HardFork.History.EpochInfo (interpreterToEpochInfo)
 import Ouroboros.Consensus.HardFork.History.Qry
   ( PastHorizonException
@@ -79,7 +91,11 @@ import Ouroboros.Consensus.Protocol.Praos.Common
   , PraosProtocolSupportsNodeCrypto
   , getOpCertCounters
   )
-import Ouroboros.Consensus.Shelley.Ledger.Ledger (shelleyLedgerGenesis)
+import Ouroboros.Consensus.Shelley.Ledger.Ledger
+  ( ShelleyPartialLedgerConfig (..)
+  , shelleyLedgerGenesis
+  , shelleyLedgerTranslationContext
+  )
 import Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 import Ouroboros.Consensus.Storage.Common (BlockComponent (..))
 import Ouroboros.Consensus.Util.Condense (condense)

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -77,6 +77,7 @@ module Cardano.Api.LedgerState
   , GenesisConfig (..)
   , readCardanoGenesisConfig
   , mkProtocolInfoCardano
+  , resolveShelleyInitialFunds
 
     -- *** Byron Genesis Config
   , readByronGenesisConfig
@@ -174,6 +175,7 @@ import Cardano.Ledger.Keys qualified as SL
 import Cardano.Ledger.Shelley.API qualified as ShelleyAPI
 import Cardano.Ledger.Shelley.Core qualified as Core
 import Cardano.Ledger.Shelley.Genesis qualified as Ledger
+import Cardano.Ledger.Shelley.Transition qualified as Ledger
 import Cardano.Ledger.Slot qualified as Ledger
 import Cardano.Ledger.State qualified as SL
 import Cardano.Protocol.Crypto qualified as Crypto
@@ -221,8 +223,10 @@ import Ouroboros.Network.Protocol.ChainSync.PipelineDecision
 import Control.Concurrent
 import Control.DeepSeq
 import Control.Error.Util (note)
-import Control.Exception.Safe
+import Control.Exception.Safe hiding (MonadThrow)
 import Control.Monad
+import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Class.MonadThrow (MonadThrow)
 import Control.Monad.State.Strict
 import Control.Tracer qualified as Tracer
 import Data.Aeson as Aeson
@@ -272,7 +276,7 @@ import GHC.Stack (HasCallStack)
 import Lens.Micro
 import Network.Mux qualified as Mux
 import Network.TypedProtocol.Core (Nat (..))
-import System.FS.API (SomeHasFS)
+import System.FS.API (SomeHasFS (..))
 import System.FilePath
 
 data InitialLedgerStateError
@@ -1520,6 +1524,53 @@ readCardanoGenesisConfig enc = do
   let dijkstraGenesis = exampleDijkstraGenesis -- TODO Dijkstra: add plumbing to read genesis
   let transCfg = Ledger.mkLatestTransitionConfig shelleyGenesis alonzoGenesis conwayGenesis dijkstraGenesis
   pure $ GenesisCardano enc byronGenesis shelleyGenesisHash transCfg
+
+-- | Resolve a Shelley genesis' 'Ledger.sgInitialFunds' against its
+-- 'Ledger.sgExtraConfig', mirroring the resolution ledger's own
+-- @registerInitialFunds@ performs when building the initial ledger state
+-- from genesis.
+--
+-- A 'Ledger.ShelleyGenesis' carries two sources of initial funds: the legacy
+-- 'Ledger.sgInitialFunds' field, and 'Ledger.sgExtraConfig', which is where
+-- @cardano-cli create-testnet-data@ puts the funded addresses, embedded or in
+-- an external hash-verified file. The ledger reconciles the two only while
+-- building the initial ledger state and never writes the result back into the
+-- 'Ledger.ShelleyGenesis' value, so a parsed genesis read outside that path
+-- must repeat the resolution. Once the ledger drops the legacy field, the
+-- two-source reconciliation here can go, but turning 'Ledger.secInitialFunds'
+-- into actual funds (including reading and hash-checking an injection file)
+-- is still needed.
+--
+-- Throws 'Ledger.InjectionConflictingSources' if the genesis specifies initial
+-- funds through both the legacy field and the extra config, and
+-- 'Ledger.InjectionHashMismatch' if an 'Ledger.InjectionFromFile' source does
+-- not hash to the value the genesis declares for it.
+resolveShelleyInitialFunds
+  :: (MonadST m, MonadThrow m)
+  => SomeHasFS m
+  -- ^ Filesystem capability used to stream an 'Ledger.InjectionFromFile'
+  -- source, mounted at the Shelley genesis file's directory.
+  -> Ledger.ShelleyGenesis
+  -- ^ The Shelley genesis whose initial funds to resolve.
+  -> m Ledger.ShelleyGenesis
+resolveShelleyInitialFunds (SomeHasFS hasFS) genesis = do
+  initialFundsSource <-
+    Ledger.resolveInjectionSource
+      "initialFunds"
+      (Ledger.sgExtraConfig genesis)
+      Ledger.secInitialFunds
+      (Ledger.sgInitialFunds genesis)
+  resolvedInitialFunds <-
+    fromList <$> Ledger.foldInjectionData hasFS initialFundsSource (flip (:)) []
+  pure $
+    genesis
+      & Ledger.sgInitialFundsL .~ resolvedInitialFunds
+      -- The source has now been folded into 'sgInitialFunds'; null it out
+      -- so that re-resolving this (already-resolved) genesis later does
+      -- not trip 'Ledger.InjectionConflictingSources'.
+      & Ledger.sgExtraConfigL .~ (clearInitialFundsSource <$> Ledger.sgExtraConfig genesis)
+ where
+  clearInitialFundsSource extraConfig = extraConfig{Ledger.secInitialFunds = Ledger.NoInjection}
 
 exampleDijkstraGenesis :: Ledger.DijkstraGenesis
 exampleDijkstraGenesis =

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -58,6 +58,7 @@ library
     Cardano.Rpc.Server.Internal.Error
     Cardano.Rpc.Server.Internal.Monad
     Cardano.Rpc.Server.Internal.Node
+    Cardano.Rpc.Server.Internal.TimedCache
     Cardano.Rpc.Server.Internal.Tracing
     Cardano.Rpc.Server.Internal.UtxoRpc.Eval
     Cardano.Rpc.Server.Internal.UtxoRpc.Predicate
@@ -115,6 +116,7 @@ library
     errors,
     filepath,
     formatting,
+    fs-api ^>=0.4,
     generic-data,
     grapesy,
     grpc-spec,
@@ -125,6 +127,7 @@ library
     proto-lens-protobuf-types,
     random,
     rio,
+    strict-sop-core,
     text,
     time,
 

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/TimedCache.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/TimedCache.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE NoFieldSelectors #-}
+
+-- | A cache for a single value. The value is dropped once nothing has read it
+-- for a while. Use it for data that is expensive to build but too big or too
+-- rarely needed to keep around forever.
+module Cardano.Rpc.Server.Internal.TimedCache
+  ( TimedCache
+  , newTimedCache
+  , readThroughCache
+  )
+where
+
+import RIO
+
+import Data.Time.Clock (DiffTime)
+
+-- | Holds at most one value. The value is dropped once no read has happened
+-- for 'expiryTimeout'.
+--
+-- Create with 'newTimedCache', read with 'readThroughCache'.
+data TimedCache a = TimedCache
+  { cacheVar :: !(MVar (Maybe (CacheEntry a)))
+  -- ^ 'Nothing' means the cache is empty. Otherwise this holds everything the
+  -- cache knows, and it is the only mutable cell there is. Keeping the read
+  -- time inside the entry rather than beside it is what makes the cache safe:
+  -- one lock covers the value, its watcher and its deadline together, so a
+  -- reader can no longer refresh the deadline while the watcher is deciding
+  -- to drop the value. The 'MVar' is also the lock: when several readers hit
+  -- an empty cache at once, one of them loads and the others wait for its
+  -- result.
+  , expiryTimeout :: !DiffTime
+  -- ^ How long the value is kept after the last read.
+  }
+
+-- | Everything the cache holds while it is full.
+data CacheEntry a = CacheEntry
+  { cachedValue :: !a
+  -- ^ The cached value.
+  , watcher :: !(Async ())
+  -- ^ The thread that will drop this value once it goes unread. It lives here
+  -- so that a value can never be in the cache without its watcher, and so
+  -- that the handle goes away together with the value it watches.
+  , lastAccess :: !DiffTime
+  -- ^ When the value was last read, from the monotonic clock.
+  }
+
+-- | Create an empty cache.
+--
+-- This starts no thread. The watcher thread only exists while the cache
+-- holds a value, so an unused cache holds no data and runs nothing.
+newTimedCache
+  :: MonadIO m
+  => DiffTime
+  -- ^ How long the cached value is kept after the last read
+  -> m (TimedCache a)
+newTimedCache expiryTimeout = do
+  cacheVar <- newMVar Nothing
+  pure TimedCache{cacheVar, expiryTimeout}
+
+-- | Read the cached value. If the cache is empty, run the load action and
+-- cache its result. Every read restarts the expiry timer.
+--
+-- If the load throws, the exception goes to the caller and the cache stays
+-- empty. The next read simply tries again.
+readThroughCache
+  :: MonadUnliftIO m
+  => TimedCache a
+  -- ^ The cache to read
+  -> m a
+  -- ^ How to load the value on a cache miss
+  -> m a
+readThroughCache TimedCache{cacheVar, expiryTimeout} doLoad =
+  modifyMVar cacheVar $ \case
+    Just entry@CacheEntry{cachedValue} -> do
+      -- Restart the expiry timer. We hold the lock while doing it, so the
+      -- watcher cannot be reading the old deadline at the same time.
+      now <- getMonotonicDiffTime
+      pure (Just entry{lastAccess = now}, cachedValue)
+    Nothing -> do
+      -- The load runs while we hold the lock, on purpose. When several
+      -- readers hit an empty cache at once, the first one loads and the
+      -- others block on the lock until the result is stored. This gives one
+      -- load in total instead of one load per reader. Do not move the load
+      -- out of the lock.
+      loaded <- doLoad
+      -- Start the timer now that the value is ready. Timing it from when this
+      -- reader arrived would let a slow load eat part of the value's lifetime.
+      now <- getMonotonicDiffTime
+      -- Fork the watcher while still holding the lock, so the value and its
+      -- watcher go into the cache together. 'asyncWithUnmask' because a
+      -- thread forked inside a 'modifyMVar' callback starts masked, and the
+      -- watcher should run unmasked. This is hygiene only: nobody throws to
+      -- the watcher, and 'threadDelay' can be interrupted even when masked.
+      -- The handle is only stored. Nobody waits on it, links it or cancels
+      -- it: the watcher outlives this request and stops by itself.
+      watcher <- liftIO $ asyncWithUnmask (\unmask -> unmask watchForExpiry)
+      pure (Just CacheEntry{cachedValue = loaded, watcher, lastAccess = now}, loaded)
+ where
+  -- How much of the value's life is left, given when it was last read and
+  -- what the clock says now. Zero or less means it can be dropped.
+  remainingIdleTime :: DiffTime -> DiffTime -> DiffTime
+  remainingIdleTime lastAccess now = lastAccess + expiryTimeout - now
+
+  -- Sleep until the value has gone unread for 'expiryTimeout', then drop it
+  -- and exit.
+  --
+  -- There is exactly one watcher per cached value, because the watcher is
+  -- stored in the entry next to the value it watches. It drops the value at
+  -- most once, then exits, taking its own handle with it. Nothing supervises
+  -- it and nothing has to: once the cache is empty, no thread is left either.
+  watchForExpiry :: IO ()
+  watchForExpiry =
+    readMVar cacheVar >>= \case
+      -- The cache is empty, so there is nothing to watch. Only a watcher
+      -- empties the cache, and this one has not, so this should not happen.
+      -- Stopping is the right answer if it ever does.
+      Nothing -> pure ()
+      Just CacheEntry{lastAccess} -> do
+        now <- getMonotonicDiffTime
+        let remaining = remainingIdleTime lastAccess now
+        if remaining > 0
+          then do
+            -- A read may move the deadline while we sleep, so look at the
+            -- entry again instead of dropping the value right after waking up.
+            delayFor remaining
+            watchForExpiry
+          else do
+            isEmptied <- modifyMVar cacheVar $ \case
+              -- Already empty, so there is nothing left to drop.
+              Nothing -> pure (Nothing, True)
+              Just entry@CacheEntry{lastAccess = lastAccessUnderLock} -> do
+                -- Check again while holding the lock. A read may have
+                -- restarted the timer between the check above and us getting
+                -- the lock.
+                nowUnderLock <- getMonotonicDiffTime
+                pure $
+                  if remainingIdleTime lastAccessUnderLock nowUnderLock > 0
+                    then (Just entry, False)
+                    else (Nothing, True)
+            unless isEmptied watchForExpiry
+
+-- | The monotonic clock, in seconds since some fixed point.
+--
+-- The wall clock would be wrong here. An NTP time jump could drop a value
+-- right after a read, or keep a stale one alive for hours.
+getMonotonicDiffTime :: MonadIO m => m DiffTime
+getMonotonicDiffTime = realToFrac <$> getMonotonicTime
+
+-- | Sleep for the given duration, rounded up to whole microseconds.
+delayFor :: MonadIO m => DiffTime -> m ()
+delayFor duration = threadDelay . ceiling $ duration * 1_000_000

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
@@ -28,13 +28,13 @@ import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as UtxoRpc
 import Cardano.Rpc.Server.Internal.Error
 import Cardano.Rpc.Server.Internal.Monad
 import Cardano.Rpc.Server.Internal.Orphans ()
+import Cardano.Rpc.Server.Internal.TimedCache (readThroughCache)
 import Cardano.Rpc.Server.Internal.UtxoRpc.Predicate
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type
 import Cardano.Rpc.Server.NodeKernelAccess
 
 import Cardano.Crypto.Hash.Class qualified as Crypto (hashToBytes)
-import Cardano.Ledger.Api.Transition qualified as L (tcShelleyGenesisL)
-import Cardano.Ledger.Shelley.Genesis qualified as L (sgNetworkMagic)
+import Cardano.Ledger.Shelley.Genesis qualified as L (ShelleyGenesis, sgNetworkMagic)
 
 import RIO hiding (toList)
 
@@ -42,9 +42,13 @@ import Control.Error.Util (hush)
 import Data.Default
 import Data.List (sortBy)
 import Data.ProtoLens (defMessage)
+import Data.Text qualified as Text (pack)
 import Data.Time.Clock (UTCTime)
 import GHC.IsList
 import Network.GRPC.Spec
+import System.FS.API (MountPoint (..), SomeHasFS (..))
+import System.FS.IO (ioHasFS)
+import System.FilePath (takeDirectory)
 
 -- | Handle the @ReadParams@ RPC method.
 -- Queries the node for current protocol parameters and returns them
@@ -170,20 +174,84 @@ searchUtxosMethod req = do
 -- Returns the chain's identity - the Shelley genesis hash and the CAIP-2 chain
 -- identifier - together with the @cardano@ config, the Byron, Shelley, Alonzo
 -- and Conway genesis parameters mapped by 'genesisBundleToProto'.
+--
+-- The whole Shelley genesis comes from the bundle's cache, so the file is only
+-- read on a cache miss. The @FAILED_PRECONDITION@ that
+-- 'readShelleyGenesisWithInitialFunds' raises for a genesis file that has
+-- changed since the node started is therefore raised on cache misses only: a
+-- file edited while the cache is warm goes unnoticed until the cache next
+-- empties, which is at most five idle minutes later.
 readGenesisMethod
   :: MonadRpc e m
   => Proto UtxoRpc.ReadGenesisRequest
   -> m (Proto UtxoRpc.ReadGenesisResponse)
 readGenesisMethod _req = do
   -- TODO: field masks are ignored for now (same as readParamsMethod)
-  NodeKernelAccess{genesisConfig = genesisBundle@GenesisBundle{shelleyGenesisHash, transitionConfig}} <-
+  NodeKernelAccess
+    { genesisConfig =
+      genesisBundle@GenesisBundle
+        { shelleyGenesisHash
+        , shelleyGenesis = (shelleyGenesisFile, shelleyGenesisCache)
+        }
+    } <-
     grabNodeKernelAccess
-  let networkMagic = L.sgNetworkMagic $ transitionConfig ^. L.tcShelleyGenesisL
+  shelleyGenesis <-
+    readThroughCache shelleyGenesisCache $
+      readShelleyGenesisWithInitialFunds shelleyGenesisFile shelleyGenesisHash
   pure $
     defMessage
       & U5c.genesis .~ Crypto.hashToBytes (unGenesisHashShelley shelleyGenesisHash)
-      & U5c.caip2 .~ networkMagicToCaip2 networkMagic
-      & U5c.cardano .~ genesisBundleToProto genesisBundle
+      & U5c.caip2 .~ networkMagicToCaip2 (L.sgNetworkMagic shelleyGenesis)
+      & U5c.cardano .~ genesisBundleToProto genesisBundle shelleyGenesis
+
+-- | Re-read the Shelley genesis file to recover the network's initial funds.
+--
+-- The genesis consensus keeps in memory is compacted, with the initial funds
+-- erased, so the file is the only place they can come from.
+readShelleyGenesisWithInitialFunds
+  :: forall e m
+   . MonadRpc e m
+  => ShelleyGenesisFile In
+  -- ^ Path to the Shelley genesis file, as the node was configured with it
+  -> GenesisHashShelley
+  -- ^ Blake2b-256 hash the node computed over that file at startup
+  -> m L.ShelleyGenesis
+readShelleyGenesisWithInitialFunds shelleyGenesisFile@(File path) bootGenesisHash = do
+  -- 'readShelleyGenesis' is the node's own boot-time path: it reads the bytes,
+  -- hashes them and checks them against the hash we pass in, then decodes.
+  -- Running it at IO because its 'MonadIOTransError' needs a 'MonadCatch' that
+  -- 'MonadRpc' does not provide.
+  ShelleyConfig bootGenesis _ <-
+    either rejectGenesisFile pure
+      =<< liftIO (runExceptT (readShelleyGenesis shelleyGenesisFile (Just bootGenesisHash)))
+  -- An injection file is named relative to the genesis file's own directory,
+  -- which is where consensus mounts it when it injects the funds itself.
+  let genesisDirectory = SomeHasFS . ioHasFS . MountPoint $ takeDirectory path
+  either (rejectInitialFunds . displayException) pure
+    =<< tryAny (liftIO $ resolveShelleyInitialFunds genesisDirectory bootGenesis)
+ where
+  -- Both helpers carry explicit signatures because their result type is
+  -- polymorphic, which MonoLocalBinds would otherwise refuse to generalise on
+  -- GHC 9.6 and 9.10.
+  rejectGenesisFile :: ShelleyGenesisError -> m a
+  rejectGenesisFile = \case
+    -- Deliberately not 'renderShelleyGenesisError' for this one: its wording
+    -- blames the hash given in the node's configuration file, whereas the hash
+    -- we compare against is the one the node itself computed at startup.
+    ShelleyGenesisHashMismatch{} ->
+      throwGrpcErrorWithMessage GrpcFailedPrecondition $
+        "The Shelley genesis file "
+          <> tshow path
+          <> " has changed since the node started, so it no longer describes the genesis the node is running on."
+    err -> throwGrpcErrorWithMessage GrpcInternal $ renderShelleyGenesisError err
+
+  rejectInitialFunds :: String -> m a
+  rejectInitialFunds reason =
+    throwGrpcErrorWithMessage GrpcInternal $
+      "Cannot resolve the initial funds of the Shelley genesis file "
+        <> tshow path
+        <> ": "
+        <> Text.pack reason
 
 -- | The CAIP-2 chain identifier for a Cardano network, keyed on the Shelley
 -- network magic.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Genesis.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Genesis.hs
@@ -76,7 +76,6 @@ import Cardano.Crypto qualified as Byron
 import Cardano.Ledger.Address qualified as L
 import Cardano.Ledger.Alonzo.Genesis qualified as L
 import Cardano.Ledger.Api qualified as L
-import Cardano.Ledger.Api.Transition qualified as L
 import Cardano.Ledger.BaseTypes qualified as L
 import Cardano.Ledger.Conway.PParams qualified as L
 import Cardano.Ledger.Hashes qualified as L
@@ -98,27 +97,19 @@ import Network.GRPC.Spec
 
 -- | Convert the network's genesis bundle to the UTxO RPC 'U5c.Genesis'
 -- message, populating the Byron, Shelley, Alonzo and Conway fields.
-genesisBundleToProto :: GenesisBundle -> Proto U5c.Genesis
-genesisBundleToProto GenesisBundle{byronConfig, transitionConfig} =
-  byronGenesisToProto byronGenesis
+--
+-- The Shelley genesis is passed in separately rather than taken from the bundle,
+-- because the copy the bundle holds is the one consensus compacted: its initial
+-- funds have to be recovered from the genesis file first, which is a read and so
+-- cannot happen in this pure mapping (see
+-- 'Cardano.Rpc.Server.Internal.UtxoRpc.Query.readGenesisMethod').
+genesisBundleToProto :: GenesisBundle -> L.ShelleyGenesis -> Proto U5c.Genesis
+genesisBundleToProto GenesisBundle{byronConfig, alonzoGenesis, conwayGenesis} shelleyGenesis =
+  byronGenesisToProto (Byron.configGenesisData byronConfig)
     . shelleyGenesisToProto shelleyGenesis
     . alonzoGenesisToProto alonzoGenesis
     . conwayGenesisToProto conwayGenesis
     $ defMessage
- where
-  byronGenesis = Byron.configGenesisData byronConfig
-  shelleyGenesis = transitionConfig ^. L.tcShelleyGenesisL
-  -- LatestKnownEra is Dijkstra; its previous era is Conway, whose translation
-  -- context is the Conway genesis.
-  conwayGenesis = transitionConfig ^. L.tcPreviousEraConfigL . L.tcTranslationContextL
-  -- Dijkstra -> Conway -> Babbage -> Alonzo config, whose translation context
-  -- is the Alonzo genesis.
-  alonzoGenesis =
-    transitionConfig
-      ^. L.tcPreviousEraConfigL
-        . L.tcPreviousEraConfigL
-        . L.tcPreviousEraConfigL
-        . L.tcTranslationContextL
 
 --------------------------------------------------------------------------------
 -- Byron

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
@@ -20,6 +21,7 @@ where
 import Cardano.Api
 import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Rpc.Server.Internal.Monad (MonadRpc, grab)
+import Cardano.Rpc.Server.Internal.TimedCache (newTimedCache)
 import Cardano.Rpc.Server.Internal.Tracing
 import Cardano.Rpc.Server.NodeKernelAccess.Type
 
@@ -29,27 +31,31 @@ import Control.Tracer (Tracer, traceWith)
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy qualified as BSL
 import Data.IORef
+import Data.SOP.Strict (NP (..))
 import Data.Text (pack)
-import Network.GRPC.Spec
+import Data.Time.Clock (DiffTime)
+-- Imported narrowly: grpc-spec exports an unrelated ':*' which would otherwise
+-- make the 'NP' pattern match in 'readGenesisBundle' ambiguous.
+import Network.GRPC.Spec (GrpcError (..), GrpcException (..))
 
 -- | Construct 'NodeKernelAccess' from a consensus 'Consensus.NodeKernel'.
 -- Returns 'Nothing' and traces the block type for non-Cardano block types.
 mkNodeKernelAccess
-  :: Monad m
+  :: MonadIO m
   => Tracer m TraceRpc
   -- ^ Tracer for RPC events
   -> GenesisHashShelley
   -- ^ Boot-time Shelley genesis hash
-  -> Consensus.ProtocolInfoArgs n blk
-  -- ^ Protocol info arguments (carrying the parsed genesis and transition
-  -- config)
+  -> ShelleyGenesisFile In
+  -- ^ Path to the Shelley genesis file the node was configured with
   -> Consensus.BlockType blk
   -- ^ Block type witness
   -> Consensus.NodeKernel IO addrNTN addrNTC blk
   -- ^ Consensus node kernel
   -> m (Maybe NodeKernelAccess)
-mkNodeKernelAccess tracer shelleyGenesisHash protocolInfoArgs blockType kernel = case blockType of
-  Consensus.CardanoBlockType ->
+mkNodeKernelAccess tracer shelleyGenesisHash shelleyGenesisFile blockType kernel = case blockType of
+  Consensus.CardanoBlockType -> do
+    genesisConfig <- readGenesisBundle shelleyGenesisHash shelleyGenesisFile topLevelConfig
     pure $ Just NodeKernelAccess{chainDb, systemStart, readEraHistory, securityParam, genesisConfig}
    where
     chainDb = Consensus.getChainDB kernel
@@ -57,7 +63,6 @@ mkNodeKernelAccess tracer shelleyGenesisHash protocolInfoArgs blockType kernel =
     ledgerConfig = Consensus.configLedger topLevelConfig
     systemStart = Consensus.nodeSystemStart topLevelConfig
     securityParam = Consensus.configSecurityParam topLevelConfig
-    genesisConfig = readGenesisBundle shelleyGenesisHash protocolInfoArgs
     -- Read the current ledger state (cheap STM TVar read) and recompute
     -- the era summary on every call - O(number_of_eras).
     -- This is the same approach consensus uses for GetInterpreter queries
@@ -73,18 +78,57 @@ mkNodeKernelAccess tracer shelleyGenesisHash protocolInfoArgs blockType kernel =
     traceWith tracer . inject . TraceRpcUnsupportedBlockType . pack $ show blockType
     pure Nothing
 
--- | Gather the network's genesis configuration from the node's boot-time
--- 'Consensus.ProtocolInfoArgs'.
+-- | How long the resolved Shelley genesis is kept after the request that last
+-- needed it: five minutes.
+--
+-- Long enough that a client walking through several genesis queries pays the
+-- re-read once, short enough that an idle node is back to retaining nothing
+-- soon after being left alone.
+shelleyGenesisExpiryTimeout :: DiffTime
+shelleyGenesisExpiryTimeout = 5 * 60
+
+-- | Gather the network's genesis configuration out of the node kernel's ledger
+-- config, so that the RPC server shares the node's own genesis values instead of
+-- holding a second copy alive for the lifetime of the process.
+--
+-- The per-era ledger configs are matched positionally and exhaustively, so a new
+-- Cardano era is a compile error here rather than a silently misread genesis.
+-- The Shelley slot is matched but not read. The node only has a compacted copy
+-- with the initial funds erased, so the file is the only useful source and the
+-- cache reads it when a caller asks.
+--
+-- The only thing allocated here is that empty cache. Nothing is read from disk
+-- and no thread is started.
 readGenesisBundle
-  :: GenesisHashShelley
-  -> Consensus.ProtocolInfoArgs n (Consensus.CardanoBlock Consensus.StandardCrypto)
-  -> GenesisBundle
-readGenesisBundle shelleyGenesisHash (Consensus.ProtocolInfoArgsCardano _ cardanoProtocolParams) =
-  GenesisBundle
-    { byronConfig = Consensus.byronGenesis $ Consensus.byronProtocolParams cardanoProtocolParams
-    , shelleyGenesisHash
-    , transitionConfig = Consensus.cardanoLedgerTransitionConfig cardanoProtocolParams
-    }
+  :: MonadIO m
+  => GenesisHashShelley
+  -> ShelleyGenesisFile In
+  -> Consensus.TopLevelConfig (Consensus.CardanoBlock Consensus.StandardCrypto)
+  -> m GenesisBundle
+readGenesisBundle shelleyGenesisHash shelleyGenesisFile topLevelConfig =
+  case Consensus.getPerEraLedgerConfig perEraLedgerConfig of
+    Consensus.WrapPartialLedgerConfig byron
+      :* _shelley
+      :* _allegra
+      :* _mary
+      :* Consensus.WrapPartialLedgerConfig alonzo
+      :* _babbage
+      :* Consensus.WrapPartialLedgerConfig conway
+      :* _dijkstra
+      :* Nil -> do
+        shelleyGenesisCache <- newTimedCache shelleyGenesisExpiryTimeout
+        pure
+          GenesisBundle
+            { byronConfig = Consensus.byronLedgerConfig byron
+            , shelleyGenesisHash
+            , shelleyGenesis = (shelleyGenesisFile, shelleyGenesisCache)
+            , alonzoGenesis =
+                Consensus.shelleyLedgerTranslationContext $ Consensus.shelleyLedgerConfig alonzo
+            , conwayGenesis =
+                Consensus.shelleyLedgerTranslationContext $ Consensus.shelleyLedgerConfig conway
+            }
+ where
+  perEraLedgerConfig = Consensus.hardForkLedgerConfigPerEra $ Consensus.configLedger topLevelConfig
 
 -- | Grab the current 'NodeKernelAccess' from the environment, or throw
 -- gRPC UNAVAILABLE if the node kernel has not yet initialised.

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Type.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
@@ -7,12 +8,20 @@ module Cardano.Rpc.Server.NodeKernelAccess.Type
   )
 where
 
-import Cardano.Api (EraHistory, GenesisHashShelley, SystemStart)
+import Cardano.Api
+  ( EraHistory
+  , FileDirection (In)
+  , GenesisHashShelley
+  , ShelleyGenesisFile
+  , SystemStart
+  )
 import Cardano.Api.Consensus qualified as Consensus
+import Cardano.Rpc.Server.Internal.TimedCache (TimedCache)
 
 import Cardano.Chain.Genesis qualified as Byron (Config)
-import Cardano.Ledger.Api.Era qualified as L (LatestKnownEra)
-import Cardano.Ledger.Api.Transition qualified as L (TransitionConfig)
+import Cardano.Ledger.Alonzo.Genesis qualified as L (AlonzoGenesis)
+import Cardano.Ledger.Conway.Genesis qualified as L (ConwayGenesis)
+import Cardano.Ledger.Shelley.Genesis qualified as L (ShelleyGenesis)
 
 import Control.Monad.IO.Class (MonadIO)
 
@@ -35,20 +44,27 @@ data NodeKernelAccess = NodeKernelAccess
   -- than /k/ blocks.
   , genesisConfig :: GenesisBundle
   -- ^ The network's genesis configuration.
-  -- Genesis data never changes after startup, so it is read once and stored
-  -- as a pure value.
+  -- Genesis data never changes after startup. Most of it is shared with the
+  -- running node. The Shelley genesis is read from its file when a caller
+  -- asks for it, and dropped again afterwards.
   }
 
 -- | The per-era genesis configuration of the network the node is running on.
 --
--- Gathered once, when the node kernel hook fires. The Byron genesis and the
--- Shelley-onwards transition config are both read straight off
--- 'Consensus.CardanoProtocolParams', part of cardano-node's boot-time
--- 'Consensus.ProtocolInfoArgs'. No hard-fork navigation is needed.
+-- Gathered once, when the node kernel hook fires, by walking the per-era ledger
+-- configs of the node kernel's 'Consensus.TopLevelConfig'. The Byron, Alonzo and
+-- Conway genesis values are the ones the running node holds, shared with it
+-- rather than copied. Nothing is kept from cardano-node's boot-time
+-- 'Consensus.ProtocolInfoArgs', whose Shelley genesis reaches gigabytes on
+-- networks with large initial fund sets.
 --
--- The Shelley genesis hash is the exception: 'Consensus.ProtocolInfoArgs'
--- does not carry it, so it is threaded in separately from cardano-node's own
--- boot-time genesis parsing (see
+-- The Shelley genesis is not kept here at all. All the node has is a compacted
+-- copy with the initial funds erased, which is no use to a caller, so
+-- 'shelleyGenesis' holds the file and a cache instead and the genesis is read
+-- from disk when someone asks for it.
+--
+-- The Shelley genesis hash and file path come from cardano-node's own boot-time
+-- genesis parsing, because the ledger config carries neither (see
 -- 'Cardano.Rpc.Server.NodeKernelAccess.mkNodeKernelAccess').
 data GenesisBundle = GenesisBundle
   { byronConfig :: !Byron.Config
@@ -56,10 +72,17 @@ data GenesisBundle = GenesisBundle
   -- the hash the Byron ledger computed when it parsed the file.
   , shelleyGenesisHash :: !GenesisHashShelley
   -- ^ Blake2b-256 hash of the raw Shelley genesis file bytes.
-  , transitionConfig :: !(L.TransitionConfig L.LatestKnownEra)
-  -- ^ The Shelley-onwards genesis configuration, in the same representation
-  -- 'Cardano.Api.LedgerState.GenesisConfig' uses.
-  -- It retains the full parsed Shelley genesis, including @sgInitialFunds@
-  -- and @sgStaking@; consensus keeps only a compacted copy with those fields
-  -- erased.
+  , shelleyGenesis :: !(ShelleyGenesisFile In, TimedCache L.ShelleyGenesis)
+  -- ^ The Shelley genesis file the node booted from, and a cache of that file
+  -- parsed in full, with the initial funds resolved. The two belong together:
+  -- the path is what the cache loads from. The cache starts empty, is filled by
+  -- the first request that needs the genesis, and empties itself once five
+  -- minutes have passed without another one. A node whose genesis nobody asks
+  -- about therefore keeps none of it in memory (issue #1314).
+  , alonzoGenesis :: !L.AlonzoGenesis
+  -- ^ The Alonzo genesis, which the ledger keeps as the Alonzo translation
+  -- context.
+  , conwayGenesis :: !L.ConwayGenesis
+  -- ^ The Conway genesis, which the ledger keeps as the Conway translation
+  -- context.
   }


### PR DESCRIPTION
# Context

The UTxO RPC `ReadGenesis` response reported an empty `initial_funds` map for any network created with `cardano-cli create-testnet-data`.
`create-testnet-data` provisions wallets by writing their funded addresses into the Shelley genesis' `sgExtraConfig.secInitialFunds`, leaving the legacy `sgInitialFunds` field empty, but cardano-rpc's `ReadGenesis` handler read only `sgInitialFunds`.

Fixing that at `GenesisBundle` construction time would have entrenched #1314: the bundle already retained the whole boot-time `TransitionConfig`, keeping the full parsed genesis in memory for the node's lifetime whether or not RPC was enabled.
This PR fixes both problems together.

Fixes #1314.

- `GenesisBundle` no longer stores anything reachable from `ProtocolInfoArgs`.
  The Byron, Alonzo and Conway genesis values are shared with consensus' own ledger config, and the Shelley genesis is not kept at all, since the only copy the node has is compacted with the initial funds erased.
- The `ReadGenesis` handler reads the Shelley genesis file on demand and verifies its bytes against the hash the node computed at startup; a file that changed since startup fails the request with `FAILED_PRECONDITION`.
  Initial funds are resolved with ledger's own `resolveInjectionSource`/`foldInjectionData`, handling both `EmbeddedInjection` and `InjectionFromFile`, the latter streamed with content-hash verification.
- The resolved genesis is held in a new `TimedCache`: concurrent requests arriving at an empty cache share a single load, every read extends the value's life, and it empties itself after five minutes without a read.
  An idle or unqueried node retains no genesis data and runs no cache thread.
- cardano-api additionally exports `resolveShelleyInitialFunds`, operating on a `ShelleyGenesis`.
- Breaking: `mkNodeKernelAccess` no longer takes `ProtocolInfoArgs` and takes the Shelley genesis file path instead.

The original bug was caught by the `ReadGenesis` integration test added in cardano-node PR [#6655](https://github.com/IntersectMBO/cardano-node/pull/6655).
A stacked cardano-node PR adapting the `mkNodeKernelAccess` call site and re-enabling the `initialFunds` assertion will follow.

# How to trust this PR

- The cardano-rpc unit suite passes (`cabal test cardano-rpc-test`, 98 tests); the Genesis fixture and property tests pin the per-era proto mappings byte-for-byte.
- Consumed via a temporary `source-repository-package` stanza in cardano-node's `cabal.project` pointing at this branch's head commit, the stacked cardano-node PR will demonstrate the initial-funds fix against the real integration test.
- The retention fix has not been heap-profiled yet.
  To verify it, profile a node with a large genesis as in #1314: the `Addr`/`KeyHashObj`/cons-cell bands should return to their 11.0 levels, since nothing in `GenesisBundle` holds the parsed genesis after startup.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details - unit tests for `TimedCache` and the funds resolution are queued on this branch; integration coverage is the `ReadGenesis` test in the stacked cardano-node PR
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
