### PR TITLE
cardano-rpc: Implement ReadEraSummary gRPC method

### DIFF
--- a/.changes/20260903_cardano_rpc_read_era_summary.yml
+++ b/.changes/20260903_cardano_rpc_read_era_summary.yml
@@ -1,0 +1,7 @@
+project: cardano-rpc
+pr: 1325
+kind:
+  - feature
+  - breaking
+description: |
+  Implement the `ReadEraSummary` gRPC method, returning the era name and the start and end boundaries (Unix-epoch milliseconds, slot, epoch) of every era in the chain's history. The `NodeKernelAccess` type is now abstract; use the functions of `Cardano.Rpc.Server.NodeKernelAccess` instead of its record fields.

--- a/cardano-rpc/README.md
+++ b/cardano-rpc/README.md
@@ -21,7 +21,7 @@ Use a dedicated chain indexing service for those.
 | [ReadData](https://utxorpc.org/query/spec/#readdatarequest) | ❌ Not supported, needs a chain indexer |
 | [ReadTx](https://utxorpc.org/query/spec/#queryservice) | ❌ Not supported, needs a chain indexer |
 | [ReadGenesis](https://utxorpc.org/query/spec/#queryservice) | ✅ Supported |
-| [ReadEraSummary](https://utxorpc.org/query/spec/#queryservice) | ⬜ Not supported |
+| [ReadEraSummary](https://utxorpc.org/query/spec/#queryservice) | ✅ Supported |
 | [ReadState](https://utxorpc.org/query/spec/#queryservice) | ⬜ Not supported |
 
 ### [SubmitService](https://utxorpc.org/submit/spec/)

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -81,10 +81,10 @@ library
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.TxEval
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.TxOutput
     Cardano.Rpc.Server.NodeKernelAccess
-    Cardano.Rpc.Server.NodeKernelAccess.Type
 
   other-modules:
     Cardano.Rpc.Server.Internal.Orphans
+    Cardano.Rpc.Server.NodeKernelAccess.Internal.Type
     Paths_cardano_rpc
 
   autogen-modules:
@@ -125,6 +125,8 @@ library
     mempack,
     microlens,
     network,
+    ouroboros-consensus,
+    ouroboros-consensus:cardano,
     proto-lens >=0.7.1.7,
     proto-lens-protobuf-types,
     random,

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -71,6 +71,7 @@ library
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Byron
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Certificate
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint
+    Cardano.Rpc.Server.Internal.UtxoRpc.Type.EraSummary
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Genesis
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.Governance
     Cardano.Rpc.Server.Internal.UtxoRpc.Type.PlutusData
@@ -110,6 +111,7 @@ library
     cardano-ledger-dijkstra,
     cardano-ledger-shelley,
     cardano-rpc:gen,
+    cardano-slotting,
     containers,
     contra-tracer,
     data-default,
@@ -131,6 +133,7 @@ library
     proto-lens-protobuf-types,
     random,
     rio,
+    sop-extras,
     strict-sop-core,
     text,
     time,
@@ -185,6 +188,7 @@ test-suite cardano-rpc-test
     cardano-ledger-shelley,
     cardano-ledger-shelley:testlib,
     cardano-rpc,
+    cardano-slotting,
     containers,
     formatting,
     grpc-spec,
@@ -193,10 +197,12 @@ test-suite cardano-rpc-test
     hedgehog-quickcheck,
     memory,
     mtl,
+    ouroboros-consensus,
     ouroboros-consensus:cardano,
     proto-lens,
     rio,
     scientific,
+    sop-extras,
     tasty,
     tasty-hedgehog,
     text,
@@ -211,6 +217,7 @@ test-suite cardano-rpc-test
   build-tool-depends: tasty-discover:tasty-discover
   other-modules:
     Test.Cardano.Rpc.ByronTx
+    Test.Cardano.Rpc.EraSummary
     Test.Cardano.Rpc.Eval
     Test.Cardano.Rpc.FetchBlockTx
     Test.Cardano.Rpc.FollowTipStream

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -71,7 +71,7 @@ methodsUtxoRpc
   => Methods m (ProtobufMethodsOf UtxoRpc.QueryService)
 methodsUtxoRpc =
   UnsupportedMethod -- readData
-    . UnsupportedMethod -- readEraSummary
+    . Method (mkNonStreaming $ wrapInSpan TraceRpcQueryReadEraSummarySpan . readEraSummaryMethod)
     . Method (mkNonStreaming $ wrapInSpan TraceRpcQueryReadGenesisSpan . readGenesisMethod)
     . Method (mkNonStreaming $ wrapInSpan TraceRpcQueryParamsSpan . readParamsMethod)
     . UnsupportedMethod -- readState

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Env.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Env.hs
@@ -10,7 +10,7 @@ where
 import Cardano.Api
 import Cardano.Rpc.Server.Config
 import Cardano.Rpc.Server.Internal.Tracing
-import Cardano.Rpc.Server.NodeKernelAccess.Type (NodeKernelAccess)
+import Cardano.Rpc.Server.NodeKernelAccess.Internal.Type (NodeKernelAccess)
 
 import Control.Tracer (Tracer)
 import Data.IORef

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Monad.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Monad.hs
@@ -24,7 +24,7 @@ where
 import Cardano.Api
 import Cardano.Rpc.Server.Internal.Env
 import Cardano.Rpc.Server.Internal.Tracing
-import Cardano.Rpc.Server.NodeKernelAccess.Type (NodeKernelAccess)
+import Cardano.Rpc.Server.NodeKernelAccess.Internal.Type (NodeKernelAccess)
 
 import RIO
 

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Tracing.hs
@@ -37,6 +37,8 @@ data TraceRpcQuery
     TraceRpcQuerySearchUtxosSpan TraceSpanEvent
   | -- | Span trace marking ReadGenesis query
     TraceRpcQueryReadGenesisSpan TraceSpanEvent
+  | -- | Span trace marking ReadEraSummary query
+    TraceRpcQueryReadEraSummarySpan TraceSpanEvent
   deriving Show
 
 instance Pretty TraceRpc where
@@ -70,6 +72,8 @@ instance Pretty TraceRpcQuery where
     TraceRpcQuerySearchUtxosSpan (SpanEnd _) -> "Finished query search UTXO method"
     TraceRpcQueryReadGenesisSpan (SpanBegin _) -> "Started query read genesis method"
     TraceRpcQueryReadGenesisSpan (SpanEnd _) -> "Finished query read genesis method"
+    TraceRpcQueryReadEraSummarySpan (SpanBegin _) -> "Started query read era summary method"
+    TraceRpcQueryReadEraSummarySpan (SpanEnd _) -> "Finished query read era summary method"
 
 instance Error TraceRpcQuery where
   prettyError = pretty

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
@@ -201,14 +201,11 @@ readGenesisMethod
   -> m (Proto UtxoRpc.ReadGenesisResponse)
 readGenesisMethod _req = do
   -- TODO: field masks are ignored for now (same as readParamsMethod)
-  NodeKernelAccess
-    { genesisConfig =
-      genesisBundle@GenesisBundle
+  nodeKernelAccess <- grabNodeKernelAccess
+  let genesisBundle@GenesisBundle
         { shelleyGenesisHash
         , shelleyGenesis = (shelleyGenesisFile, shelleyGenesisCache)
-        }
-    } <-
-    grabNodeKernelAccess
+        } = genesisConfig nodeKernelAccess
   shelleyGenesis <-
     readThroughCache shelleyGenesisCache $
       readShelleyGenesisWithInitialFunds shelleyGenesisFile shelleyGenesisHash

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Query.hs
@@ -16,6 +16,7 @@ module Cardano.Rpc.Server.Internal.UtxoRpc.Query
   , readUtxosMethod
   , searchUtxosMethod
   , readGenesisMethod
+  , readEraSummaryMethod
   , paginateByTxIn
   )
 where
@@ -263,6 +264,21 @@ readShelleyGenesisWithInitialFunds shelleyGenesisFile@(File path) bootGenesisHas
         <> tshow path
         <> ": "
         <> Text.pack reason
+
+-- | Handle the @ReadEraSummary@ RPC method.
+-- Returns the node's hard-fork era summary: one entry per era the node's
+-- ledger state has seen so far, with name and start/end boundaries. See
+-- 'eraSummariesToProto' for exactly which fields are populated.
+readEraSummaryMethod
+  :: MonadRpc e m
+  => Proto UtxoRpc.ReadEraSummaryRequest
+  -> m (Proto UtxoRpc.ReadEraSummaryResponse)
+readEraSummaryMethod _req = do
+  -- TODO: field masks are ignored for now (same as readParamsMethod)
+  nodeKernelAccess <- grabNodeKernelAccess
+  summary <- readHardForkSummary nodeKernelAccess
+  pure $
+    defMessage & U5c.cardano .~ eraSummariesToProto (nodeKernelSystemStart nodeKernelAccess) summary
 
 -- | The CAIP-2 chain identifier for a Cardano network, keyed on the Shelley
 -- network magic.

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Sync.hs
@@ -66,7 +66,7 @@ fetchBlockMethod request = do
         <> tshow maxFetchBlockRefs
         <> "; batch your requests"
 
-  nodeKernelAccess@NodeKernelAccess{systemStart, readEraHistory} <- grabNodeKernelAccess
+  nodeKernelAccess <- grabNodeKernelAccess
   blocks <- forM (request ^. U5c.ref) $ \blockRef -> do
     (slot, headerHash) <- blockRefToPoint blockRef
     let throwNotFound =
@@ -77,7 +77,8 @@ fetchBlockMethod request = do
               <> serialiseToRawBytesHexText headerHash
     (rawBytes, blockInMode) <-
       fetchBlock nodeKernelAccess slot headerHash >>= maybe throwNotFound pure
-    timestamp <- slotTimestampOrThrow systemStart readEraHistory slot
+    timestamp <-
+      slotTimestampOrThrow (nodeKernelSystemStart nodeKernelAccess) (readEraHistory nodeKernelAccess) slot
     pure $ mkAnyChainBlock rawBytes blockInMode timestamp
   pure $ defMessage & U5c.block .~ blocks
 
@@ -94,8 +95,11 @@ readTipMethod
   => Proto U5c.ReadTipRequest
   -> m (Proto U5c.ReadTipResponse)
 readTipMethod _request = do
-  NodeKernelAccess{chainDb, systemStart, readEraHistory} <- grabNodeKernelAccess
-  tip <- readTipBlockRef chainDb (slotTimestampOrThrow systemStart readEraHistory)
+  nodeKernelAccess <- grabNodeKernelAccess
+  tip <-
+    readTipBlockRef
+      nodeKernelAccess
+      (slotTimestampOrThrow (nodeKernelSystemStart nodeKernelAccess) (readEraHistory nodeKernelAccess))
   pure $ defMessage & U5c.maybe'tip .~ tip
 
 -- | Handle the @FollowTip@ SyncService RPC method: stream fully parsed
@@ -115,7 +119,7 @@ readTipMethod _request = do
 -- slot and hash only, like ChainSync's @MsgRollBackward@. The tracked
 -- window is sized to the node's security parameter /k/, so no rollback
 -- consensus can produce falls outside it (see
--- 'Cardano.Rpc.Server.NodeKernelAccess.Type.NodeKernelAccess').
+-- 'Cardano.Rpc.Server.NodeKernelAccess.securityParam').
 -- Every response also carries the current chain tip.
 --
 -- Errors: @INVALID_ARGUMENT@ if an intersection block ref has an invalid
@@ -131,8 +135,7 @@ followTipMethod
   -- ^ Callback used to send each streamed response
   -> m ()
 followTipMethod request send = do
-  nodeKernelAccess@NodeKernelAccess{chainDb, systemStart, readEraHistory, securityParam} <-
-    grabNodeKernelAccess
+  nodeKernelAccess <- grabNodeKernelAccess
   requestedPoints <- traverse blockRefToIntersectPoint (request ^. U5c.intersect)
   withFollower nodeKernelAccess $ \follower -> do
     -- an empty intersect list follows from the current tip; resolving it
@@ -140,19 +143,19 @@ followTipMethod request send = do
     -- for "the current tip point"), so this step stays here rather than
     -- moving into 'followTipStream', which only takes an already-resolved,
     -- non-empty point list
-    let slotTimestamp = slotTimestampOrThrow systemStart readEraHistory
+    let slotTimestamp = slotTimestampOrThrow (nodeKernelSystemStart nodeKernelAccess) (readEraHistory nodeKernelAccess)
     startPoints <-
       if null requestedPoints
         then do
-          tipHeader <- liftIO $ Consensus.getTipHeader chainDb
+          tipHeader <- readChainTipHeader nodeKernelAccess
           pure [maybe ChainPointAtGenesis tipHeaderPoint tipHeader]
         else pure requestedPoints
     followTipStream
       follower
-      (readTipBlockRef chainDb slotTimestamp)
+      (readTipBlockRef nodeKernelAccess slotTimestamp)
       slotTimestamp
       (fetchBlockByChainPoint nodeKernelAccess)
-      (fromIntegral . L.unNonZero $ Consensus.maxRollbacks securityParam)
+      (fromIntegral . L.unNonZero $ Consensus.maxRollbacks (securityParam nodeKernelAccess))
       send
       startPoints
 
@@ -262,7 +265,7 @@ followTipStream
   -> Int
   -- ^ How many applied points to track for undo re-fetch. In production
   -- this is the node's security parameter /k/
-  -- ('Cardano.Rpc.Server.NodeKernelAccess.Type.securityParam'). Consensus
+  -- ('Cardano.Rpc.Server.NodeKernelAccess.securityParam'). Consensus
   -- never rolls back more than /k/ blocks, so tracking /k/ points covers
   -- every rollback the protocol can produce, on any network. An entry
   -- costs roughly 40 bytes, so the window costs about @40 * k@ bytes per
@@ -378,12 +381,12 @@ followTipStream ChainFollower{nextChange, findIntersect} readTip slotTimestamp f
 -- 'mkTipBlockRef', or 'Nothing' at origin.
 readTipBlockRef
   :: MonadIO m
-  => Consensus.ChainDB IO (Consensus.CardanoBlock Consensus.StandardCrypto)
+  => NodeKernelAccess
   -> (SlotNo -> m UTCTime)
   -- ^ Convert a slot to its wall-clock timestamp
   -> m (Maybe (Proto U5c.BlockRef))
-readTipBlockRef chainDb slotTimestamp = do
-  tipHeader <- liftIO $ Consensus.getTipHeader chainDb
+readTipBlockRef nodeKernelAccess slotTimestamp = do
+  tipHeader <- readChainTipHeader nodeKernelAccess
   forM tipHeader $ \header ->
     mkTipBlockRef header <$> slotTimestamp (Consensus.blockSlot header)
 
@@ -396,8 +399,8 @@ slotTimestampOrThrow
   -- ^ Read current era history from the ledger state
   -> SlotNo
   -> m UTCTime
-slotTimestampOrThrow systemStart readEraHistory slot = do
-  eraHistory <- readEraHistory
+slotTimestampOrThrow systemStart readEraHistoryAction slot = do
+  eraHistory <- readEraHistoryAction
   slotToUTCTime systemStart eraHistory slot
     & either (const throwPastHorizon) pure
  where

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type.hs
@@ -5,6 +5,7 @@
 module Cardano.Rpc.Server.Internal.UtxoRpc.Type
   ( utxoRpcPParamsToProtocolParams
   , genesisBundleToProto
+  , eraSummariesToProto
   , utxoToUtxoRpcAnyUtxoData
   , txInTxOutToAnyUtxoData
   , anyUtxoDataUtxoRpcToUtxo
@@ -31,6 +32,7 @@ where
 
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type.BigInt
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.EraSummary
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Genesis
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type.PlutusData
 import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ProtocolParameters

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/EraSummary.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/EraSummary.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | Conversion of the node's hard-fork era summary to the UTxO RPC
+-- 'U5c.EraSummaries' message.
+module Cardano.Rpc.Server.Internal.UtxoRpc.Type.EraSummary
+  ( eraSummariesToProto
+  )
+where
+
+import Cardano.Api (AnyCardanoEra (..), SystemStart, docToText, pretty, unEpochNo, unSlotNo)
+import Cardano.Api.Consensus qualified as Consensus
+import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as U5c
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type.ChainPoint (utcTimeToMs)
+
+import Cardano.Slotting.Time (fromRelativeTime)
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.HardFork.History qualified as History
+
+import RIO
+
+import Data.ProtoLens (defMessage)
+import Data.SOP.NonEmpty (nonEmptyToList)
+import Data.Text qualified as Text
+import Network.GRPC.Spec
+
+-- | Convert the node's hard-fork era summary to the UTxO RPC
+-- 'U5c.EraSummaries' message.
+--
+-- Every era except the last gets its 'U5c.maybe''end' populated from the
+-- confirmed era transition. The last era's end is always left unset, even
+-- when consensus already supplies a bound for it: consensus cannot
+-- distinguish a confirmed transition from the safe-zone forecast horizon, so
+-- the spec's "if the era has a well-defined ending" only ever holds for
+-- non-final eras here. 'History.EraUnbounded' likewise maps to unset.
+--
+-- 'U5c.protocolParams' is left unset for every era: the node does not keep
+-- historical per-era protocol parameters. Use @ReadParams@ for the current
+-- era's parameters.
+eraSummariesToProto
+  :: SystemStart
+  -> History.Summary (CardanoEras Consensus.StandardCrypto)
+  -> Proto U5c.EraSummaries
+eraSummariesToProto systemStart summary =
+  defMessage & U5c.summaries .~ zipWith3 mkEraSummary eraNames isLastEra eraEntries
+ where
+  -- All eras in chronological order, i.e. the same order as the summary's
+  -- entries: 'History.Summary' has no era name field, an entry's era is its
+  -- position, so the names are zipped in positionally.
+  eraNames :: [Text]
+  eraNames =
+    [ Text.toLower . docToText $ pretty era
+    | AnyCardanoEra era <- [minBound .. maxBound]
+    ]
+
+  eraEntries :: [History.EraSummary]
+  eraEntries = nonEmptyToList (History.getSummary summary)
+
+  -- 'eraEntries' is always non-empty ('Summary' wraps a non-empty list), so
+  -- this always ends in exactly one 'True'.
+  isLastEra :: [Bool]
+  isLastEra = replicate (length eraEntries - 1) False <> [True]
+
+  mkEraSummary :: Text -> Bool -> History.EraSummary -> Proto U5c.EraSummary
+  mkEraSummary name isLast entry =
+    defMessage
+      & U5c.name .~ name
+      & U5c.start .~ boundToProto (History.eraStart entry)
+      & U5c.maybe'end .~ if isLast then Nothing else endToProto (History.eraEnd entry)
+
+  endToProto :: History.EraEnd -> Maybe (Proto U5c.EraBoundary)
+  endToProto = \case
+    History.EraEnd bound -> Just (boundToProto bound)
+    History.EraUnbounded -> Nothing
+
+  boundToProto :: History.Bound -> Proto U5c.EraBoundary
+  boundToProto bound =
+    defMessage
+      & U5c.time .~ boundTimeMs bound
+      & U5c.slot .~ unSlotNo (History.boundSlot bound)
+      & U5c.epoch .~ unEpochNo (History.boundEpoch bound)
+
+  -- Reuses 'utcTimeToMs', the same millisecond conversion 'mkChainPointMsg'
+  -- and 'mkTipBlockRef' use for their proto timestamps, for consistency
+  -- across the API. 'fromRelativeTime' adds the boundary's 'RelativeTime' to
+  -- the system start with 'Pico'-precision arithmetic throughout.
+  boundTimeMs :: History.Bound -> Word64
+  boundTimeMs bound = utcTimeToMs (fromRelativeTime systemStart (History.boundTime bound))

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Genesis.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/UtxoRpc/Type/Genesis.hs
@@ -35,7 +35,7 @@ import Cardano.Rpc.Server.Internal.UtxoRpc.Type.Certificate
   , keyHashToBytes
   , scriptHashToBytes
   )
-import Cardano.Rpc.Server.NodeKernelAccess.Type (GenesisBundle (..))
+import Cardano.Rpc.Server.NodeKernelAccess.Internal.Type (GenesisBundle (..))
 
 import Cardano.Chain.Common qualified as Byron
   ( KeyHash

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
@@ -12,6 +12,7 @@ module Cardano.Rpc.Server.NodeKernelAccess
   , securityParam
   , genesisConfig
   , readEraHistory
+  , readHardForkSummary
   , readChainTipHeader
   , GenesisBundle (..)
   , mkNodeKernelAccess

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess.hs
@@ -7,7 +7,12 @@
 {-# LANGUAGE NoFieldSelectors #-}
 
 module Cardano.Rpc.Server.NodeKernelAccess
-  ( NodeKernelAccess (..)
+  ( Type.NodeKernelAccess
+  , nodeKernelSystemStart
+  , securityParam
+  , genesisConfig
+  , readEraHistory
+  , readChainTipHeader
   , GenesisBundle (..)
   , mkNodeKernelAccess
   , fetchBlock
@@ -23,7 +28,11 @@ import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Rpc.Server.Internal.Monad (MonadRpc, grab)
 import Cardano.Rpc.Server.Internal.TimedCache (newTimedCache)
 import Cardano.Rpc.Server.Internal.Tracing
-import Cardano.Rpc.Server.NodeKernelAccess.Type
+import Cardano.Rpc.Server.NodeKernelAccess.Internal.Type (GenesisBundle (..))
+import Cardano.Rpc.Server.NodeKernelAccess.Internal.Type qualified as Type
+
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.HardFork.History qualified as History
 
 import RIO (MonadUnliftIO, atomically, bracket, throwIO, withRunInIO)
 
@@ -52,27 +61,38 @@ mkNodeKernelAccess
   -- ^ Block type witness
   -> Consensus.NodeKernel IO addrNTN addrNTC blk
   -- ^ Consensus node kernel
-  -> m (Maybe NodeKernelAccess)
+  -> m (Maybe Type.NodeKernelAccess)
 mkNodeKernelAccess tracer shelleyGenesisHash shelleyGenesisFile blockType kernel = case blockType of
   Consensus.CardanoBlockType -> do
-    genesisConfig <- readGenesisBundle shelleyGenesisHash shelleyGenesisFile topLevelConfig
-    pure $ Just NodeKernelAccess{chainDb, systemStart, readEraHistory, securityParam, genesisConfig}
+    genesisBundle <- readGenesisBundle shelleyGenesisHash shelleyGenesisFile topLevelConfig
+    pure $
+      Just
+        Type.NodeKernelAccess
+          { Type.chainDb = chainDb
+          , Type.systemStart = Consensus.nodeSystemStart topLevelConfig
+          , Type.readHardForkSummary = readHardForkSummary'
+          , Type.securityParam = Consensus.configSecurityParam topLevelConfig
+          , Type.genesisConfig = genesisBundle
+          }
    where
     chainDb = Consensus.getChainDB kernel
     topLevelConfig = Consensus.getTopLevelConfig kernel
     ledgerConfig = Consensus.configLedger topLevelConfig
-    systemStart = Consensus.nodeSystemStart topLevelConfig
-    securityParam = Consensus.configSecurityParam topLevelConfig
+    -- Primed because 'Cardano.Rpc.Server.NodeKernelAccess' also exports an
+    -- accessor of the same name; this is the local action that feeds the
+    -- corresponding record field above.
+    --
     -- Read the current ledger state (cheap STM TVar read) and recompute
     -- the era summary on every call - O(number_of_eras).
     -- This is the same approach consensus uses for GetInterpreter queries
     -- (interpretQueryHardFork); neither path caches the summary.
     -- RunWithCachedSummary exists but is private to the blockchain time thread.
-    readEraHistory :: MonadIO n => n EraHistory
-    readEraHistory = liftIO $ do
+    readHardForkSummary'
+      :: MonadIO n
+      => n (History.Summary (CardanoEras Consensus.StandardCrypto))
+    readHardForkSummary' = liftIO $ do
       extLedger <- atomically $ Consensus.getCurrentLedger chainDb
-      pure . EraHistory . Consensus.mkInterpreter $
-        Consensus.hardForkSummary ledgerConfig (Consensus.ledgerState extLedger)
+      pure $ Consensus.hardForkSummary ledgerConfig (Consensus.ledgerState extLedger)
   _ -> do
     -- unsupported block type
     traceWith tracer . inject . TraceRpcUnsupportedBlockType . pack $ show blockType
@@ -134,7 +154,7 @@ readGenesisBundle shelleyGenesisHash shelleyGenesisFile topLevelConfig =
 -- gRPC UNAVAILABLE if the node kernel has not yet initialised.
 grabNodeKernelAccess
   :: MonadRpc e m
-  => m NodeKernelAccess
+  => m Type.NodeKernelAccess
 grabNodeKernelAccess =
   grab >>= liftIO . readIORef >>= \case
     Nothing ->
@@ -148,11 +168,46 @@ grabNodeKernelAccess =
     Just nodeKernelAccess ->
       pure nodeKernelAccess
 
+-- | The network's system start time, extracted from genesis config.
+-- Used together with 'readEraHistory' to convert slots to wall-clock time.
+nodeKernelSystemStart :: Type.NodeKernelAccess -> SystemStart
+nodeKernelSystemStart Type.NodeKernelAccess{Type.systemStart = value} = value
+
+-- | The protocol security parameter /k/: consensus never rolls back more
+-- than /k/ blocks.
+securityParam :: Type.NodeKernelAccess -> Consensus.SecurityParam
+securityParam Type.NodeKernelAccess{Type.securityParam = value} = value
+
+-- | The network's genesis configuration.
+genesisConfig :: Type.NodeKernelAccess -> GenesisBundle
+genesisConfig Type.NodeKernelAccess{Type.genesisConfig = value} = value
+
+-- | Read the raw hard-fork era summary from the current ledger state, with
+-- the era boundaries directly accessible.
+readHardForkSummary
+  :: MonadIO m
+  => Type.NodeKernelAccess
+  -> m (History.Summary (CardanoEras Consensus.StandardCrypto))
+readHardForkSummary Type.NodeKernelAccess{Type.readHardForkSummary = action} = action
+
+-- | Read current era history from the ledger state: the hard-fork era
+-- summary wrapped into the opaque interpreter used for slot/time conversion
+-- queries.
+readEraHistory :: MonadIO m => Type.NodeKernelAccess -> m EraHistory
+readEraHistory access = EraHistory . Consensus.mkInterpreter <$> readHardForkSummary access
+
+-- | Read the current chain tip header from ChainDB, or 'Nothing' at origin.
+readChainTipHeader
+  :: MonadIO m
+  => Type.NodeKernelAccess
+  -> m (Maybe (Consensus.Header (Consensus.CardanoBlock Consensus.StandardCrypto)))
+readChainTipHeader Type.NodeKernelAccess{Type.chainDb = chainDb} = liftIO $ Consensus.getTipHeader chainDb
+
 -- | Fetch a raw block and its parsed era-contextualised form from ChainDB
 -- by slot and header hash.
 fetchBlock
   :: MonadIO m
-  => NodeKernelAccess
+  => Type.NodeKernelAccess
   -- ^ Node kernel access handle
   -> SlotNo
   -- ^ Block slot number
@@ -160,7 +215,7 @@ fetchBlock
   -- ^ Block header hash
   -> m (Maybe (ByteString, BlockInMode))
   -- ^ Raw CBOR bytes and the block in era context, or 'Nothing' if not found
-fetchBlock NodeKernelAccess{chainDb} slot (HeaderHash shortHash) = do
+fetchBlock Type.NodeKernelAccess{Type.chainDb = chainDb} slot (HeaderHash shortHash) = do
   let point = Consensus.RealPoint slot (Consensus.OneEraHash shortHash)
       component = (,) <$> fmap BSL.toStrict Consensus.GetRawBlock <*> fmap fromConsensusBlock Consensus.GetBlock
   liftIO $ Consensus.getBlockComponent chainDb component point
@@ -201,10 +256,10 @@ data ChainFollower = ChainFollower
 -- ChainSync client, so one follower per stream scales the same way.
 withFollower
   :: MonadUnliftIO m
-  => NodeKernelAccess
+  => Type.NodeKernelAccess
   -> (ChainFollower -> m a)
   -> m a
-withFollower NodeKernelAccess{chainDb} action =
+withFollower Type.NodeKernelAccess{Type.chainDb = chainDb} action =
   withRunInIO $ \runInIO ->
     Consensus.withRegistry $ \registry ->
       bracket

--- a/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Internal/Type.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/NodeKernelAccess/Internal/Type.hs
@@ -2,15 +2,14 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE NoFieldSelectors #-}
 
-module Cardano.Rpc.Server.NodeKernelAccess.Type
+module Cardano.Rpc.Server.NodeKernelAccess.Internal.Type
   ( NodeKernelAccess (..)
   , GenesisBundle (..)
   )
 where
 
 import Cardano.Api
-  ( EraHistory
-  , FileDirection (In)
+  ( FileDirection (In)
   , GenesisHashShelley
   , ShelleyGenesisFile
   , SystemStart
@@ -22,6 +21,8 @@ import Cardano.Chain.Genesis qualified as Byron (Config)
 import Cardano.Ledger.Alonzo.Genesis qualified as L (AlonzoGenesis)
 import Cardano.Ledger.Conway.Genesis qualified as L (ConwayGenesis)
 import Cardano.Ledger.Shelley.Genesis qualified as L (ShelleyGenesis)
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.HardFork.History qualified as History
 
 import Control.Monad.IO.Class (MonadIO)
 
@@ -32,12 +33,15 @@ data NodeKernelAccess = NodeKernelAccess
   -- ^ Handle to the consensus chain database
   , systemStart :: SystemStart
   -- ^ Network system start time, extracted from genesis config.
-  -- Used together with 'readEraHistory' to convert slots to wall-clock time.
-  , readEraHistory :: forall m. MonadIO m => m EraHistory
-  -- ^ Read current era history from the ledger state.
+  -- Used together with the era history to convert slots to wall-clock time.
+  , readHardForkSummary
+      :: forall m
+       . MonadIO m
+      => m (History.Summary (CardanoEras Consensus.StandardCrypto))
+  -- ^ Read the hard-fork era summary from the current ledger state.
   -- This is a separate read from 'chainDb', but the inconsistency is
   -- always safe: the ledger state is at or ahead of any block in ChainDB,
-  -- and era summaries only grow, so the returned history always covers the
+  -- and era summaries only grow, so the summary always covers the
   -- slot of any block fetched from ChainDB.
   , securityParam :: Consensus.SecurityParam
   -- ^ The protocol security parameter /k/: consensus never rolls back more

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/EraSummary.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/EraSummary.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Rpc.EraSummary where
+
+import Cardano.Api (EpochNo (..), SlotNo (..), SystemStart (..))
+import Cardano.Api.Consensus qualified as Consensus
+import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as U5c
+import Cardano.Rpc.Server.Internal.UtxoRpc.Type (eraSummariesToProto)
+
+import Cardano.Ledger.BaseTypes (knownNonZeroBounded)
+import Cardano.Slotting.Time (RelativeTime (..))
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types (slotLengthFromSec)
+import Ouroboros.Consensus.Cardano.Block (CardanoEras)
+import Ouroboros.Consensus.HardFork.History qualified as History
+
+import RIO
+
+import Data.SOP.NonEmpty (NonEmpty (..))
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+
+import Hedgehog as H
+import Hedgehog.Extras qualified as H
+
+-- | Placeholder era parameters: 'eraSummariesToProto' never reads them, but
+-- an 'History.EraSummary' fixture still needs one.
+dummyEraParams :: History.EraParams
+dummyEraParams =
+  History.defaultEraParams
+    (Consensus.SecurityParam (knownNonZeroBounded @2160))
+    (slotLengthFromSec 1)
+
+mkBound :: SlotNo -> EpochNo -> RelativeTime -> History.Bound
+mkBound slot epoch time =
+  History.Bound
+    { History.boundTime = time
+    , History.boundSlot = slot
+    , History.boundEpoch = epoch
+    , History.boundPerasRound = History.NoPerasEnabled
+    }
+
+mkEraSummary :: History.Bound -> History.EraEnd -> History.EraSummary
+mkEraSummary start end =
+  History.EraSummary
+    { History.eraStart = start
+    , History.eraEnd = end
+    , History.eraParams = dummyEraParams
+    }
+
+-- | Two eras: the boundary between them uses a fractional-second
+-- 'RelativeTime' to prove the millisecond conversion is exact (rounded to
+-- the nearest millisecond, never routed through 'Double'). The second era is
+-- last and carries a real 'History.EraEnd' bound, but its end must still
+-- come out unset.
+hprop_era_summary_multi_era :: Property
+hprop_era_summary_multi_era = H.propertyOnce $ do
+  let systemStart = SystemStart (posixSecondsToUTCTime 0)
+
+      byronStart = mkBound (SlotNo 0) (EpochNo 0) (RelativeTime 0)
+      -- 172800.6789s proves the ms conversion is exact fixed-point via the
+      -- shared 'utcTimeToMs' (nearest-ms rounding): .6789s -> 679ms. A
+      -- Double-based path, or a floor instead of a round, would give 678.
+      transition = mkBound (SlotNo 21600) (EpochNo 1) (RelativeTime 172800.6789)
+      shelleyEnd = mkBound (SlotNo 43200) (EpochNo 2) (RelativeTime 259200)
+
+      byronSummary = mkEraSummary byronStart (History.EraEnd transition)
+      shelleySummary = mkEraSummary transition (History.EraEnd shelleyEnd)
+
+      summary :: History.Summary (CardanoEras Consensus.StandardCrypto)
+      summary = History.Summary (NonEmptyCons byronSummary (NonEmptyOne shelleySummary))
+
+      proto = eraSummariesToProto systemStart summary
+      entries = proto ^. U5c.summaries
+
+  length entries === 2
+
+  byronEntry <- H.nothingFail $ listToMaybe entries
+  shelleyEntry <- H.nothingFail . listToMaybe $ drop 1 entries
+
+  byronEntry ^. U5c.name === "byron"
+  byronEntry ^. U5c.start . U5c.time === 0
+  byronEntry ^. U5c.start . U5c.slot === 0
+  byronEntry ^. U5c.start . U5c.epoch === 0
+  H.assertWith (byronEntry ^. U5c.maybe'end) isJust
+  byronEntry ^. U5c.end . U5c.time === 172800679
+  byronEntry ^. U5c.end . U5c.slot === 21600
+  byronEntry ^. U5c.end . U5c.epoch === 1
+
+  shelleyEntry ^. U5c.name === "shelley"
+  shelleyEntry ^. U5c.start . U5c.time === 172800679
+  shelleyEntry ^. U5c.start . U5c.slot === 21600
+  shelleyEntry ^. U5c.start . U5c.epoch === 1
+  -- Last era: end must be unset even though the fixture supplies a real bound.
+  H.assertWith (shelleyEntry ^. U5c.maybe'end) isNothing
+
+-- | A single-era summary (only Byron) has exactly one entry, and that entry
+-- has no end, whether or not consensus reports the era as unbounded.
+hprop_era_summary_single_era_no_end :: Property
+hprop_era_summary_single_era_no_end = H.propertyOnce $ do
+  let systemStart = SystemStart (posixSecondsToUTCTime 0)
+      byronStart = mkBound (SlotNo 0) (EpochNo 0) (RelativeTime 0)
+      byronSummary = mkEraSummary byronStart History.EraUnbounded
+
+      summary :: History.Summary (CardanoEras Consensus.StandardCrypto)
+      summary = History.Summary (NonEmptyOne byronSummary)
+
+      proto = eraSummariesToProto systemStart summary
+      entries = proto ^. U5c.summaries
+
+  length entries === 1
+
+  byronEntry <- H.nothingFail $ listToMaybe entries
+  byronEntry ^. U5c.name === "byron"
+  H.assertWith (byronEntry ^. U5c.maybe'end) isNothing


### PR DESCRIPTION
# Context

Implements the `ReadEraSummary` gRPC method, previously answered with `UNIMPLEMENTED` — the Phase 1 quick win of #1302 (Ogmios feature parity). Clients can now read the chain's era summaries: the era name and each era's start and end boundaries as Unix-epoch milliseconds, absolute slot and epoch number.

Response semantics follow the other UTxO RPC implementations (Dolos, Blink Labs dingo):

- boundary timestamps are absolute Unix-epoch milliseconds
- the current era's `end` is left unset, since the era has no well-defined ending yet
- `protocol_params` is left unset; use `ReadParams` for the current protocol parameters

The first commit is a preparatory refactoring: `NodeKernelAccess`'s record fields are no longer exported; consumers go through the module's functions.

# How to trust this PR

Unit tests cover the summary-to-proto conversion, including the millisecond arithmetic and the unset end of the current era. Semantics were cross-checked against Dolos and dingo. An end-to-end testnet test is prepared in cardano-node and will land with the version bump there.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
