### PR TITLE
Enable Dijkstra-era transaction construction and balancing

### DIFF
--- a/.changes/20260822_035732_cardano-api_palas_dijkstra_tx_construction.yml
+++ b/.changes/20260822_035732_cardano-api_palas_dijkstra_tx_construction.yml
@@ -1,0 +1,9 @@
+description: |
+  Dijkstra transactions can now be built, fee-estimated and auto-balanced with the experimental API (`makeUnsignedTx`, `estimateBalancedTxBody`, `makeTransactionBodyAutoBalance`). Extra key witnesses become key-hash guards, the era's replacement for required signer hashes — the same keys must sign.
+
+  Breaking: `BalanceIsNegative` now carries the era's `UnsignedTx` instead of a Conway-specific one; code matching on it needs the more general type.
+kind:
+  - feature
+  - breaking
+pr: 1312
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/BodyContent/New.hs
@@ -187,8 +187,7 @@ makeUnsignedTx
    . Era era
   -> TxBodyContent (LedgerEra era)
   -> Either MakeUnsignedTxError (UnsignedTx (LedgerEra era))
-makeUnsignedTx DijkstraEra _ = error "TODO Dijkstra: makeUnsignedTx: era not supported"
-makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
+makeUnsignedTx era bc = obtainCommonConstraints era $ do
   let TxScriptWitnessRequirements languages scripts datums redeemers = collectTxBodyScriptWitnessRequirements bc
 
   -- cardano-api types
@@ -219,23 +218,31 @@ makeUnsignedTx era@ConwayEra bc = obtainCommonConstraints era $ do
 
   let setMint = convMintValue apiMintValue
       setReqSignerHashes = convExtraKeyWitnesses apiExtraKeyWitnesses
+      -- reqSignerHashesTxBodyL is gated AtMostEra "Conway" in the ledger;
+      -- Dijkstra replaced required signer hashes with guards, and a key-hash
+      -- guard makes the ledger demand that key's signature: translate,
+      -- appending so any other guards stay intact.
+      applyReqSignerHashes b = case era of
+        ConwayEra -> b & L.reqSignerHashesTxBodyL .~ setReqSignerHashes
+        DijkstraEra ->
+          b & L.guardsTxBodyL %~ (<> OSet.fromSet (Set.map L.KeyHashObj setReqSignerHashes))
       ledgerTxBody =
-        L.mkBasicTxBody
-          & L.inputsTxBodyL .~ txins
-          & L.collateralInputsTxBodyL .~ collTxIns
-          & L.referenceInputsTxBodyL .~ refTxIns
-          & L.outputsTxBodyL .~ outs
-          & L.totalCollateralTxBodyL .~ L.maybeToStrictMaybe totCollateral
-          & L.collateralReturnTxBodyL .~ L.maybeToStrictMaybe retCollateral
-          & L.feeTxBodyL .~ fee
-          & L.vldtTxBodyL . L.invalidBeforeL .~ L.maybeToStrictMaybe (txValidityLowerBound bc)
-          & L.vldtTxBodyL . L.invalidHereAfterL .~ L.maybeToStrictMaybe (txValidityUpperBound bc)
-          & L.reqSignerHashesTxBodyL .~ setReqSignerHashes
-          & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
-          & L.withdrawalsTxBodyL .~ withdrawals
-          & L.certsTxBodyL .~ certs
-          & L.mintTxBodyL .~ setMint
-          & L.auxDataHashTxBodyL .~ L.maybeToStrictMaybe (Ledger.hashTxAuxData <$> txAuxData)
+        applyReqSignerHashes $
+          L.mkBasicTxBody
+            & L.inputsTxBodyL .~ txins
+            & L.collateralInputsTxBodyL .~ collTxIns
+            & L.referenceInputsTxBodyL .~ refTxIns
+            & L.outputsTxBodyL .~ outs
+            & L.totalCollateralTxBodyL .~ L.maybeToStrictMaybe totCollateral
+            & L.collateralReturnTxBodyL .~ L.maybeToStrictMaybe retCollateral
+            & L.feeTxBodyL .~ fee
+            & L.vldtTxBodyL . L.invalidBeforeL .~ L.maybeToStrictMaybe (txValidityLowerBound bc)
+            & L.vldtTxBodyL . L.invalidHereAfterL .~ L.maybeToStrictMaybe (txValidityUpperBound bc)
+            & L.scriptIntegrityHashTxBodyL .~ scriptIntegrityHash
+            & L.withdrawalsTxBodyL .~ withdrawals
+            & L.certsTxBodyL .~ certs
+            & L.mintTxBodyL .~ setMint
+            & L.auxDataHashTxBodyL .~ L.maybeToStrictMaybe (Ledger.hashTxAuxData <$> txAuxData)
 
       scriptWitnesses =
         L.mkBasicTxWits
@@ -910,13 +917,11 @@ extractWitnessableVotes
   -> [(Witnessable VoterItem (LedgerEra era), AnyWitness (LedgerEra era))]
 extractWitnessableVotes Nothing = []
 extractWitnessableVotes (Just txVoteProc) =
-  case useEra @era of
-    DijkstraEra -> error "TODO Dijkstra: extractWitnessableVotes: era not supported"
-    ConwayEra ->
-      List.nub
-        [ (WitVote vote, wit)
-        | (vote, wit) <- getVotes txVoteProc
-        ]
+  obtainCommonConstraints (useEra @era) $
+    List.nub
+      [ (WitVote vote, wit)
+      | (vote, wit) <- getVotes txVoteProc
+      ]
  where
   getVotes
     :: TxVotingProcedures (LedgerEra era)

--- a/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Tx/Internal/Fee.hs
@@ -132,7 +132,7 @@ data TxBodyErrorAutoBalance era
   | BalanceIsNegative
       L.Coin
       -- ^ Negative balance
-      (UnsignedTx (LedgerEra ConwayEra))
+      (UnsignedTx era)
       -- ^ The transaction body
   | NotEnoughAdaInUTxO
       L.MaryValue
@@ -442,42 +442,40 @@ estimateBalancedTxBody'
         balanceTxOut =
           obtainCommonConstraints (useEra @era) $
             TxOut (L.mkBasicTxOut (toShelleyAddr changeaddr) balance)
-    case useEra @era of
-      DijkstraEra -> error "TODO Dijkstra: estimateBalancedTxBody: era not supported for fee estimation"
-      ConwayEra -> do
-        when (coinBalance < 0) $
-          Left $
-            TxFeeEstimationBalanceError $
-              BalanceIsNegative coinBalance txbody2
+    obtainCommonConstraints (useEra @era) $ do
+      when (coinBalance < 0) $
+        Left $
+          TxFeeEstimationBalanceError $
+            BalanceIsNegative coinBalance txbody2
 
-        -- Step 6. Check all txouts have the min required UTxO value
-        -- TOOD: Fix me. You need a new error type to accomodate your new types
-        first (TxFeeEstimationBalanceError . uncurry TxBodyErrorMinUTxONotMet)
-          . mapM_ (checkMinUTxOValue pparams)
-          $ txOuts txbodycontent1
+      -- Step 6. Check all txouts have the min required UTxO value
+      -- TOOD: Fix me. You need a new error type to accomodate your new types
+      first (TxFeeEstimationBalanceError . uncurry TxBodyErrorMinUTxONotMet)
+        . mapM_ (checkMinUTxOValue pparams)
+        $ txOuts txbodycontent1
 
-        -- check if the balance is positive or negative
-        -- in one case we can produce change, in the other the inputs are insufficient
-        finalTxOuts <-
-          first TxFeeEstimationBalanceError $
-            checkAndIncludeChange pparams balanceTxOut (txOuts txbodycontent1)
+      -- check if the balance is positive or negative
+      -- in one case we can produce change, in the other the inputs are insufficient
+      finalTxOuts <-
+        first TxFeeEstimationBalanceError $
+          checkAndIncludeChange pparams balanceTxOut (txOuts txbodycontent1)
 
-        -- Step 7.
+      -- Step 7.
 
-        -- Create the txbody with the final fee and change output. This should work
-        -- provided that the fee and change are less than 2^32-1, and so will
-        -- fit within the encoding size we picked above when calculating the fee.
-        -- Yes this could be an over-estimate by a few bytes if the fee or change
-        -- would fit within 2^16-1. That's a possible optimisation.
-        let finalTxBodyContent =
-              txbodycontent1
-                { txFee = fee
-                , txOuts = finalTxOuts
-                , txReturnCollateral = maybeReturnTxCollateral
-                , txTotalCollateral = maybeTotalTxCollateral
-                }
+      -- Create the txbody with the final fee and change output. This should work
+      -- provided that the fee and change are less than 2^32-1, and so will
+      -- fit within the encoding size we picked above when calculating the fee.
+      -- Yes this could be an over-estimate by a few bytes if the fee or change
+      -- would fit within 2^16-1. That's a possible optimisation.
+      let finalTxBodyContent =
+            txbodycontent1
+              { txFee = fee
+              , txOuts = finalTxOuts
+              , txReturnCollateral = maybeReturnTxCollateral
+              , txTotalCollateral = maybeTotalTxCollateral
+              }
 
-        return finalTxBodyContent
+      return finalTxBodyContent
 
 data IsEmpty = Empty | NonEmpty
   deriving (Eq, Show)
@@ -1684,49 +1682,47 @@ makeTransactionBodyAutoBalance
             , txTotalCollateral = maybeTotalTxCollateral
             }
 
-    case useEra @era of
-      DijkstraEra -> error "TODO Dijkstra: makeTransactionBodyAutoBalance: era not supported"
-      ConwayEra -> do
-        let balance :: L.MaryValue = evaluateTransactionBalance pp poolids stakeDelegDeposits utxo txbody2
-            adaBalance = getAda (useEra @era) balance
-        when (adaBalance < 0) $
-          Left $
-            BalanceIsNegative adaBalance txbodyForChange
+    obtainCommonConstraints (useEra @era) $ do
+      let balance :: L.MaryValue = evaluateTransactionBalance pp poolids stakeDelegDeposits utxo txbody2
+          adaBalance = getAda (useEra @era) balance
+      when (adaBalance < 0) $
+        Left $
+          BalanceIsNegative adaBalance txbodyForChange
 
-        let
-          -- The multiasset output of evaluateTransactionBalance will be negative when
-          -- minting a multiasset. Therefore we must make the multiasset balance positive
-          balanceTxOut :: TxOut (LedgerEra era) =
-            obtainCommonConstraints (useEra @era) $
-              TxOut (L.mkBasicTxOut (toShelleyAddr changeaddr) balance)
-        first (uncurry TxBodyErrorMinUTxONotMet)
-          . mapM_ (checkMinUTxOValue pp)
-          $ txOuts txbodycontent1
+      let
+        -- The multiasset output of evaluateTransactionBalance will be negative when
+        -- minting a multiasset. Therefore we must make the multiasset balance positive
+        balanceTxOut :: TxOut (LedgerEra era) =
+          obtainCommonConstraints (useEra @era) $
+            TxOut (L.mkBasicTxOut (toShelleyAddr changeaddr) balance)
+      first (uncurry TxBodyErrorMinUTxONotMet)
+        . mapM_ (checkMinUTxOValue pp)
+        $ txOuts txbodycontent1
 
-        -- check if change meets txout criteria, and include if non-zero
-        finalTxOuts <- checkAndIncludeChange pp balanceTxOut (txOuts txbodycontent1)
+      -- check if change meets txout criteria, and include if non-zero
+      finalTxOuts <- checkAndIncludeChange pp balanceTxOut (txOuts txbodycontent1)
 
-        -- TODO: we could add the extra fee for the CBOR encoding of the change,
-        -- now that we know the magnitude of the change: i.e. 1-8 bytes extra.
-        -- The txbody with the final fee and change output. This should work
-        -- provided that the fee and change are less than 2^32-1, and so will
-        -- fit within the encoding size we picked above when calculating the fee.
-        -- Yes this could be an over-estimate by a few bytes if the fee or change
-        -- would fit within 2^16-1. That's a possible optimisation.
-        let finalTxBodyContent =
-              txbodycontent1
-                { txFee = fee
-                , txOuts = finalTxOuts
-                , txReturnCollateral = maybeReturnTxCollateral
-                , txTotalCollateral = maybeTotalTxCollateral
-                }
-        txbody3 <-
-          first TxBodyErrorMakeUnsignedTx $
-            makeUnsignedTx
-              useEra
-              finalTxBodyContent
-        return
-          (txbody3, finalTxBodyContent)
+      -- TODO: we could add the extra fee for the CBOR encoding of the change,
+      -- now that we know the magnitude of the change: i.e. 1-8 bytes extra.
+      -- The txbody with the final fee and change output. This should work
+      -- provided that the fee and change are less than 2^32-1, and so will
+      -- fit within the encoding size we picked above when calculating the fee.
+      -- Yes this could be an over-estimate by a few bytes if the fee or change
+      -- would fit within 2^16-1. That's a possible optimisation.
+      let finalTxBodyContent =
+            txbodycontent1
+              { txFee = fee
+              , txOuts = finalTxOuts
+              , txReturnCollateral = maybeReturnTxCollateral
+              , txTotalCollateral = maybeTotalTxCollateral
+              }
+      txbody3 <-
+        first TxBodyErrorMakeUnsignedTx $
+          makeUnsignedTx
+            useEra
+            finalTxBodyContent
+      return
+        (txbody3, finalTxBodyContent)
 
 getAda :: Era era -> L.Value (LedgerEra era) -> L.Coin
 getAda e val = case e of

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Body.hs
@@ -2499,8 +2499,7 @@ extractWitnessableVotes
   :: ConwayEraOnwards era
   -> Maybe (Featured eon era (TxVotingProcedures BuildTx era))
   -> [(Witnessable VoterItem (ShelleyLedgerEra era), BuildTxWith BuildTx (Witness WitCtxStake era))]
-extractWitnessableVotes ConwayEraOnwardsDijkstra _ = error "TODO Dijkstra: extractWitnessableVotes: era not supported"
-extractWitnessableVotes e@ConwayEraOnwardsConway txVotingProcedures =
+extractWitnessableVotes e txVotingProcedures =
   List.nub
     [ (conwayEraOnwardsConstraints e $ WitVote vote, BuildTxWith wit)
     | (vote, wit) <- getVotes $ maybe TxVotingProceduresNone unFeatured txVotingProcedures

--- a/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
+++ b/cardano-api/src/Cardano/Api/Tx/Internal/Fee.hs
@@ -67,6 +67,7 @@ import Cardano.Api.Era.Internal.Eon.MaryEraOnwards
 import Cardano.Api.Era.Internal.Eon.ShelleyBasedEra
 import Cardano.Api.Era.Internal.Feature
 import Cardano.Api.Error
+import Cardano.Api.Experimental.Era (obtainCommonConstraints)
 import Cardano.Api.Experimental.Tx.Internal.Certificate qualified as Exp
 import Cardano.Api.Ledger.Internal.Reexport qualified as L
 import Cardano.Api.Plutus
@@ -1639,7 +1640,7 @@ substituteExecutionUnits
       pure $
         Just $
           Featured era $
-            conwayEraOnwardsConstraints era $
+            obtainCommonConstraints (convert era) $
               mkTxProposalProcedures substitutedExecutionUnits
 
     mapScriptWitnessesMinting


### PR DESCRIPTION
# Context

Dijkstra transactions can now be built, fee-estimated and auto-balanced.

The experimental `makeUnsignedTx`, `estimateBalancedTxBody` and `makeTransactionBodyAutoBalance` all work in Dijkstra.

Extra key witnesses become key-hash guards, the era's replacement for required signer hashes.

Breaking: `BalanceIsNegative` now carries the era's `UnsignedTx` instead of a Conway-specific one.

No new dependencies: everything builds against released packages.

# How to trust this PR

Minimal generalisation changes. Use `Hide whitespace` when viewing the diff.

The one genuine API change is `BalanceIsNegative` carrying `UnsignedTx era` (a strict generalization of the previously Conway-hardcoded field).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`

