### PR TITLE
Honour TestDijkstraHardForkAtEpoch when parsing the node configuration

### DIFF
--- a/.changes/20260825_161536_cardano-api_palas_dijkstra_hard_fork_trigger.yml
+++ b/.changes/20260825_161536_cardano-api_palas_dijkstra_hard_fork_trigger.yml
@@ -1,0 +1,6 @@
+description: |
+  `foldBlocks` and the rest of the ledger-state machinery now honour `TestDijkstraHardForkAtEpoch` in the node configuration file, so they can follow a chain into the Dijkstra era.
+kind:
+  - bugfix
+pr: 1321
+project: cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -398,7 +398,7 @@ test-suite cardano-api-test
     hedgehog-quickcheck,
     microlens,
     mtl,
-    ouroboros-consensus:{ouroboros-consensus, protocol},
+    ouroboros-consensus:{cardano, ouroboros-consensus, protocol},
     raw-strings-qq,
     tasty,
     tasty-hedgehog,
@@ -427,6 +427,7 @@ test-suite cardano-api-test
     Test.Cardano.Api.Ledger
     Test.Cardano.Api.Leios
     Test.Cardano.Api.Metadata
+    Test.Cardano.Api.NodeConfig
     Test.Cardano.Api.Ord
     Test.Cardano.Api.Orphans
     Test.Cardano.Api.RawBytes

--- a/cardano-api/src/Cardano/Api/LedgerState.hs
+++ b/cardano-api/src/Cardano/Api/LedgerState.hs
@@ -1173,7 +1173,7 @@ instance FromJSON NodeConfig where
         <*> parseAlonzoHardForkEpoch o
         <*> parseBabbageHardForkEpoch o
         <*> parseConwayHardForkEpoch o
-        <*> pure Consensus.CardanoTriggerHardForkAtDefaultVersion -- TODO Dijkstra
+        <*> parseDijkstraHardForkEpoch o
     parseShelleyHardForkEpoch :: Object -> Parser (Consensus.CardanoHardForkTrigger blk)
     parseShelleyHardForkEpoch o =
       asum
@@ -1212,6 +1212,13 @@ instance FromJSON NodeConfig where
     parseConwayHardForkEpoch o =
       asum
         [ Consensus.CardanoTriggerHardForkAtEpoch <$> o .: "TestConwayHardForkAtEpoch"
+        , pure Consensus.CardanoTriggerHardForkAtDefaultVersion
+        ]
+
+    parseDijkstraHardForkEpoch :: Object -> Parser (Consensus.CardanoHardForkTrigger blk)
+    parseDijkstraHardForkEpoch o =
+      asum
+        [ Consensus.CardanoTriggerHardForkAtEpoch <$> o .: "TestDijkstraHardForkAtEpoch"
         , pure Consensus.CardanoTriggerHardForkAtDefaultVersion
         ]
 

--- a/cardano-api/test/cardano-api-test/Test/Cardano/Api/NodeConfig.hs
+++ b/cardano-api/test/cardano-api-test/Test/Cardano/Api/NodeConfig.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Cardano.Api.NodeConfig
+  ( tests
+  )
+where
+
+import Cardano.Api (EpochNo (..))
+import Cardano.Api.LedgerState (NodeConfig (..))
+
+import Ouroboros.Consensus.Cardano.Node qualified as Consensus
+
+import Data.Aeson qualified as Aeson
+import GHC.Stack
+
+import Hedgehog as H
+import Hedgehog.Extras (propertyOnce)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+-- | A minimal node configuration with the given extra keys.
+nodeConfigWith :: [(Aeson.Key, Aeson.Value)] -> Aeson.Value
+nodeConfigWith extras =
+  Aeson.object $
+    [ "ByronGenesisFile" Aeson..= ("byron-genesis.json" :: String)
+    , "ShelleyGenesisFile" Aeson..= ("shelley-genesis.json" :: String)
+    , "AlonzoGenesisFile" Aeson..= ("alonzo-genesis.json" :: String)
+    , "ConwayGenesisFile" Aeson..= ("conway-genesis.json" :: String)
+    , "RequiresNetworkMagic" Aeson..= ("RequiresNoMagic" :: String)
+    , "LastKnownBlockVersion-Major" Aeson..= (3 :: Int)
+    , "LastKnownBlockVersion-Minor" Aeson..= (0 :: Int)
+    , "LastKnownBlockVersion-Alt" Aeson..= (0 :: Int)
+    ]
+      <> map (uncurry (Aeson..=)) extras
+
+parseTriggers
+  :: (HasCallStack, MonadTest m)
+  => [(Aeson.Key, Aeson.Value)]
+  -> m Consensus.CardanoHardForkTriggers
+parseTriggers extras =
+  case Aeson.fromJSON $ nodeConfigWith extras of
+    Aeson.Error e -> withFrozenCallStack $ H.annotate e >> H.failure
+    Aeson.Success nc -> pure $ ncHardForkTriggers nc
+
+prop_parse_dijkstra_hard_fork_at_epoch :: Property
+prop_parse_dijkstra_hard_fork_at_epoch = propertyOnce $ do
+  triggers <- parseTriggers [("TestDijkstraHardForkAtEpoch", Aeson.toJSON (5 :: Int))]
+  case triggers of
+    Consensus.CardanoHardForkTriggers'{Consensus.triggerHardForkDijkstra = trigger} ->
+      case trigger of
+        Consensus.CardanoTriggerHardForkAtEpoch (EpochNo 5) -> H.success
+        other -> H.annotateShow other >> H.failure
+
+prop_parse_dijkstra_hard_fork_default :: Property
+prop_parse_dijkstra_hard_fork_default = propertyOnce $ do
+  triggers <- parseTriggers []
+  case triggers of
+    Consensus.CardanoHardForkTriggers'{Consensus.triggerHardForkDijkstra = trigger} ->
+      case trigger of
+        Consensus.CardanoTriggerHardForkAtDefaultVersion -> H.success
+        other -> H.annotateShow other >> H.failure
+
+tests :: TestTree
+tests =
+  testGroup
+    "Test.Cardano.Api.NodeConfig"
+    [ testProperty "parse TestDijkstraHardForkAtEpoch" prop_parse_dijkstra_hard_fork_at_epoch
+    , testProperty "parse Dijkstra hard fork default" prop_parse_dijkstra_hard_fork_default
+    ]

--- a/cardano-api/test/cardano-api-test/cardano-api-test.hs
+++ b/cardano-api/test/cardano-api-test/cardano-api-test.hs
@@ -25,6 +25,7 @@ import Test.Cardano.Api.KeysByron qualified
 import Test.Cardano.Api.Ledger qualified
 import Test.Cardano.Api.Leios qualified
 import Test.Cardano.Api.Metadata qualified
+import Test.Cardano.Api.NodeConfig qualified
 import Test.Cardano.Api.Ord qualified
 import Test.Cardano.Api.RawBytes qualified
 import Test.Cardano.Api.Transaction.Autobalance qualified
@@ -67,6 +68,7 @@ tests =
     , Test.Cardano.Api.Ledger.tests
     , Test.Cardano.Api.Leios.tests
     , Test.Cardano.Api.Metadata.tests
+    , Test.Cardano.Api.NodeConfig.tests
     , Test.Cardano.Api.Ord.tests
     , Test.Cardano.Api.RawBytes.tests
     , Test.Cardano.Api.Transaction.Body.Plutus.Scripts.tests


### PR DESCRIPTION
# Context

`parseHardForkTriggers` filled the Dijkstra slot of `CardanoHardForkTriggers'` with `CardanoTriggerHardForkAtDefaultVersion` unconditionally (a leftover `TODO Dijkstra`), so `foldBlocks` — and everything built on the ledger-state machinery, such as cardano-testnet's epoch-state helpers — could not follow a chain whose Dijkstra fork is configured by epoch: it stayed on the Conway ledger and failed at the first Dijkstra block.

Parse the trigger exactly like every other era's (`TestDijkstraHardForkAtEpoch`, falling back to the default-version trigger), and add a `NodeConfig` parsing test that pins both behaviours.

# How to trust this PR

- The new `parseDijkstraHardForkEpoch` is a byte-for-byte sibling of the six parsers above it, only with the Dijkstra key; the only call-site change swaps the hardcoded `pure` for it.
- The Dijkstra slot already exists in the released consensus type (the old code was filling it), so no dependency changes beyond adding the already-used `ouroboros-consensus:cardano` sublib to the test suite's build-depends.
- The new test decodes a minimal node configuration through the real `FromJSON NodeConfig` instance and asserts the trigger both with the key present (`CardanoTriggerHardForkAtEpoch`) and absent (`CardanoTriggerHardForkAtDefaultVersion`).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
