### PR TITLE
Support Dijkstra protocol parameters

### DIFF
--- a/.changes/20260822_025911_cardano-api_palas_dijkstra_protocol_parameters.yml
+++ b/.changes/20260822_025911_cardano-api_palas_dijkstra_protocol_parameters.yml
@@ -1,0 +1,6 @@
+description: |
+  Protocol-parameter updates can now be created and inspected for `DijkstraEra`, via the new `DijkstraEraBasedProtocolParametersUpdate`. It adds the four parameters introduced in Dijkstra: the maximum reference-script size per block and per transaction, and the reference-script cost stride and multiplier.
+kind:
+  - feature
+pr: 1309
+project: cardano-api

--- a/cardano-api/gen/Test/Gen/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/ProtocolParameters.hs
@@ -10,6 +10,7 @@ import Cardano.Api.Ledger
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Core.Arbitrary (genEraProtVer)
+import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
 
 import Hedgehog (MonadGen)
 import Hedgehog.Gen qualified as Gen
@@ -102,7 +103,7 @@ genEraBasedProtocolParametersUpdate era =
     AlonzoEra -> genAlonzoEraBasedProtocolParametersUpdate
     BabbageEra -> genBabbageEraBasedProtocolParametersUpdate
     ConwayEra -> genConwayEraBasedProtocolParametersUpdate
-    DijkstraEra -> error "TODO Dijkstra: genEraBasedProtocolParametersUpdate: era not supported"
+    DijkstraEra -> genDijkstraEraBasedProtocolParametersUpdate
 
 genShelleyEraBasedProtocolParametersUpdate
   :: MonadGen m => m (EraBasedProtocolParametersUpdate ShelleyEra)
@@ -157,3 +158,21 @@ genConwayEraBasedProtocolParametersUpdate =
     <*> genAlonzoOnwardsPParams
     <*> genIntroducedInBabbagePParams
     <*> genIntroducedInConwayPParams
+
+genIntroducedInDijkstraPParams :: MonadGen m => m (IntroducedInDijkstraPParams era)
+genIntroducedInDijkstraPParams =
+  IntroducedInDijkstraPParams
+    <$> genStrictMaybe Q.arbitrary
+    <*> genStrictMaybe Q.arbitrary
+    <*> genStrictMaybe Q.arbitrary
+    <*> genStrictMaybe Q.arbitrary
+
+genDijkstraEraBasedProtocolParametersUpdate
+  :: MonadGen m => m (EraBasedProtocolParametersUpdate DijkstraEra)
+genDijkstraEraBasedProtocolParametersUpdate =
+  DijkstraEraBasedProtocolParametersUpdate
+    <$> genCommonProtocolParametersUpdate
+    <*> genAlonzoOnwardsPParams
+    <*> genIntroducedInBabbagePParams
+    <*> genIntroducedInConwayPParams
+    <*> genIntroducedInDijkstraPParams

--- a/cardano-api/src/Cardano/Api/Internal/Orphans/Misc.hs
+++ b/cardano-api/src/Cardano/Api/Internal/Orphans/Misc.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Binary
 import Cardano.Ledger.Binary qualified as CBOR
 import Cardano.Ledger.Coin qualified as L
 import Cardano.Ledger.Conway.PParams qualified as Ledger
+import Cardano.Ledger.Dijkstra.PParams qualified as Ledger
 import Cardano.Ledger.HKD (NoUpdate (..))
 import Cardano.Ledger.Plutus.Language qualified as L
 import Cardano.Ledger.Shelley.PParams qualified as Ledger
@@ -271,6 +272,50 @@ instance Semigroup (Ledger.ConwayPParams StrictMaybe era) where
       , Ledger.cppDRepActivity = lastMappendWithTHKD Ledger.cppDRepActivity p1 p2
       , Ledger.cppMinFeeRefScriptCostPerByte =
           lastMappendWithTHKD Ledger.cppMinFeeRefScriptCostPerByte p1 p2
+      }
+
+instance Semigroup (Ledger.DijkstraPParams StrictMaybe era) where
+  (<>) p1 p2 =
+    Ledger.DijkstraPParams
+      { Ledger.dppTxFeePerByte = lastMappendWithTHKD Ledger.dppTxFeePerByte p1 p2
+      , Ledger.dppTxFeeFixed = lastMappendWithTHKD Ledger.dppTxFeeFixed p1 p2
+      , Ledger.dppMaxBBSize = lastMappendWithTHKD Ledger.dppMaxBBSize p1 p2
+      , Ledger.dppMaxTxSize = lastMappendWithTHKD Ledger.dppMaxTxSize p1 p2
+      , Ledger.dppMaxBHSize = lastMappendWithTHKD Ledger.dppMaxBHSize p1 p2
+      , Ledger.dppKeyDeposit = lastMappendWithTHKD Ledger.dppKeyDeposit p1 p2
+      , Ledger.dppPoolDeposit = lastMappendWithTHKD Ledger.dppPoolDeposit p1 p2
+      , Ledger.dppEMax = lastMappendWithTHKD Ledger.dppEMax p1 p2
+      , Ledger.dppNOpt = lastMappendWithTHKD Ledger.dppNOpt p1 p2
+      , Ledger.dppA0 = lastMappendWithTHKD Ledger.dppA0 p1 p2
+      , Ledger.dppRho = lastMappendWithTHKD Ledger.dppRho p1 p2
+      , Ledger.dppTau = lastMappendWithTHKD Ledger.dppTau p1 p2
+      , Ledger.dppProtocolVersion = NoUpdate -- For Dijkstra, protocol version cannot be changed via PParamsUpdate
+      , Ledger.dppMinPoolCost = lastMappendWithTHKD Ledger.dppMinPoolCost p1 p2
+      , Ledger.dppCoinsPerUTxOByte = lastMappendWithTHKD Ledger.dppCoinsPerUTxOByte p1 p2
+      , Ledger.dppCostModels = lastMappendWithTHKD Ledger.dppCostModels p1 p2
+      , Ledger.dppPrices = lastMappendWithTHKD Ledger.dppPrices p1 p2
+      , Ledger.dppMaxTxExUnits = lastMappendWithTHKD Ledger.dppMaxTxExUnits p1 p2
+      , Ledger.dppMaxBlockExUnits = lastMappendWithTHKD Ledger.dppMaxBlockExUnits p1 p2
+      , Ledger.dppMaxValSize = lastMappendWithTHKD Ledger.dppMaxValSize p1 p2
+      , Ledger.dppCollateralPercentage = lastMappendWithTHKD Ledger.dppCollateralPercentage p1 p2
+      , Ledger.dppMaxCollateralInputs = lastMappendWithTHKD Ledger.dppMaxCollateralInputs p1 p2
+      , Ledger.dppPoolVotingThresholds = lastMappendWithTHKD Ledger.dppPoolVotingThresholds p1 p2
+      , Ledger.dppDRepVotingThresholds = lastMappendWithTHKD Ledger.dppDRepVotingThresholds p1 p2
+      , Ledger.dppCommitteeMinSize = lastMappendWithTHKD Ledger.dppCommitteeMinSize p1 p2
+      , Ledger.dppCommitteeMaxTermLength = lastMappendWithTHKD Ledger.dppCommitteeMaxTermLength p1 p2
+      , Ledger.dppGovActionLifetime = lastMappendWithTHKD Ledger.dppGovActionLifetime p1 p2
+      , Ledger.dppGovActionDeposit = lastMappendWithTHKD Ledger.dppGovActionDeposit p1 p2
+      , Ledger.dppDRepDeposit = lastMappendWithTHKD Ledger.dppDRepDeposit p1 p2
+      , Ledger.dppDRepActivity = lastMappendWithTHKD Ledger.dppDRepActivity p1 p2
+      , Ledger.dppMinFeeRefScriptCostPerByte =
+          lastMappendWithTHKD Ledger.dppMinFeeRefScriptCostPerByte p1 p2
+      , Ledger.dppMaxRefScriptSizePerBlock =
+          lastMappendWithTHKD Ledger.dppMaxRefScriptSizePerBlock p1 p2
+      , Ledger.dppMaxRefScriptSizePerTx =
+          lastMappendWithTHKD Ledger.dppMaxRefScriptSizePerTx p1 p2
+      , Ledger.dppRefScriptCostStride = lastMappendWithTHKD Ledger.dppRefScriptCostStride p1 p2
+      , Ledger.dppRefScriptCostMultiplier =
+          lastMappendWithTHKD Ledger.dppRefScriptCostMultiplier p1 p2
       }
 
 lastMappendWithTHKD :: (a -> Ledger.THKD g StrictMaybe b) -> a -> a -> Ledger.THKD g StrictMaybe b

--- a/cardano-api/src/Cardano/Api/ProtocolParameters.hs
+++ b/cardano-api/src/Cardano/Api/ProtocolParameters.hs
@@ -39,6 +39,7 @@ module Cardano.Api.ProtocolParameters
   , ShelleyToAlonzoPParams (..)
   , IntroducedInBabbagePParams (..)
   , IntroducedInConwayPParams (..)
+  , IntroducedInDijkstraPParams (..)
   , createEraBasedProtocolParamUpdate
   , createPParams
 
@@ -112,6 +113,7 @@ import Cardano.Ledger.Babbage.Core qualified as Ledger
 import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Coin qualified as L
 import Cardano.Ledger.Conway.PParams qualified as Ledger
+import Cardano.Ledger.Dijkstra.PParams qualified as Ledger
 import Cardano.Ledger.Hashes (HASH)
 import Cardano.Ledger.Plutus.CostModels qualified as Plutus
 import Cardano.Ledger.Plutus.Language qualified as Plutus
@@ -214,6 +216,13 @@ data EraBasedProtocolParametersUpdate era where
     -> IntroducedInBabbagePParams ConwayEra
     -> IntroducedInConwayPParams (ShelleyLedgerEra ConwayEra)
     -> EraBasedProtocolParametersUpdate ConwayEra
+  DijkstraEraBasedProtocolParametersUpdate
+    :: CommonProtocolParametersUpdate
+    -> AlonzoOnwardsPParams DijkstraEra
+    -> IntroducedInBabbagePParams DijkstraEra
+    -> IntroducedInConwayPParams (ShelleyLedgerEra DijkstraEra)
+    -> IntroducedInDijkstraPParams (ShelleyLedgerEra DijkstraEra)
+    -> EraBasedProtocolParametersUpdate DijkstraEra
 
 deriving instance Show (EraBasedProtocolParametersUpdate era)
 
@@ -276,6 +285,38 @@ pparamsUpdateToIntroducedInConwayPParams ppupdate =
     , icMinFeeRefScriptCostPerByte = ppupdate ^. Ledger.ppuMinFeeRefScriptCostPerByteL
     }
 
+data IntroducedInDijkstraPParams era
+  = IntroducedInDijkstraPParams
+  { idMaxRefScriptSizePerBlock :: StrictMaybe Word32
+  , idMaxRefScriptSizePerTx :: StrictMaybe Word32
+  , idRefScriptCostStride :: StrictMaybe (Ledger.NonZero Word32)
+  , idRefScriptCostMultiplier :: StrictMaybe Ledger.PositiveInterval
+  }
+  deriving (Eq, Show)
+
+createIntroducedInDijkstraPParams
+  :: (Ledger.ConwayEraPParams ledgerera, Ledger.DijkstraEraPParams ledgerera)
+  => IntroducedInDijkstraPParams ledgerera
+  -> Ledger.PParamsUpdate ledgerera
+createIntroducedInDijkstraPParams IntroducedInDijkstraPParams{..} =
+  Ledger.emptyPParamsUpdate
+    & Ledger.ppuMaxRefScriptSizePerBlockL .~ idMaxRefScriptSizePerBlock
+    & Ledger.ppuMaxRefScriptSizePerTxL .~ idMaxRefScriptSizePerTx
+    & Ledger.ppuRefScriptCostStrideL .~ idRefScriptCostStride
+    & Ledger.ppuRefScriptCostMultiplierL .~ idRefScriptCostMultiplier
+
+pparamsUpdateToIntroducedInDijkstraPParams
+  :: Ledger.DijkstraEraPParams ledgerera
+  => Ledger.PParamsUpdate ledgerera
+  -> IntroducedInDijkstraPParams ledgerera
+pparamsUpdateToIntroducedInDijkstraPParams ppupdate =
+  IntroducedInDijkstraPParams
+    { idMaxRefScriptSizePerBlock = ppupdate ^. Ledger.ppuMaxRefScriptSizePerBlockL
+    , idMaxRefScriptSizePerTx = ppupdate ^. Ledger.ppuMaxRefScriptSizePerTxL
+    , idRefScriptCostStride = ppupdate ^. Ledger.ppuRefScriptCostStrideL
+    , idRefScriptCostMultiplier = ppupdate ^. Ledger.ppuRefScriptCostMultiplierL
+    }
+
 createEraBasedProtocolParamUpdate
   :: ShelleyBasedEra era
   -> EraBasedProtocolParametersUpdate era
@@ -318,6 +359,18 @@ createEraBasedProtocolParamUpdate sbe eraPParamsUpdate =
           Ledger.PParamsUpdate inBab = createIntroducedInBabbagePParams BabbageEraOnwardsConway introInBabbage
           Ledger.PParamsUpdate inCon = createIntroducedInConwayPParams introInConway
        in Ledger.PParamsUpdate $ common <> inAlonzoPParams <> inBab <> inCon
+    DijkstraEraBasedProtocolParametersUpdate
+      c
+      introInAlonzo
+      introInBabbage
+      introInConway
+      introInDijkstra ->
+        let Ledger.PParamsUpdate common = createCommonPParamsUpdate c
+            Ledger.PParamsUpdate inAlonzoPParams = createPParamsUpdateIntroducedInAlonzo AlonzoEraOnwardsDijkstra introInAlonzo
+            Ledger.PParamsUpdate inBab = createIntroducedInBabbagePParams BabbageEraOnwardsDijkstra introInBabbage
+            Ledger.PParamsUpdate inCon = createIntroducedInConwayPParams introInConway
+            Ledger.PParamsUpdate inDij = createIntroducedInDijkstraPParams introInDijkstra
+         in Ledger.PParamsUpdate $ common <> inAlonzoPParams <> inBab <> inCon <> inDij
 
 -- | Protocol parameters common to each era. This can only ever be reduced
 -- if parameters are deprecated.
@@ -1011,7 +1064,16 @@ fromLedgerPParamsUpdate sbe ppup =
               introInConway = pparamsUpdateToIntroducedInConwayPParams ppup
            in ConwayEraBasedProtocolParametersUpdate common introInAlonzo introInBabbage introInConway
         ShelleyBasedEraDijkstra ->
-          error "TODO Dijkstra: fromLedgerPParamsUpdate: era not supported"
+          let introInAlonzo = pparamsUpdateToAlonzoOnwardsPParams AlonzoEraOnwardsDijkstra ppup
+              introInBabbage = pparamsUpdateToIntroducedInBabbagePParams BabbageEraOnwardsDijkstra ppup
+              introInConway = pparamsUpdateToIntroducedInConwayPParams ppup
+              introInDijkstra = pparamsUpdateToIntroducedInDijkstraPParams ppup
+           in DijkstraEraBasedProtocolParametersUpdate
+                common
+                introInAlonzo
+                introInBabbage
+                introInConway
+                introInDijkstra
 
 data ProtocolParametersError
   = PParamsErrorMissingMinUTxoValue !AnyCardanoEra


### PR DESCRIPTION
# Context

Add `DijkstraEraBasedProtocolParametersUpdate` with `IntroducedInDijkstraPParams` (the reference-script size and cost parameters new in Dijkstra), the `fromLedgerPParamsUpdate` conversion back into it, a `Semigroup` instance for `DijkstraPParams` updates and generators. The protocol version itself is not updatable in Dijkstra.

# How to trust this PR

This is Conway's pattern extended by one era.

The new constructor, the `IntroducedInDijkstraPParams` record, its two conversion helpers, the `Semigroup` instance and the generators each mirror their `Conway` counterpart line-for-line, including the `NoUpdate` protocol-version arm, which is copied from the `Conway` instance directly above it.

The only genuinely new content is the four Dijkstra parameters, and those are read and written through the ledger's own `ppu…L` lenses, so there is no hand-rolled logic to check. Two previously-erroring TODO stubs are filled (`fromLedgerPParamsUpdate` and the generator dispatch), and the new generators plug into the existing era-generic test machinery.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
