### PR TITLE
CI: enable long file paths for Git on Windows runners

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -89,6 +89,10 @@ jobs:
 
     - uses: actions/checkout@v6
 
+    - name: Configure Git to support long file paths on Windows
+      if: ${{ matrix.sys.os == 'windows-latest' }}
+      run: git config --system core.longpaths true
+
     - name: Install gRPC system dependencies
       uses: input-output-hk/cardano-dev/actions/grpc-deps@grpc-deps-0.0.1.0
 


### PR DESCRIPTION
# Context

Git for Windows fails on paths longer than 260 characters unless `core.longpaths` is enabled. The repository itself is fine (longest path: 172 characters), but cabal clones source-repository-package pins under `dist-newstyle/src/<name>-<hash>/` on the runner (a ~120-character prefix). So pinned repos with deep file trees break the Windows job during dependency fetching (`plutus` has 180-character paths: ~300 characters total).

This adds one 4-line step to the Windows matrix leg, right after checkout: `git config --system core.longpaths true`.

Leios-prototype work relies on such pins (SRPs), and any PR that temporarily carries a tagged pin benefits today.

# How to trust this PR

It is a really small change, the way to test it would be to look at the CI when having SRPs. But if CI for windows works on the PR, we will at least know we are not making things worse.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/` (not applicable)
