### PR TITLE
Add TCP and TLS listening support to the cardano-rpc gRPC server

### DIFF
--- a/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
+++ b/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
@@ -1,7 +1,7 @@
 project: cardano-rpc
-pr: 0
+pr: 1322
 kind:
   - feature
   - breaking
 description: |
-  The cardano-rpc gRPC server can now listen on a plain TCP endpoint (HTTP/2 without TLS) instead of a unix domain socket, configured via the node configuration keys `RpcListenAddress`/`RpcListenPort` or the `--grpc-listen-address`/`--grpc-listen-port` CLI flags; the listen address defaults to `127.0.0.1`, and configuring both a socket path and a listen port is rejected at configuration parsing time. As part of this, `RpcConfigF`'s `rpcSocketPath` field was replaced by `rpcEndpoint`, a new `RpcEndpoint` sum type with `RpcEndpointUnixSocket` and `RpcEndpointTcp` constructors, and `TraceRpc` gained a new `TraceRpcServerListening` constructor.
+  The cardano-rpc gRPC server can now listen on HTTP/2 (h2c) or HTTP/2 over TLS on a configured IP address and port instead of only a unix domain socket, configured via new cardano-node options such as `--grpc-listen-port` and `--grpc-tls-certificate`. `RpcConfigF`'s `rpcSocketPath` field was replaced by the new `RpcEndpoint` sum type.

--- a/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
+++ b/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
@@ -4,4 +4,4 @@ kind:
   - feature
   - breaking
 description: |
-  The cardano-rpc gRPC server can now listen on HTTP/2 (h2c) or HTTP/2 over TLS on a configured IP address and port instead of only a unix domain socket, configured via new cardano-node options such as `--grpc-listen-port` and `--grpc-tls-certificate`. `RpcConfigF`'s `rpcSocketPath` field was replaced by the new `RpcEndpoint` sum type.
+  The cardano-rpc gRPC server can now listen on HTTP/2 (h2c) or HTTP/2 over TLS on a configured IP address and port instead of only a unix domain socket, configured via new cardano-node options such as `--grpc-listen-port` and `--grpc-tls-certificate`. `RpcConfigF`'s `rpcSocketPath` field was replaced by the new `RpcEndpoint` sum type. Error responses no longer include internal diagnostic detail such as call stacks. Script evaluation requests are rejected when the transaction exceeds the protocol maximum size or carries more than 100 redeemers. UTxO reads are limited to 20000 keys and block fetches to 500 references per request.

--- a/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
+++ b/.changes/20260828_cardano_rpc_grpc_tcp_listener.yml
@@ -1,0 +1,7 @@
+project: cardano-rpc
+pr: 0
+kind:
+  - feature
+  - breaking
+description: |
+  The cardano-rpc gRPC server can now listen on a plain TCP endpoint (HTTP/2 without TLS) instead of a unix domain socket, configured via the node configuration keys `RpcListenAddress`/`RpcListenPort` or the `--grpc-listen-address`/`--grpc-listen-port` CLI flags; the listen address defaults to `127.0.0.1`, and configuring both a socket path and a listen port is rejected at configuration parsing time. As part of this, `RpcConfigF`'s `rpcSocketPath` field was replaced by `rpcEndpoint`, a new `RpcEndpoint` sum type with `RpcEndpointUnixSocket` and `RpcEndpointTcp` constructors, and `TraceRpc` gained a new `TraceRpcServerListening` constructor.

--- a/cardano-rpc/README.md
+++ b/cardano-rpc/README.md
@@ -80,3 +80,18 @@ To build the package use the following command:
 cabal build cardano-rpc
 ```
 
+## Security
+
+The RPC server has no authentication or authorisation: every method is open to anyone who can reach the listener, including transaction submission and script evaluation.
+Everything served is public chain data, so the concern is resource consumption and node exposure rather than confidentiality.
+
+Defaults are conservative: the server is off unless `--grpc-enable` is given, it listens on a unix socket by default, and `--grpc-listen-port` binds `127.0.0.1` unless another address is given.
+The node warns at startup when RPC is enabled on a block-producing node.
+
+TLS encrypts the connection and lets clients verify the node; it does not restrict who may call, since there is no client-certificate support.
+A TLS listener on a public address is as open as a cleartext one.
+
+For deployment, keep the listener on loopback or a trusted network segment.
+Anywhere else, front it with a reverse proxy that terminates TLS and handles authentication and rate limiting, the pattern recommended in ADR-018.
+
+The server writes TLS key-log material if `SSLKEYLOGFILE` is set in its environment.

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -123,6 +123,7 @@ library
     memory,
     mempack,
     microlens,
+    network,
     proto-lens >=0.7.1.7,
     proto-lens-protobuf-types,
     random,

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -120,6 +120,7 @@ library
     generic-data,
     grapesy,
     grpc-spec,
+    iproute,
     memory,
     mempack,
     microlens,

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -46,7 +46,6 @@ import Cardano.Rpc.Server.NodeKernelAccess
 import RIO
 
 import Control.Tracer
-import Data.Text qualified as Text
 import Network.GRPC.Common
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
@@ -125,19 +124,37 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
         , rpcEndpoint = Identity rpcEndpoint
         , nodeSocketPath = Identity nodeSocketPath
         } = rpcConfig
-      insecureConfig :: InsecureConfig
-      insecureConfig = case rpcEndpoint of
-        RpcEndpointUnixSocket (File socketPath) -> InsecureUnix socketPath
-        RpcEndpointTcp host port ->
-          InsecureConfig
-            { insecureHost = Just $ Text.unpack host
-            , insecurePort = port
+      config :: ServerConfig
+      config = case rpcEndpoint of
+        RpcEndpointUnixSocket (File socketPath) ->
+          ServerConfig
+            { serverInsecure = Just $ InsecureUnix socketPath
+            , serverSecure = Nothing
             }
-      config =
-        ServerConfig
-          { serverInsecure = Just insecureConfig
-          , serverSecure = Nothing
-          }
+        RpcEndpointHttp host port ->
+          ServerConfig
+            { serverInsecure =
+                Just
+                  InsecureConfig
+                    { insecureHost = Just $ show host
+                    , insecurePort = port
+                    }
+            , serverSecure = Nothing
+            }
+        RpcEndpointHttps host port (RpcTlsFiles certificateFile privateKeyFile chainCertificateFiles) ->
+          ServerConfig
+            { serverInsecure = Nothing
+            , serverSecure =
+                Just
+                  SecureConfig
+                    { secureHost = show host
+                    , securePort = port
+                    , securePubCert = unFile certificateFile
+                    , secureChainCerts = unFile <$> chainCertificateFiles
+                    , securePrivKey = unFile privateKeyFile
+                    , secureSslKeyLog = def
+                    }
+            }
       rpcEnv =
         RpcEnv
           { config = rpcConfig

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -30,6 +30,7 @@ import Cardano.Rpc.Proto.Api.UtxoRpc.Submit qualified as UtxoRpc
 import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as UtxoRpc
 import Cardano.Rpc.Server.Config
 import Cardano.Rpc.Server.Internal.Env
+import Cardano.Rpc.Server.Internal.Error (renderRpcExceptionForClient)
 import Cardano.Rpc.Server.Internal.Monad
 import Cardano.Rpc.Server.Internal.Node
 import Cardano.Rpc.Server.Internal.Orphans ()
@@ -176,7 +177,19 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
             ]
  where
   serverParams :: ServerParams
-  serverParams = def{serverTopLevel = topLevelHandler}
+  serverParams =
+    def
+      { serverTopLevel = topLevelHandler
+      , serverExceptionToClient = exceptionToClient
+      }
+
+  -- Clients must never see internal error detail or call stacks; full detail is
+  -- still traced server-side by 'topLevelHandler'.
+  exceptionToClient :: SomeException -> IO (Maybe Text)
+  exceptionToClient e =
+    pure . Just $ maybe genericErrorMessage renderRpcExceptionForClient $ fromException e
+   where
+    genericErrorMessage = "Internal error while processing the request."
 
   -- Halve grapesy's default of 128: bounds per-connection RPC parallelism.
   -- Remaining fields keep grapesy defaults, including the HTTP/2 flood-protection

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -167,7 +167,7 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
     traceWith tracer $ TraceRpcServerListening rpcEndpoint
     runRIO rpcEnv $
       withRunInIO $ \runInIO ->
-        runServerWithHandlers serverParams config . fmap (hoistSomeRpcHandler runInIO) $
+        runServer http2Settings config <=< mkGrpcServer serverParams . fmap (hoistSomeRpcHandler runInIO) $
           mconcat
             [ fromMethods methodsNodeRpc
             , fromMethods methodsUtxoRpc
@@ -177,6 +177,13 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
  where
   serverParams :: ServerParams
   serverParams = def{serverTopLevel = topLevelHandler}
+
+  -- Halve grapesy's default of 128: bounds per-connection RPC parallelism.
+  -- Remaining fields keep grapesy defaults, including the HTTP/2 flood-protection
+  -- rate limits and the 256 KiB / 2 MiB flow-control windows that cap buffered
+  -- inbound request data per stream / connection.
+  http2Settings :: HTTP2Settings
+  http2Settings = def{http2MaxConcurrentStreams = 64}
 
   -- Top level hook for request handlers, handle exceptions
   topLevelHandler :: RequestHandler () -> RequestHandler ()

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -46,6 +46,7 @@ import Cardano.Rpc.Server.NodeKernelAccess
 import RIO
 
 import Control.Tracer
+import Data.Text qualified as Text
 import Network.GRPC.Common
 import Network.GRPC.Server
 import Network.GRPC.Server.Protobuf
@@ -121,12 +122,20 @@ runRpcServer
 runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExceptions $ do
   let RpcConfig
         { isEnabled = Identity isEnabled
-        , rpcSocketPath = Identity (File rpcSocketPathFp)
+        , rpcEndpoint = Identity rpcEndpoint
         , nodeSocketPath = Identity nodeSocketPath
         } = rpcConfig
+      insecureConfig :: InsecureConfig
+      insecureConfig = case rpcEndpoint of
+        RpcEndpointUnixSocket (File socketPath) -> InsecureUnix socketPath
+        RpcEndpointTcp host port ->
+          InsecureConfig
+            { insecureHost = Just $ Text.unpack host
+            , insecurePort = port
+            }
       config =
         ServerConfig
-          { serverInsecure = Just $ InsecureUnix rpcSocketPathFp
+          { serverInsecure = Just insecureConfig
           , serverSecure = Nothing
           }
       rpcEnv =
@@ -137,7 +146,8 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
           , rpcNodeKernelAccess = nodeKernelAccessRef
           }
 
-  when isEnabled $
+  when isEnabled $ do
+    traceWith tracer $ TraceRpcServerListening rpcEndpoint
     runRIO rpcEnv $
       withRunInIO $ \runInIO ->
         runServerWithHandlers serverParams config . fmap (hoistSomeRpcHandler runInIO) $

--- a/cardano-rpc/src/Cardano/Rpc/Server/Config.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Config.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
@@ -10,6 +11,9 @@ module Cardano.Rpc.Server.Config
   , PartialRpcConfig
   , RpcConfigF (..)
   , RpcEndpoint (..)
+  , RpcTlsFiles (..)
+  , TlsCertificate
+  , TlsPrivateKey
   , defaultRpcListenAddress
   , makeRpcConfig
   , nodeSocketPathToRpcSocketPath
@@ -20,6 +24,7 @@ import Cardano.Api
 
 import RIO
 
+import Data.IP (IP)
 import Data.Monoid
 import Network.Socket (PortNumber)
 import System.FilePath (takeDirectory, (</>))
@@ -29,20 +34,6 @@ import Generic.Data (gmappend, gmempty)
 type PartialRpcConfig = RpcConfigF Last
 
 type RpcConfig = RpcConfigF Identity
-
--- | Endpoint the RPC server listens on. Exactly one listener is active at a
--- time. Future transports (for example TLS) are added as new constructors.
-data RpcEndpoint
-  = RpcEndpointUnixSocket !SocketPath
-  | -- | host and port of the TCP listener, HTTP/2 without TLS. The host is
-    -- always concrete: config parsers apply 'defaultRpcListenAddress' when
-    -- only a port was provided. Port 0 makes the operating system choose.
-    RpcEndpointTcp !Text !PortNumber
-  deriving (Eq, Show)
-
--- | Default host the TCP listener binds to when only a port is configured.
-defaultRpcListenAddress :: Text
-defaultRpcListenAddress = "127.0.0.1"
 
 -- | RPC server configuration, which is a part of cardano-node configuration.
 data RpcConfigF m = RpcConfig
@@ -70,6 +61,44 @@ instance Semigroup (RpcConfigF Last) where
 instance Monoid (RpcConfigF Last) where
   mempty = gmempty
 
+-- | Endpoint the RPC server listens on. Exactly one listener is active at a
+-- time.
+data RpcEndpoint
+  = RpcEndpointUnixSocket !SocketPath
+  | -- | IP address and port of the HTTP/2 without TLS (h2c) listener.
+    RpcEndpointHttp !IP !PortNumber
+  | -- | IP address, port and TLS credential files of the HTTP/2 over TLS
+    -- listener.
+    RpcEndpointHttps !IP !PortNumber !RpcTlsFiles
+  deriving (Eq, Show)
+
+instance Pretty RpcEndpoint where
+  pretty = \case
+    RpcEndpointUnixSocket (File socketPath) -> pretty socketPath
+    RpcEndpointHttp host port -> pshow host <> ":" <> pshow port
+    RpcEndpointHttps host port _ -> pshow host <> ":" <> pshow port <> " (TLS)"
+
+-- | TLS credential files for the RPC server, PEM format.
+data RpcTlsFiles = RpcTlsFiles
+  { certificateFile :: !(File TlsCertificate In)
+  -- ^ server X.509 certificate
+  , privateKeyFile :: !(File TlsPrivateKey In)
+  -- ^ private key matching the certificate
+  , chainCertificateFiles :: ![File TlsCertificate In]
+  -- ^ intermediate chain certificates, if any
+  }
+  deriving (Eq, Show)
+
+-- | Empty content tag for 'File' identifying a TLS certificate file.
+data TlsCertificate
+
+-- | Empty content tag for 'File' identifying a TLS private key file.
+data TlsPrivateKey
+
+-- | Default IP address the HTTP/2 listener binds to when only a port is configured.
+defaultRpcListenAddress :: IP
+defaultRpcListenAddress = "127.0.0.1"
+
 -- | Build RPC Config
 --
 -- Uses the following defaults if the values are not provided
@@ -88,7 +117,7 @@ makeRpcConfig
     , nodeSocketPath = Last mNodeSocketPath
     } = do
     let isEnabled = fromMaybe False mIsEnabled
-        -- default to a some non-existing path. Does not matter if the gRPC endpoint is disabled
+        -- Default to a non-existing path. Irrelevant when the RPC server is disabled; when enabled, the validation below requires an explicit node socket path.
         nodeSocketPath = fromMaybe "./node.socket" mNodeSocketPath
         rpcEndpoint = fromMaybe (RpcEndpointUnixSocket $ nodeSocketPathToRpcSocketPath nodeSocketPath) mRpcEndpoint
     when (isEnabled && isNothing mNodeSocketPath) $

--- a/cardano-rpc/src/Cardano/Rpc/Server/Config.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Config.hs
@@ -9,6 +9,8 @@ module Cardano.Rpc.Server.Config
   ( RpcConfig
   , PartialRpcConfig
   , RpcConfigF (..)
+  , RpcEndpoint (..)
+  , defaultRpcListenAddress
   , makeRpcConfig
   , nodeSocketPathToRpcSocketPath
   )
@@ -19,6 +21,7 @@ import Cardano.Api
 import RIO
 
 import Data.Monoid
+import Network.Socket (PortNumber)
 import System.FilePath (takeDirectory, (</>))
 
 import Generic.Data (gmappend, gmempty)
@@ -27,12 +30,26 @@ type PartialRpcConfig = RpcConfigF Last
 
 type RpcConfig = RpcConfigF Identity
 
+-- | Endpoint the RPC server listens on. Exactly one listener is active at a
+-- time. Future transports (for example TLS) are added as new constructors.
+data RpcEndpoint
+  = RpcEndpointUnixSocket !SocketPath
+  | -- | host and port of the TCP listener, HTTP/2 without TLS. The host is
+    -- always concrete: config parsers apply 'defaultRpcListenAddress' when
+    -- only a port was provided. Port 0 makes the operating system choose.
+    RpcEndpointTcp !Text !PortNumber
+  deriving (Eq, Show)
+
+-- | Default host the TCP listener binds to when only a port is configured.
+defaultRpcListenAddress :: Text
+defaultRpcListenAddress = "127.0.0.1"
+
 -- | RPC server configuration, which is a part of cardano-node configuration.
 data RpcConfigF m = RpcConfig
   { isEnabled :: !(m Bool)
   -- ^ whether the RPC server is enabled
-  , rpcSocketPath :: !(m SocketPath)
-  -- ^ path to the socket file where the RPC server listens
+  , rpcEndpoint :: !(m RpcEndpoint)
+  -- ^ endpoint where the RPC server listens
   , nodeSocketPath :: !(m SocketPath)
   -- ^ cardano-node socket path. Only valid if RPC endpoint is enabled.
   }
@@ -57,7 +74,7 @@ instance Monoid (RpcConfigF Last) where
 --
 -- Uses the following defaults if the values are not provided
 -- * RPC is disabled
--- * @rpc.sock@ is placed in the same path as the node socket
+-- * the endpoint is a unix socket, @rpc.sock@, placed in the same path as the node socket
 --
 -- Validates if the node socket is enabled if RPC is enabled.
 makeRpcConfig
@@ -67,21 +84,22 @@ makeRpcConfig
 makeRpcConfig
   RpcConfig
     { isEnabled = Last mIsEnabled
-    , rpcSocketPath = Last mRpcSocketPath
+    , rpcEndpoint = Last mRpcEndpoint
     , nodeSocketPath = Last mNodeSocketPath
     } = do
     let isEnabled = fromMaybe False mIsEnabled
         -- default to a some non-existing path. Does not matter if the gRPC endpoint is disabled
         nodeSocketPath = fromMaybe "./node.socket" mNodeSocketPath
-        rpcSocketPath = fromMaybe (nodeSocketPathToRpcSocketPath nodeSocketPath) mRpcSocketPath
+        rpcEndpoint = fromMaybe (RpcEndpointUnixSocket $ nodeSocketPathToRpcSocketPath nodeSocketPath) mRpcEndpoint
     when (isEnabled && isNothing mNodeSocketPath) $
       throwError
         "Configuration error: gRPC endpoint was enabled but node socket file was not specified. Cannot run gRPC server without node socket."
-    pure $
+    pure
       RpcConfig
-        (pure isEnabled)
-        (pure rpcSocketPath)
-        (pure nodeSocketPath)
+        { isEnabled = pure isEnabled
+        , rpcEndpoint = pure rpcEndpoint
+        , nodeSocketPath = pure nodeSocketPath
+        }
 
 -- | Convert node socket path to a default rpc socket path.
 -- By default it's @rpc.sock@ in the same directory as node socket path.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Error.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Error.hs
@@ -14,6 +14,7 @@ module Cardano.Rpc.Server.Internal.Error
   , throwExceptT
   , throwGrpcErrorWithMessage
   , RpcException (..)
+  , renderRpcExceptionForClient
   )
 where
 
@@ -41,6 +42,11 @@ instance Exception RpcException where
       [ show (prettyError e)
       , prettyCallStack callStack
       ]
+
+-- | Render an 'RpcException' for an RPC client, without the call stack.
+-- The call stack is internal detail (module names, source lines) and must stay server-side only.
+renderRpcExceptionForClient :: RpcException -> Text
+renderRpcExceptionForClient (RpcException e) = tshow (prettyError e)
 
 -- | Throw a 'GrpcException' with the given error code and message.
 -- grapesy converts this to proper gRPC trailers before it reaches 'serverTopLevel'.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -4,7 +4,7 @@
 -- | Provides datatypes used in tracing
 module Cardano.Rpc.Server.Internal.Tracing where
 
-import Cardano.Api (SlotNo)
+import Cardano.Api (File (..), SlotNo)
 import Cardano.Api.Consensus (TxValidationErrorInCardanoMode)
 import Cardano.Api.Era (Inject (..))
 import Cardano.Api.Error
@@ -12,6 +12,7 @@ import Cardano.Api.Pretty
 import Cardano.Api.Serialise.Cbor (DecoderError)
 import Cardano.Api.Serialise.Raw (SerialiseAsRawBytesError)
 import Cardano.Api.Serialise.SerialiseUsing
+import Cardano.Rpc.Server.Config (RpcEndpoint (..))
 
 import Control.Exception
 import Data.Word (Word64)
@@ -24,6 +25,8 @@ data TraceRpc
   | TraceRpcNodeKernelAccess TraceRpcNodeKernelAccess
   | TraceRpcError SomeException
   | TraceRpcFatalError SomeException
+  | -- | Emitted just before the server starts listening on the endpoint.
+    TraceRpcServerListening !RpcEndpoint
 
 -- | Traces used in Query service
 data TraceRpcQuery
@@ -45,6 +48,10 @@ instance Pretty TraceRpc where
     TraceRpcNodeKernelAccess t -> pretty t
     TraceRpcError e -> "Exception when processing RPC request:\n" <> prettyException e
     TraceRpcFatalError e -> "RPC server fatal error: " <> prettyException e
+    TraceRpcServerListening (RpcEndpointUnixSocket (File socketPath)) ->
+      "RPC server starting, listening on unix socket " <> pretty socketPath
+    TraceRpcServerListening (RpcEndpointTcp host port) ->
+      "RPC server starting, listening on " <> pretty host <> ":" <> pshow port
 
 -- | Span type
 data TraceSpanEvent

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -4,7 +4,7 @@
 -- | Provides datatypes used in tracing
 module Cardano.Rpc.Server.Internal.Tracing where
 
-import Cardano.Api (File (..), SlotNo)
+import Cardano.Api (SlotNo)
 import Cardano.Api.Consensus (TxValidationErrorInCardanoMode)
 import Cardano.Api.Era (Inject (..))
 import Cardano.Api.Error
@@ -12,7 +12,7 @@ import Cardano.Api.Pretty
 import Cardano.Api.Serialise.Cbor (DecoderError)
 import Cardano.Api.Serialise.Raw (SerialiseAsRawBytesError)
 import Cardano.Api.Serialise.SerialiseUsing
-import Cardano.Rpc.Server.Config (RpcEndpoint (..))
+import Cardano.Rpc.Server.Config (RpcEndpoint)
 
 import Control.Exception
 import Data.Word (Word64)
@@ -25,8 +25,7 @@ data TraceRpc
   | TraceRpcNodeKernelAccess TraceRpcNodeKernelAccess
   | TraceRpcError SomeException
   | TraceRpcFatalError SomeException
-  | -- | Emitted just before the server starts listening on the endpoint.
-    TraceRpcServerListening !RpcEndpoint
+  | TraceRpcServerListening !RpcEndpoint
 
 -- | Traces used in Query service
 data TraceRpcQuery
@@ -48,10 +47,7 @@ instance Pretty TraceRpc where
     TraceRpcNodeKernelAccess t -> pretty t
     TraceRpcError e -> "Exception when processing RPC request:\n" <> prettyException e
     TraceRpcFatalError e -> "RPC server fatal error: " <> prettyException e
-    TraceRpcServerListening (RpcEndpointUnixSocket (File socketPath)) ->
-      "RPC server starting, listening on unix socket " <> pretty socketPath
-    TraceRpcServerListening (RpcEndpointTcp host port) ->
-      "RPC server starting, listening on " <> pretty host <> ":" <> pshow port
+    TraceRpcServerListening endpoint -> "RPC server starting on " <> pretty endpoint
 
 -- | Span type
 data TraceSpanEvent

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Eval.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Eval.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Api qualified as L
 
 import RIO hiding (toList)
 
+import Data.ByteString qualified as BS
 import Data.Default
 import Data.Map.Strict qualified as Map
 import Data.ProtoLens (defMessage)
@@ -48,11 +49,33 @@ evalTxMethod request = do
   AnyCardanoEra (era :: CardanoEra era) <- liftIO . throwExceptT $ determineEra nodeConnInfo
   (eon :: Era era) <- forEraInEon @Era era (error "Minimum Conway era required") pure
 
+  let rawTx = request ^. U5c.tx . U5c.raw
+
+  -- A tx's inputs live inside its raw bytes, so this also bounds the input set the
+  -- query batch below resolves. The exact protocol limit is enforced further down,
+  -- once protocol parameters are available.
+  when (BS.length rawTx > maxEvalTxSizeBytes) $
+    throwGrpcErrorWithMessage GrpcInvalidArgument $
+      "transaction size "
+        <> tshow (BS.length rawTx)
+        <> " exceeds the evaluation limit "
+        <> tshow maxEvalTxSizeBytes
+
   (Exp.SignedTx ledgerTx :: Exp.SignedTx era) <-
     putTraceThrowEither
       . first TraceRpcEvalTxDecodingError
       . obtainCommonConstraints eon (deserialiseFromRawBytes asType)
-      $ request ^. U5c.tx . U5c.raw
+      $ rawTx
+
+  -- Each redeemer gets the full per-tx execution budget during evaluation, so an
+  -- unbounded redeemer count lets an unauthenticated caller multiply evaluation cost.
+  let redeemerCount =
+        obtainCommonConstraints eon $
+          Map.size . L.unRedeemers $
+            ledgerTx ^. L.witsTxL . L.rdmrsTxWitsL
+  when (redeemerCount > maxEvalRedeemers) $
+    throwGrpcErrorWithMessage GrpcInvalidArgument $
+      "too many redeemers: " <> tshow redeemerCount <> ", maximum " <> tshow maxEvalRedeemers
 
   let allInputs =
         obtainCommonConstraints eon $
@@ -77,6 +100,16 @@ evalTxMethod request = do
         registeredPools <- throwEither =<< throwEither =<< queryStakePoolParameters (convert eon) apiPoolIds
         pure
           (protocolParams, utxo, systemStart, eraHistory, stakeDelegDeposits, registeredPools)
+
+  -- A tx that only needs to decode, not be valid, could otherwise be submitted for
+  -- evaluation regardless of size; bound it to what could plausibly be submitted.
+  let maxTxSize = fromIntegral $ protocolParams ^. L.ppMaxTxSizeL
+  when (BS.length rawTx > maxTxSize) $
+    throwGrpcErrorWithMessage GrpcInvalidArgument $
+      "transaction size "
+        <> tshow (BS.length rawTx)
+        <> " exceeds the protocol maximum "
+        <> tshow maxTxSize
 
   obtainCommonConstraints eon $ do
     let ledgerUtxo = toLedgerUTxO (convert eon) utxo
@@ -118,6 +151,17 @@ evalTxMethod request = do
   putTraceThrowEither value = withFrozenCallStack $ do
     either putTrace (const $ pure ()) value
     throwEither value
+
+-- | Coarse pre-decode bound (~4x the current mainnet maxTxSize): caps decode and
+-- UTxO-query work for oversized requests. The exact protocol limit is enforced
+-- after protocol parameters are fetched.
+maxEvalTxSizeBytes :: Int
+maxEvalTxSizeBytes = 65536
+
+-- | Bounds attacker-controlled script evaluations per request: each redeemer may
+-- consume the full per-tx execution budget.
+maxEvalRedeemers :: Int
+maxEvalRedeemers = 100
 
 -- | Extract the credentials and pool IDs needed for balance check queries from
 -- the transaction body certificates.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
@@ -94,6 +94,15 @@ readUtxosMethod
 readUtxosMethod req
   | null $ req ^. U5c.keys = pure defMessage
   | otherwise = do
+      let keyCount = length $ req ^. U5c.keys
+      when (keyCount > maxReadUtxosKeys) $
+        throwGrpcErrorWithMessage GrpcInvalidArgument $
+          "too many keys: "
+            <> tshow keyCount
+            <> ", maximum "
+            <> tshow maxReadUtxosKeys
+            <> "; batch your requests"
+
       utxoFilter <- QueryUTxOByTxIn . fromList <$> mapM txoRefToTxIn (req ^. U5c.keys)
 
       nodeConnInfo <- grab
@@ -120,6 +129,11 @@ readUtxosMethod req
   txoRefToTxIn r = do
     txId' <- throwEither $ deserialiseFromRawBytes AsTxId $ r ^. U5c.hash
     pure $ TxIn txId' (TxIx . fromIntegral $ r ^. U5c.index)
+
+-- | Bounds per-request UTxO lookups the node performs; SearchUtxos pagination
+-- caps at 10_000 per page.
+maxReadUtxosKeys :: Int
+maxReadUtxosKeys = 20_000
 
 -- | Handle the @SearchUtxos@ RPC method.
 -- Filters the UTxO set by a predicate and returns a paginated result.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
@@ -57,6 +57,15 @@ fetchBlockMethod
   -> m (Proto U5c.FetchBlockResponse)
   -- ^ Response containing the fetched blocks with raw CBOR and cardano header
 fetchBlockMethod request = do
+  let refCount = length $ request ^. U5c.ref
+  when (refCount > maxFetchBlockRefs) $
+    throwGrpcErrorWithMessage GrpcInvalidArgument $
+      "too many block references: "
+        <> tshow refCount
+        <> ", maximum "
+        <> tshow maxFetchBlockRefs
+        <> "; batch your requests"
+
   nodeKernelAccess@NodeKernelAccess{systemStart, readEraHistory} <- grabNodeKernelAccess
   blocks <- forM (request ^. U5c.ref) $ \blockRef -> do
     (slot, headerHash) <- blockRefToPoint blockRef
@@ -71,6 +80,10 @@ fetchBlockMethod request = do
     timestamp <- slotTimestampOrThrow systemStart readEraHistory slot
     pure $ mkAnyChainBlock rawBytes blockInMode timestamp
   pure $ defMessage & U5c.block .~ blocks
+
+-- | Each ref is a ChainDB read and a full block in the non-streaming response.
+maxFetchBlockRefs :: Int
+maxFetchBlockRefs = 500
 
 -- | Handle the @ReadTip@ SyncService RPC method.
 -- Reads the current chain tip from ChainDB and returns it as slot, block


### PR DESCRIPTION
# Context

The cardano-rpc gRPC server has only listened on a unix domain socket, so any remote or non-local access needed a proxy such as Envoy in front of it (the stance in ADR-018). This PR adds native HTTP/2 listeners.

The server can now listen on one of:

- a unix domain socket (existing behaviour, still the default), or
- HTTP/2 without TLS (h2c) on a configured IP address and port, or
- HTTP/2 over TLS on a configured IP address and port, with certificate, private key and optional chain certificate files.

The bind address defaults to `127.0.0.1` and accepts an IPv4 or IPv6 literal. Configuring both a socket path and a listen port is rejected at configuration parse time. The node configuration surface (`RpcListenAddress`/`RpcListenPort`/`RpcTls*` keys and the matching `--grpc-listen-*`/`--grpc-tls-*` CLI flags) lives in cardano-node; this PR is the cardano-rpc library support.

Node-side configuration: IntersectMBO/cardano-node#6668.

## Breaking change

`RpcConfigF`'s `rpcSocketPath` field is replaced by `rpcEndpoint`, of a new `RpcEndpoint` sum type:

```haskell
data RpcEndpoint
  = RpcEndpointUnixSocket !SocketPath
  | RpcEndpointHttp !IP !PortNumber
  | RpcEndpointHttps !IP !PortNumber !RpcTlsFiles
```

`RpcTlsFiles` is a new record of `File`-typed certificate and key paths. `RpcEndpoint` has a `Pretty` instance, and `TraceRpc` gained a `TraceRpcServerListening` constructor, emitted when the server starts, reporting the active endpoint.

## Security considerations

The RPC server has no authentication or authorisation. Every method is open to anyone who can reach the listener, including transaction submission and script evaluation. Everything it serves is public chain data, so the concern is resource consumption and node exposure rather than confidentiality.

The defaults are conservative. The server stays off unless you pass `--grpc-enable`, it listens on a unix socket by default, and `--grpc-listen-port` binds to `127.0.0.1` unless you name another address. The node warns at startup when RPC is enabled on a block producer, when the listener binds a non-loopback address, when `SSLKEYLOGFILE` is set with TLS active, and when the TLS private key is group- or world-readable.

TLS (`--grpc-tls-certificate`, `--grpc-tls-private-key`) encrypts the connection and lets a client verify the node. It does not restrict who may call, and there is no client certificate support. A TLS listener on a public address is as open as a cleartext one.

Concurrent streams are capped at 64 per connection, and the HTTP/2 flood limits and flow-control windows from `http2` apply. Error responses carry only a redacted message, never call stacks or internal detail; full detail stays in the node's traces. Script evaluation is bounded: a 64 KiB pre-decode cap, the protocol's max transaction size, and at most 100 redeemers. UTxO reads are capped at 20000 keys, and block fetches at 500 references per request. Not bounded: the number of concurrent connections, idle connections (never reaped), and the total gRPC message size (a per-message limit needs an upstream `grapesy` feature).

Keep the listener on loopback or a trusted network segment. Anywhere else, put a reverse proxy in front of it to terminate TLS and handle authentication and rate limiting, as ADR-018 describes. Note that the server writes TLS key log material if `SSLKEYLOGFILE` is set in its environment.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
