### PR TITLE
Serialise and witness Dijkstra-era transactions

### DIFF
--- a/.changes/20260824_092254_cardano-api_palas_dijkstra_tx_serialisation.yml
+++ b/.changes/20260824_092254_cardano-api_palas_dijkstra_tx_serialisation.yml
@@ -1,0 +1,6 @@
+description: |
+  Dijkstra transactions can now be serialised and witnessed: the `Tx DijkstraEra` text-envelope types work (witnessed and unwitnessed), Plutus V1-V3 scripts are supported in the era (the ledger's maximum for Dijkstra is V3 for now), and `createCompatibleTx` handles Dijkstra. By the era's design, transactions cannot be marked script-invalid in Dijkstra.
+kind:
+  - feature
+pr: 1313
+project: cardano-api

--- a/.changes/20260824_123958_cardano-rpc_palas_dijkstra_txcert_import.yml
+++ b/.changes/20260824_123958_cardano-rpc_palas_dijkstra_txcert_import.yml
@@ -1,0 +1,6 @@
+description: |
+  cardano-rpc now gets `DijkstraTxCert` through `cardano-api`'s reexport instead of importing it directly from the ledger; no user-facing changes.
+kind:
+  - refactoring
+pr: 1313
+project: cardano-rpc

--- a/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
+++ b/cardano-api/gen/Test/Gen/Cardano/Api/Typed.hs
@@ -1171,7 +1171,15 @@ genTxScriptValidity :: CardanoEra era -> Gen (TxScriptValidity era)
 genTxScriptValidity =
   inEonForEra
     (pure TxScriptValidityNone)
-    (\w -> TxScriptValidity w <$> genScriptValidity)
+    ( \w ->
+        TxScriptValidity w <$> case w of
+          AlonzoEraOnwardsAlonzo -> genScriptValidity
+          AlonzoEraOnwardsBabbage -> genScriptValidity
+          AlonzoEraOnwardsConway -> genScriptValidity
+          -- Dijkstra does not support IsValid False: the CBOR encoding omits the
+          -- isValid flag entirely and decoding always yields IsValid True.
+          AlonzoEraOnwardsDijkstra -> pure ScriptValid
+    )
 
 genScriptValidity :: Gen ScriptValidity
 genScriptValidity = Gen.element [ScriptInvalid, ScriptValid]

--- a/cardano-api/src/Cardano/Api/Compatible/Tx.hs
+++ b/cardano-api/src/Cardano/Api/Compatible/Tx.hs
@@ -18,6 +18,7 @@ where
 import Cardano.Api.Address (StakeCredential)
 import Cardano.Api.Era
 import Cardano.Api.Experimental.AnyScriptWitness
+import Cardano.Api.Experimental.Era (obtainCommonConstraints)
 import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Experimental.Tx.Internal.AnyWitness
 import Cardano.Api.Experimental.Tx.Internal.AnyWitness qualified as Exp
@@ -114,7 +115,7 @@ createCompatibleTx sbe ins outs extraDatums txFee' anyProtocolUpdate anyVote txC
                 ]
               -- append proposal reference inputs & set proposal procedures
               updateTxBody :: Endo (L.TxBody L.TopTx (ShelleyLedgerEra era)) =
-                conwayEraOnwardsConstraints conwayOnwards $
+                obtainCommonConstraints (convert conwayOnwards) $
                   Endo $
                     (L.referenceInputsTxBodyL %~ (<> fromList referenceInputs))
                       . (L.proposalProceduresTxBodyL .~ proposals)
@@ -171,7 +172,7 @@ createCompatibleTx sbe ins outs extraDatums txFee' anyProtocolUpdate anyVote txC
     -> L.Tx L.TopTx (ShelleyLedgerEra era)
     -> L.Tx L.TopTx (ShelleyLedgerEra era)
   overwriteVotingProcedures conwayOnwards votingProcedures =
-    conwayEraOnwardsConstraints conwayOnwards $
+    obtainCommonConstraints (convert conwayOnwards) $
       (L.bodyTxL . L.votingProceduresTxBodyL) .~ votingProcedures
 
   indexedTxCerts
@@ -319,7 +320,7 @@ indexWitnessedTxProposalProcedures
        )
      ]
 indexWitnessedTxProposalProcedures cOnwards (Exp.TxProposalProcedures proposals) = do
-  let allProposalsList = zip [0 ..] $ conwayEraOnwardsConstraints cOnwards $ toList proposals
+  let allProposalsList = zip [0 ..] $ obtainCommonConstraints (convert cOnwards) $ toList proposals
   [ (proposal, (ScriptWitnessIndexProposing ix, anyWitness))
     | (ix, (proposal, anyWitness)) <- allProposalsList
     ]

--- a/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
+++ b/cardano-api/src/Cardano/Api/Ledger/Internal/Reexport.hs
@@ -85,6 +85,7 @@ module Cardano.Api.Ledger.Internal.Reexport
   , valueFromList
   -- Dijkstra
   , DijkstraPlutusPurpose (..)
+  , DijkstraTxCert (..)
   -- Conway
   , Anchor (..)
   , Committee (..)
@@ -397,6 +398,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), credToText)
 import Cardano.Ledger.DRep (DRep (..), drepAnchorL, drepDepositL, drepExpiryL)
 import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
+import Cardano.Ledger.Dijkstra.TxCert (DijkstraTxCert (..))
 import Cardano.Ledger.Hashes
   ( ADDRHASH
   , SafeHash

--- a/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
+++ b/cardano-api/src/Cardano/Api/Plutus/Internal/Script.hs
@@ -660,6 +660,12 @@ scriptLanguageSupportedInEra era lang =
       Just PlutusScriptV2InConway
     (ShelleyBasedEraConway, PlutusScriptLanguage PlutusScriptV3) ->
       Just PlutusScriptV3InConway
+    (ShelleyBasedEraDijkstra, PlutusScriptLanguage PlutusScriptV1) ->
+      Just PlutusScriptV1InDijkstra
+    (ShelleyBasedEraDijkstra, PlutusScriptLanguage PlutusScriptV2) ->
+      Just PlutusScriptV2InDijkstra
+    (ShelleyBasedEraDijkstra, PlutusScriptLanguage PlutusScriptV3) ->
+      Just PlutusScriptV3InDijkstra
     _ -> Nothing
 
 languageOfScriptLanguageInEra

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal.hs
@@ -181,12 +181,14 @@ legacyComparison (TextEnvelopeType expectedType) (TextEnvelopeType actualType) =
     ("Tx AlonzoEra", "Witnessed Tx AlonzoEra") -> True
     ("Tx BabbageEra", "Witnessed Tx BabbageEra") -> True
     ("Tx ConwayEra", "Witnessed Tx ConwayEra") -> True
+    ("Tx DijkstraEra", "Witnessed Tx DijkstraEra") -> True
     ("TxSignedShelley", "Unwitnessed Tx ShelleyEra") -> True
     ("Tx AllegraEra", "Unwitnessed Tx AllegraEra") -> True
     ("Tx MaryEra", "Unwitnessed Tx MaryEra") -> True
     ("Tx AlonzoEra", "Unwitnessed Tx AlonzoEra") -> True
     ("Tx BabbageEra", "Unwitnessed Tx BabbageEra") -> True
     ("Tx ConwayEra", "Unwitnessed Tx ConwayEra") -> True
+    ("Tx DijkstraEra", "Unwitnessed Tx DijkstraEra") -> True
     ("Certificate", "CertificateConway") -> True
     ("Certificate", "CertificateShelley") -> True
     (expectedOther, expectedActual) -> expectedOther == expectedActual
@@ -394,22 +396,26 @@ textEnvelopeTypeToEra =
     "Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "Witnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "Witnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "Witnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "Witnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Witnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Witnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Witnessed Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "Unwitnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "Unwitnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "Unwitnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "Unwitnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Unwitnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Unwitnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Unwitnessed Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "TxWitness ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "TxWitness AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "TxWitness MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "TxWitness AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "TxWitness BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "TxWitness ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "TxWitness DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     unknownCddlType -> Left $ TextEnvelopeUnknownType unknownCddlType

--- a/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal/Cddl.hs
+++ b/cardano-api/src/Cardano/Api/Serialise/TextEnvelope/Internal/Cddl.hs
@@ -317,24 +317,28 @@ cddlTypeToEra =
     "Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "Witnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "Witnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "Witnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "Witnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Witnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Witnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Witnessed Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "Unwitnessed Tx ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "Unwitnessed Tx AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "Unwitnessed Tx MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "Unwitnessed Tx AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "Unwitnessed Tx BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "Unwitnessed Tx ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "Unwitnessed Tx DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     "TxWitness ShelleyEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraShelley
     "TxWitness AllegraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAllegra
     "TxWitness MaryEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraMary
     "TxWitness AlonzoEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     "TxWitness BabbageEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     "TxWitness ConwayEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraConway
+    "TxWitness DijkstraEra" -> return $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
     unknownCddlType -> Left $ TextEnvelopeCddlErrUnknownType unknownCddlType
 
 {-# DEPRECATED readFileTextEnvelopeCddlAnyOf "Use readFileTextEnvelopeAnyOf instead." #-}

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Certificate.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Certificate.hs
@@ -24,8 +24,7 @@ import Cardano.Ledger.BaseTypes qualified as L
 import Cardano.Ledger.Binary qualified as L (ipv4ToBytes, ipv6ToBytes)
 import Cardano.Ledger.Coin qualified as L (DeltaCoin (..))
 import Cardano.Ledger.Dijkstra.TxCert qualified as L
-  ( DijkstraTxCert (..)
-  , dijkstraToConwayDelegCert
+  ( dijkstraToConwayDelegCert
   )
 import Cardano.Ledger.Hashes qualified as L (ScriptHash (..), VRFVerKeyHash (..))
 


### PR DESCRIPTION
# Context

This PR allows Dijkstra transactions to be serialised, deserialised, and witnessed.

The `Tx DijkstraEra` text-envelope types work (witnessed and unwitnessed), Plutus V1–V3 scripts are supported in the era (V3 is the ledger's maximum for Dijkstra for now), and the compatible-transaction path handles Dijkstra. By the era's design, transactions cannot be marked script-invalid in Dijkstra.

No new dependencies: everything builds against released packages.

# How to trust this PR

Almost everything is table-filling:

The one generator change mirrors ledger design, not a workaround: Dijkstra removed `isValid == False` from the wire format, so generators only produce script-valid transactions there.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
