### PR TITLE
Expose the Dijkstra era in AnyCardanoEra, AnyShelleyBasedEra and SomeEra

### DIFF
--- a/.changes/20260824_144719_cardano-api_palas_dijkstra_era_enumerations.yml
+++ b/.changes/20260824_144719_cardano-api_palas_dijkstra_era_enumerations.yml
@@ -1,0 +1,9 @@
+description: |
+  The Dijkstra era can now be selected and enumerated like the other eras: `maxBound` and `[minBound .. maxBound]` for `AnyCardanoEra`, `AnyShelleyBasedEra` and the experimental `Some Era` include it, and the era-name parsers (`anyCardanoEraFromStringLike` and the JSON instances) accept "Dijkstra".
+
+  Also fixed an `Enum` roundtrip crash: `fromEnum` already mapped Dijkstra to 7 for `AnyCardanoEra` and `AnyShelleyBasedEra`, but `toEnum 7` errored.
+kind:
+  - feature
+  - bugfix
+pr: 1317
+project: cardano-api

--- a/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Core.hs
@@ -381,7 +381,7 @@ instance Eq AnyCardanoEra where
 
 instance Bounded AnyCardanoEra where
   minBound = AnyCardanoEra ByronEra
-  maxBound = AnyCardanoEra ConwayEra
+  maxBound = AnyCardanoEra DijkstraEra
 
 instance Enum AnyCardanoEra where
   -- [e..] = [e..maxBound]
@@ -405,6 +405,7 @@ instance Enum AnyCardanoEra where
     4 -> AnyCardanoEra AlonzoEra
     5 -> AnyCardanoEra BabbageEra
     6 -> AnyCardanoEra ConwayEra
+    7 -> AnyCardanoEra DijkstraEra
     n ->
       error $
         "AnyCardanoEra.toEnum: "
@@ -445,6 +446,7 @@ anyCardanoEraFromStringLike = \case
   "Alonzo" -> pure $ AnyCardanoEra AlonzoEra
   "Babbage" -> pure $ AnyCardanoEra BabbageEra
   "Conway" -> pure $ AnyCardanoEra ConwayEra
+  "Dijkstra" -> pure $ AnyCardanoEra DijkstraEra
   wrong -> Left wrong
 
 -- | Like the 'AnyCardanoEra' constructor but does not demand a 'IsCardanoEra'

--- a/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
+++ b/cardano-api/src/Cardano/Api/Era/Internal/Eon/ShelleyBasedEra.hs
@@ -279,7 +279,7 @@ instance Eq AnyShelleyBasedEra where
 
 instance Bounded AnyShelleyBasedEra where
   minBound = AnyShelleyBasedEra ShelleyBasedEraShelley
-  maxBound = AnyShelleyBasedEra ShelleyBasedEraConway
+  maxBound = AnyShelleyBasedEra ShelleyBasedEraDijkstra
 
 instance Enum AnyShelleyBasedEra where
   enumFrom e = enumFromTo e maxBound
@@ -300,6 +300,7 @@ instance Enum AnyShelleyBasedEra where
     4 -> AnyShelleyBasedEra ShelleyBasedEraAlonzo
     5 -> AnyShelleyBasedEra ShelleyBasedEraBabbage
     6 -> AnyShelleyBasedEra ShelleyBasedEraConway
+    7 -> AnyShelleyBasedEra ShelleyBasedEraDijkstra
     n ->
       error $
         "AnyShelleyBasedEra.toEnum: "
@@ -318,6 +319,7 @@ instance FromJSON AnyShelleyBasedEra where
       "Alonzo" -> pure $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
       "Babbage" -> pure $ AnyShelleyBasedEra ShelleyBasedEraBabbage
       "Conway" -> pure $ AnyShelleyBasedEra ShelleyBasedEraConway
+      "Dijkstra" -> pure $ AnyShelleyBasedEra ShelleyBasedEraDijkstra
       wrong -> fail $ "Failed to parse unknown shelley-based era: " <> Text.unpack wrong
 
 -- | This pairs up some era-dependent type with a 'ShelleyBasedEra' value that

--- a/cardano-api/src/Cardano/Api/Experimental/Era.hs
+++ b/cardano-api/src/Cardano/Api/Experimental/Era.hs
@@ -130,7 +130,7 @@ instance Eq (Some Era) where
 
 instance Bounded (Some Era) where
   minBound = Some ConwayEra
-  maxBound = Some ConwayEra
+  maxBound = Some DijkstraEra
 
 instance Enum (Some Era) where
   toEnum 0 = Some ConwayEra


### PR DESCRIPTION
# Context

Until now the Dijkstra era was deliberately kept out of the era enumerations, so generic code and tests would not wander into unsupported paths. With the previous slices of Dijkstra support in place, it can be exposed: `maxBound` flips to Dijkstra for `AnyCardanoEra`, `AnyShelleyBasedEra` and the experimental `Some Era`, and the `toEnum`/era-name-parser arms are added.

This also fixes a latent crash: `fromEnum` already mapped Dijkstra to 7 for `AnyCardanoEra` and `AnyShelleyBasedEra`, but `toEnum 7` errored, so the `Enum` roundtrip failed.

Side effect worth knowing: every property test that draws from `[minBound .. maxBound]` (JSON/CBOR roundtrips and friends) now exercises Dijkstra.

# How to trust this PR

The diff is really small, and it basically just adds Dijkstra to enumerations.

The most important thing is tests still pass.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
