### PR TITLE
Bump `ouroboros-consensus-4.2.1.0`

### DIFF
--- a/.changes/20260903_165615_cardano-api_pablo.lamela_bump_ouroboros_consensus.yml
+++ b/.changes/20260903_165615_cardano-api_pablo.lamela_bump_ouroboros_consensus.yml
@@ -1,0 +1,6 @@
+description: Bumped ouroboros-consensus to address issue that affected queries `kes-period-info`
+  and `tip`.
+kind:
+- bugfix
+pr: 1327
+project: cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-08-02T17:21:34Z
-  , cardano-haskell-packages 2026-08-11T14:53:43Z
+  , cardano-haskell-packages 2026-09-03T10:20:53Z
 
 packages:
     cardano-api

--- a/cardano-api/cardano-api.cabal
+++ b/cardano-api/cardano-api.cabal
@@ -178,7 +178,7 @@ library
     network-mux,
     nothunks,
     ordered-containers,
-    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=4.1,
+    ouroboros-consensus:{cardano, diffusion, ouroboros-consensus, protocol} ^>=4.2.1.0,
     ouroboros-network:{api, framework, ouroboros-network, protocols} ^>=1.2,
     parsec,
     plutus-core ^>=1.65,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1786489982,
-        "narHash": "sha256-T0r6CvdSEDxszlb7uK7mxEVZcCtFNbk8tlr8B1bRKqM=",
+        "lastModified": 1788439818,
+        "narHash": "sha256-+sjKSr1tFhiLrxhplOOToCjXMyWZV4ZbvYOdkqwHzBg=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "13d0f23cf6af9ea55194b91f6947c0a2aeb522d9",
+        "rev": "95889113a879bc92976bba48cf743bd78f99710f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION

# Context

https://github.com/IntersectMBO/cardano-cli/issues/1434 is caused by https://github.com/IntersectMBO/cardano-ledger/issues/6039 which has been solved by [ouroboros-consensus-4.2.1.0](https://chap.intersectmbo.org/package/ouroboros-consensus-4.2.1.0/). So this PR bumps to `ouroboros-consensus-4.2.1.0` and updates CHaP to include this fixed version.

# How to trust this PR

This is just a version update, so if there are no issues in the new version and CI compiles, it should be good.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
