### PR TITLE
Dispatch ledger queries in the Dijkstra era

### DIFF
--- a/.changes/20260822_030407_cardano-api_palas_dijkstra_ledger_queries.yml
+++ b/.changes/20260822_030407_cardano-api_palas_dijkstra_ledger_queries.yml
@@ -1,0 +1,6 @@
+description: |
+  All Conway-onwards ledger queries can now be run in the Dijkstra era: constitution, governance state, DRep and SPO state and stake distributions, committee state, vote delegatees, proposals, ratification state and future protocol parameters, default votes, and DRep delegations. Previously they errored for Dijkstra.
+kind:
+  - feature
+pr: 1310
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
@@ -73,8 +73,10 @@ import Cardano.Api.Certificate.Internal
 import Cardano.Api.Consensus.Internal.Mode
 import Cardano.Api.Era.Internal.Case
 import Cardano.Api.Era.Internal.Core
-import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards
+import Cardano.Api.Era.Internal.Eon.Convert (Convert (convert))
+import Cardano.Api.Era.Internal.Eon.ConwayEraOnwards ()
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
+import Cardano.Api.Experimental.Era (obtainCommonConstraints)
 import Cardano.Api.Genesis.Internal.Parameters
 import Cardano.Api.HasTypeProxy (HasTypeProxy (..))
 import Cardano.Api.Key.Internal
@@ -586,7 +588,9 @@ toConsensusQueryShelleyBased sbe = \case
   QueryConstitution ->
     caseShelleyToBabbageOrConwayEraOnwards
       (const $ error "toConsensusQueryShelleyBased: QueryConstitution is only available in the Conway era")
-      (const $ Some (consensusQueryInEraInMode era Consensus.GetConstitution))
+      ( \w ->
+          obtainCommonConstraints (convert w) $ Some (consensusQueryInEraInMode era Consensus.GetConstitution)
+      )
       sbe
   QueryGenesisParameters ->
     Some (consensusQueryInEraInMode era Consensus.GetGenesisConfig)
@@ -657,20 +661,26 @@ toConsensusQueryShelleyBased sbe = \case
   QueryRatifyState ->
     caseShelleyToBabbageOrConwayEraOnwards
       (const $ error "toConsensusQueryShelleyBased: QueryRatifyState is only available in the Conway era")
-      (const $ Some (consensusQueryInEraInMode era Consensus.GetRatifyState))
+      ( \w ->
+          obtainCommonConstraints (convert w) $ Some (consensusQueryInEraInMode era Consensus.GetRatifyState)
+      )
       sbe
   QueryFuturePParams ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
           error "toConsensusQueryShelleyBased: QueryFuturePParams is only available in the Conway era onwards"
       )
-      (const $ Some (consensusQueryInEraInMode era Consensus.GetFuturePParams))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some (consensusQueryInEraInMode era Consensus.GetFuturePParams)
+      )
       sbe
   QueryDRepState creds ->
     caseShelleyToBabbageOrConwayEraOnwards
       (const $ error "toConsensusQueryShelleyBased: QueryDRepState is only available in the Conway era")
       ( \w ->
-          Some (consensusQueryInEraInMode era (conwayEraOnwardsConstraints w $ Consensus.GetDRepState creds))
+          obtainCommonConstraints (convert w) $
+            Some (consensusQueryInEraInMode era (Consensus.GetDRepState creds))
       )
       sbe
   QueryDRepStakeDistr dreps ->
@@ -678,23 +688,30 @@ toConsensusQueryShelleyBased sbe = \case
       ( const $
           error "toConsensusQueryShelleyBased: QueryDRepStakeDistr is only available in the Conway era"
       )
-      (const $ Some (consensusQueryInEraInMode era (Consensus.GetDRepStakeDistr dreps)))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some (consensusQueryInEraInMode era (Consensus.GetDRepStakeDistr dreps))
+      )
       sbe
   QuerySPOStakeDistr spos ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
           error "toConsensusQueryShelleyBased: QuerySPOStakeDistr is only available in the Conway era"
       )
-      (const $ Some (consensusQueryInEraInMode era (Consensus.GetSPOStakeDistr spos)))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some (consensusQueryInEraInMode era (Consensus.GetSPOStakeDistr spos))
+      )
       sbe
   QueryCommitteeMembersState coldCreds hotCreds statuses ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
           error "toConsensusQueryShelleyBased: QueryCommitteeMembersState is only available in the Conway era"
       )
-      ( const $
-          Some
-            (consensusQueryInEraInMode era (Consensus.GetCommitteeMembersState coldCreds hotCreds statuses))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some
+              (consensusQueryInEraInMode era (Consensus.GetCommitteeMembersState coldCreds hotCreds statuses))
       )
       sbe
   QueryStakeVoteDelegatees creds ->
@@ -702,12 +719,13 @@ toConsensusQueryShelleyBased sbe = \case
       ( const $
           error "toConsensusQueryShelleyBased: QueryStakeVoteDelegatees is only available in the Conway era"
       )
-      ( const $
-          Some
-            ( consensusQueryInEraInMode
-                era
-                (Consensus.GetFilteredVoteDelegatees creds')
-            )
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some
+              ( consensusQueryInEraInMode
+                  era
+                  (Consensus.GetFilteredVoteDelegatees creds')
+              )
       )
       sbe
    where
@@ -718,9 +736,10 @@ toConsensusQueryShelleyBased sbe = \case
       ( const $
           error "toConsensusQueryShelleyBased: QueryProposals is only available in the Conway era"
       )
-      ( const $
-          Some
-            (consensusQueryInEraInMode era (Consensus.GetProposals govActs))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some
+              (consensusQueryInEraInMode era (Consensus.GetProposals govActs))
       )
       sbe
   QueryLedgerPeerSnapshot peerKind ->
@@ -731,9 +750,10 @@ toConsensusQueryShelleyBased sbe = \case
       ( const $
           error "toConsensusQueryShelleyBased: QueryStakePoolDefaultVote is only available in the Conway era"
       )
-      ( const $
-          Some
-            (consensusQueryInEraInMode era (Consensus.QueryStakePoolDefaultVote govActs))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some
+              (consensusQueryInEraInMode era (Consensus.QueryStakePoolDefaultVote govActs))
       )
       sbe
   GetDRepDelegations dreps ->
@@ -741,9 +761,10 @@ toConsensusQueryShelleyBased sbe = \case
       ( const $
           error "toConsensusQueryShelleyBased: GetDRepDelegations is only available in the Conway era"
       )
-      ( const $
-          Some
-            (consensusQueryInEraInMode era (Consensus.GetDRepDelegations dreps))
+      ( \w ->
+          obtainCommonConstraints (convert w) $
+            Some
+              (consensusQueryInEraInMode era (Consensus.GetDRepDelegations dreps))
       )
       sbe
  where

--- a/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
+++ b/cardano-api/src/Cardano/Api/Query/Internal/Type/QueryInMode.hs
@@ -587,7 +587,10 @@ toConsensusQueryShelleyBased sbe = \case
     Some (consensusQueryInEraInMode era Consensus.GetEpochNo)
   QueryConstitution ->
     caseShelleyToBabbageOrConwayEraOnwards
-      (const $ error "toConsensusQueryShelleyBased: QueryConstitution is only available in the Conway era")
+      ( const $
+          error
+            "toConsensusQueryShelleyBased: QueryConstitution is only available from the Conway era onwards"
+      )
       ( \w ->
           obtainCommonConstraints (convert w) $ Some (consensusQueryInEraInMode era Consensus.GetConstitution)
       )
@@ -660,7 +663,9 @@ toConsensusQueryShelleyBased sbe = \case
     Some (consensusQueryInEraInMode era Consensus.GetGovState)
   QueryRatifyState ->
     caseShelleyToBabbageOrConwayEraOnwards
-      (const $ error "toConsensusQueryShelleyBased: QueryRatifyState is only available in the Conway era")
+      ( const $
+          error "toConsensusQueryShelleyBased: QueryRatifyState is only available from the Conway era onwards"
+      )
       ( \w ->
           obtainCommonConstraints (convert w) $ Some (consensusQueryInEraInMode era Consensus.GetRatifyState)
       )
@@ -668,7 +673,8 @@ toConsensusQueryShelleyBased sbe = \case
   QueryFuturePParams ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryFuturePParams is only available in the Conway era onwards"
+          error
+            "toConsensusQueryShelleyBased: QueryFuturePParams is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -677,7 +683,9 @@ toConsensusQueryShelleyBased sbe = \case
       sbe
   QueryDRepState creds ->
     caseShelleyToBabbageOrConwayEraOnwards
-      (const $ error "toConsensusQueryShelleyBased: QueryDRepState is only available in the Conway era")
+      ( const $
+          error "toConsensusQueryShelleyBased: QueryDRepState is only available from the Conway era onwards"
+      )
       ( \w ->
           obtainCommonConstraints (convert w) $
             Some (consensusQueryInEraInMode era (Consensus.GetDRepState creds))
@@ -686,7 +694,8 @@ toConsensusQueryShelleyBased sbe = \case
   QueryDRepStakeDistr dreps ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryDRepStakeDistr is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: QueryDRepStakeDistr is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -696,7 +705,8 @@ toConsensusQueryShelleyBased sbe = \case
   QuerySPOStakeDistr spos ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QuerySPOStakeDistr is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: QuerySPOStakeDistr is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -706,7 +716,8 @@ toConsensusQueryShelleyBased sbe = \case
   QueryCommitteeMembersState coldCreds hotCreds statuses ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryCommitteeMembersState is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: QueryCommitteeMembersState is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -717,7 +728,8 @@ toConsensusQueryShelleyBased sbe = \case
   QueryStakeVoteDelegatees creds ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryStakeVoteDelegatees is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: QueryStakeVoteDelegatees is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -734,7 +746,7 @@ toConsensusQueryShelleyBased sbe = \case
   QueryProposals govActs ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryProposals is only available in the Conway era"
+          error "toConsensusQueryShelleyBased: QueryProposals is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -748,7 +760,8 @@ toConsensusQueryShelleyBased sbe = \case
   QueryStakePoolDefaultVote govActs ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: QueryStakePoolDefaultVote is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: QueryStakePoolDefaultVote is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $
@@ -759,7 +772,8 @@ toConsensusQueryShelleyBased sbe = \case
   GetDRepDelegations dreps ->
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          error "toConsensusQueryShelleyBased: GetDRepDelegations is only available in the Conway era"
+          error
+            "toConsensusQueryShelleyBased: GetDRepDelegations is only available from the Conway era onwards"
       )
       ( \w ->
           obtainCommonConstraints (convert w) $


### PR DESCRIPTION

# Context

Route all Conway-onwards queries (constitution, governance state, DRep/SPO state and stake distributions, committee state, vote delegatees, proposals, ratification and future parameters, default votes and DRep delegations) through
`caseShelleyToBabbageOrConwayEraOnwards` with `obtainCommonConstraints`, so they work in Dijkstra as well. Also covers the treasury query in `queryStateForBalancedTx`, the stability-window constant and the next-epoch nonce computation.

# How to trust this PR

One mechanical pattern applied thirteen times inside a single function (`toConsensusQueryShelleyBased`): each Conway-onwards query's continuation changes from `const $ Some …` to `\w -> obtainCommonConstraints (convert w) $ Some …`, which makes the same consensus query available in Dijkstra. The consensus query constructors themselves are untouched — no query logic changes, only the era gate widens. The pre-Conway error arms stay exactly as they were.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
