### PR TITLE
cardano-rpc: Implement gRPC server reflection (grpc.reflection.v1 and v1alpha)

### DIFF
--- a/.changes/20260909_cardano_rpc_grpc_reflection.yml
+++ b/.changes/20260909_cardano_rpc_grpc_reflection.yml
@@ -1,0 +1,6 @@
+project: cardano-rpc
+pr: 1334
+kind:
+  - feature
+description: |
+  The cardano-rpc gRPC server now implements the gRPC Server Reflection Protocol (grpc.reflection.v1 and grpc.reflection.v1alpha), so tools such as grpcurl, Postman and buf can list and describe the server's available services and message schemas without needing local .proto files.

--- a/cardano-rpc/README.md
+++ b/cardano-rpc/README.md
@@ -49,6 +49,15 @@ Use a dedicated chain indexing service for those.
 |--------|--------|
 | [WatchTx](https://utxorpc.org/watch/spec/#watchservice) | ⬜ Not supported |
 
+## Other gRPC services
+
+Besides the UTxO RPC spec above, `cardano-rpc` implements the standard [gRPC Server Reflection Protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md), so tools such as `grpcurl` can list and describe the server's services without needing local `.proto` files.
+
+| Method | Status |
+|--------|--------|
+| [grpc.reflection.v1.ServerReflection/ServerReflectionInfo](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) | ✅ Supported |
+| [grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) | ✅ Supported |
+
 ## Building
 
 You need the following dependencies installed on your system:

--- a/cardano-rpc/cardano-rpc.cabal
+++ b/cardano-rpc/cardano-rpc.cabal
@@ -49,6 +49,8 @@ library
   exposed-modules:
     Cardano.Rpc.Client
     Cardano.Rpc.Proto.Api.Node
+    Cardano.Rpc.Proto.Api.Reflection.V1
+    Cardano.Rpc.Proto.Api.Reflection.V1alpha
     Cardano.Rpc.Proto.Api.UtxoRpc.Query
     Cardano.Rpc.Proto.Api.UtxoRpc.Submit
     Cardano.Rpc.Proto.Api.UtxoRpc.Sync
@@ -58,6 +60,8 @@ library
     Cardano.Rpc.Server.Internal.Error
     Cardano.Rpc.Server.Internal.Monad
     Cardano.Rpc.Server.Internal.Node
+    Cardano.Rpc.Server.Internal.Reflection
+    Cardano.Rpc.Server.Internal.Reflection.DescriptorTable
     Cardano.Rpc.Server.Internal.TimedCache
     Cardano.Rpc.Server.Internal.Tracing
     Cardano.Rpc.Server.Internal.UtxoRpc.Eval
@@ -96,7 +100,7 @@ library
     base,
     base16-bytestring,
     bytestring,
-    cardano-api >=11.5,
+    cardano-api >=11.7,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class,
@@ -147,6 +151,10 @@ library gen
   exposed-modules:
     Proto.Cardano.Rpc.Node
     Proto.Cardano.Rpc.Node_Fields
+    Proto.Grpc.Reflection.V1.Reflection
+    Proto.Grpc.Reflection.V1.Reflection_Fields
+    Proto.Grpc.Reflection.V1alpha.Reflection
+    Proto.Grpc.Reflection.V1alpha.Reflection_Fields
     Proto.Utxorpc.V1beta.Cardano.Cardano
     Proto.Utxorpc.V1beta.Cardano.Cardano_Fields
     Proto.Utxorpc.V1beta.Query.Query
@@ -200,6 +208,7 @@ test-suite cardano-rpc-test
     ouroboros-consensus,
     ouroboros-consensus:cardano,
     proto-lens,
+    proto-lens-protobuf-types,
     rio,
     scientific,
     sop-extras,
@@ -226,6 +235,8 @@ test-suite cardano-rpc-test
     Test.Cardano.Rpc.Pagination
     Test.Cardano.Rpc.Predicate
     Test.Cardano.Rpc.ProtocolParameters
+    Test.Cardano.Rpc.Reflection
+    Test.Cardano.Rpc.Reflection.DescriptorTable
     Test.Cardano.Rpc.Script
     Test.Cardano.Rpc.TxOutput
     Test.Cardano.Rpc.Type

--- a/cardano-rpc/gen/Proto/Grpc/Reflection/V1/Reflection.hs
+++ b/cardano-rpc/gen/Proto/Grpc/Reflection/V1/Reflection.hs
@@ -1,0 +1,2377 @@
+{- This file was auto-generated from grpc/reflection/v1/reflection.proto by the proto-lens-protoc program. -}
+{-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
+{-# OPTIONS_GHC -Wno-unused-imports#-}
+{-# OPTIONS_GHC -Wno-duplicate-exports#-}
+{-# OPTIONS_GHC -Wno-dodgy-exports#-}
+module Proto.Grpc.Reflection.V1.Reflection (
+        ServerReflection(..), ErrorResponse(), ExtensionNumberResponse(),
+        ExtensionRequest(), FileDescriptorResponse(),
+        ListServiceResponse(), ServerReflectionRequest(),
+        ServerReflectionRequest'MessageRequest(..),
+        _ServerReflectionRequest'FileByFilename,
+        _ServerReflectionRequest'FileContainingSymbol,
+        _ServerReflectionRequest'FileContainingExtension,
+        _ServerReflectionRequest'AllExtensionNumbersOfType,
+        _ServerReflectionRequest'ListServices, ServerReflectionResponse(),
+        ServerReflectionResponse'MessageResponse(..),
+        _ServerReflectionResponse'FileDescriptorResponse,
+        _ServerReflectionResponse'AllExtensionNumbersResponse,
+        _ServerReflectionResponse'ListServicesResponse,
+        _ServerReflectionResponse'ErrorResponse, ServiceResponse()
+    ) where
+import qualified Data.ProtoLens.Runtime.Control.DeepSeq as Control.DeepSeq
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Prism as Data.ProtoLens.Prism
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.errorCode' @:: Lens' ErrorResponse Data.Int.Int32@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.errorMessage' @:: Lens' ErrorResponse Data.Text.Text@ -}
+data ErrorResponse
+  = ErrorResponse'_constructor {_ErrorResponse'errorCode :: !Data.Int.Int32,
+                                _ErrorResponse'errorMessage :: !Data.Text.Text,
+                                _ErrorResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ErrorResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ErrorResponse "errorCode" Data.Int.Int32 where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ErrorResponse'errorCode
+           (\ x__ y__ -> x__ {_ErrorResponse'errorCode = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ErrorResponse "errorMessage" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ErrorResponse'errorMessage
+           (\ x__ y__ -> x__ {_ErrorResponse'errorMessage = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ErrorResponse where
+  messageName _ = Data.Text.pack "grpc.reflection.v1.ErrorResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\rErrorResponse\DC2\GS\n\
+      \\n\
+      \error_code\CAN\SOH \SOH(\ENQR\terrorCode\DC2#\n\
+      \\rerror_message\CAN\STX \SOH(\tR\ferrorMessage"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        errorCode__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_code"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"errorCode")) ::
+              Data.ProtoLens.FieldDescriptor ErrorResponse
+        errorMessage__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_message"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"errorMessage")) ::
+              Data.ProtoLens.FieldDescriptor ErrorResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, errorCode__field_descriptor),
+           (Data.ProtoLens.Tag 2, errorMessage__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ErrorResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ErrorResponse'_unknownFields = y__})
+  defMessage
+    = ErrorResponse'_constructor
+        {_ErrorResponse'errorCode = Data.ProtoLens.fieldDefault,
+         _ErrorResponse'errorMessage = Data.ProtoLens.fieldDefault,
+         _ErrorResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ErrorResponse -> Data.ProtoLens.Encoding.Bytes.Parser ErrorResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        8 -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (Prelude.fmap
+                                          Prelude.fromIntegral
+                                          Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                       "error_code"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"errorCode") y x)
+                        18
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "error_message"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"errorMessage") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ErrorResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v = Lens.Family2.view (Data.ProtoLens.Field.field @"errorCode") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                      ((Prelude..)
+                         Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral _v))
+             ((Data.Monoid.<>)
+                (let
+                   _v
+                     = Lens.Family2.view (Data.ProtoLens.Field.field @"errorMessage") _x
+                 in
+                   if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                         ((Prelude..)
+                            (\ bs
+                               -> (Data.Monoid.<>)
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                    (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Data.Text.Encoding.encodeUtf8 _v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ErrorResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ErrorResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ErrorResponse'errorCode x__)
+                (Control.DeepSeq.deepseq (_ErrorResponse'errorMessage x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.baseTypeName' @:: Lens' ExtensionNumberResponse Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.extensionNumber' @:: Lens' ExtensionNumberResponse [Data.Int.Int32]@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.vec'extensionNumber' @:: Lens' ExtensionNumberResponse (Data.Vector.Unboxed.Vector Data.Int.Int32)@ -}
+data ExtensionNumberResponse
+  = ExtensionNumberResponse'_constructor {_ExtensionNumberResponse'baseTypeName :: !Data.Text.Text,
+                                          _ExtensionNumberResponse'extensionNumber :: !(Data.Vector.Unboxed.Vector Data.Int.Int32),
+                                          _ExtensionNumberResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ExtensionNumberResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "baseTypeName" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'baseTypeName
+           (\ x__ y__ -> x__ {_ExtensionNumberResponse'baseTypeName = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "extensionNumber" [Data.Int.Int32] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'extensionNumber
+           (\ x__ y__
+              -> x__ {_ExtensionNumberResponse'extensionNumber = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "vec'extensionNumber" (Data.Vector.Unboxed.Vector Data.Int.Int32) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'extensionNumber
+           (\ x__ y__
+              -> x__ {_ExtensionNumberResponse'extensionNumber = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ExtensionNumberResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.ExtensionNumberResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\ETBExtensionNumberResponse\DC2$\n\
+      \\SObase_type_name\CAN\SOH \SOH(\tR\fbaseTypeName\DC2)\n\
+      \\DLEextension_number\CAN\STX \ETX(\ENQR\SIextensionNumber"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        baseTypeName__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "base_type_name"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"baseTypeName")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionNumberResponse
+        extensionNumber__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "extension_number"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Packed
+                 (Data.ProtoLens.Field.field @"extensionNumber")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionNumberResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, baseTypeName__field_descriptor),
+           (Data.ProtoLens.Tag 2, extensionNumber__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ExtensionNumberResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ExtensionNumberResponse'_unknownFields = y__})
+  defMessage
+    = ExtensionNumberResponse'_constructor
+        {_ExtensionNumberResponse'baseTypeName = Data.ProtoLens.fieldDefault,
+         _ExtensionNumberResponse'extensionNumber = Data.Vector.Generic.empty,
+         _ExtensionNumberResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ExtensionNumberResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector Data.ProtoLens.Encoding.Growing.RealWorld Data.Int.Int32
+             -> Data.ProtoLens.Encoding.Bytes.Parser ExtensionNumberResponse
+        loop x mutable'extensionNumber
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'extensionNumber <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'extensionNumber)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'extensionNumber")
+                              frozen'extensionNumber x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "base_type_name"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"baseTypeName") y x)
+                                  mutable'extensionNumber
+                        16
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (Prelude.fmap
+                                           Prelude.fromIntegral
+                                           Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                        "extension_number"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append
+                                          mutable'extensionNumber y)
+                                loop x v
+                        18
+                          -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        Data.ProtoLens.Encoding.Bytes.isolate
+                                          (Prelude.fromIntegral len)
+                                          ((let
+                                              ploop qs
+                                                = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                     if packedEnd then
+                                                         Prelude.return qs
+                                                     else
+                                                         do !q <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                                                    (Prelude.fmap
+                                                                       Prelude.fromIntegral
+                                                                       Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                    "extension_number"
+                                                            qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                     (Data.ProtoLens.Encoding.Growing.append
+                                                                        qs q)
+                                                            ploop qs'
+                                            in ploop)
+                                             mutable'extensionNumber)
+                                loop x y
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'extensionNumber
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'extensionNumber <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                           Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'extensionNumber)
+          "ExtensionNumberResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v
+                  = Lens.Family2.view (Data.ProtoLens.Field.field @"baseTypeName") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (let
+                   p = Lens.Family2.view
+                         (Data.ProtoLens.Field.field @"vec'extensionNumber") _x
+                 in
+                   if Data.Vector.Generic.null p then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                         ((\ bs
+                             -> (Data.Monoid.<>)
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                     (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            (Data.ProtoLens.Encoding.Bytes.runBuilder
+                               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                  ((Prelude..)
+                                     Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral)
+                                  p))))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ExtensionNumberResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ExtensionNumberResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ExtensionNumberResponse'baseTypeName x__)
+                (Control.DeepSeq.deepseq
+                   (_ExtensionNumberResponse'extensionNumber x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.containingType' @:: Lens' ExtensionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.extensionNumber' @:: Lens' ExtensionRequest Data.Int.Int32@ -}
+data ExtensionRequest
+  = ExtensionRequest'_constructor {_ExtensionRequest'containingType :: !Data.Text.Text,
+                                   _ExtensionRequest'extensionNumber :: !Data.Int.Int32,
+                                   _ExtensionRequest'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ExtensionRequest where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ExtensionRequest "containingType" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionRequest'containingType
+           (\ x__ y__ -> x__ {_ExtensionRequest'containingType = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ExtensionRequest "extensionNumber" Data.Int.Int32 where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionRequest'extensionNumber
+           (\ x__ y__ -> x__ {_ExtensionRequest'extensionNumber = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ExtensionRequest where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.ExtensionRequest"
+  packedMessageDescriptor _
+    = "\n\
+      \\DLEExtensionRequest\DC2'\n\
+      \\SIcontaining_type\CAN\SOH \SOH(\tR\SOcontainingType\DC2)\n\
+      \\DLEextension_number\CAN\STX \SOH(\ENQR\SIextensionNumber"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        containingType__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "containing_type"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"containingType")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionRequest
+        extensionNumber__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "extension_number"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"extensionNumber")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionRequest
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, containingType__field_descriptor),
+           (Data.ProtoLens.Tag 2, extensionNumber__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ExtensionRequest'_unknownFields
+        (\ x__ y__ -> x__ {_ExtensionRequest'_unknownFields = y__})
+  defMessage
+    = ExtensionRequest'_constructor
+        {_ExtensionRequest'containingType = Data.ProtoLens.fieldDefault,
+         _ExtensionRequest'extensionNumber = Data.ProtoLens.fieldDefault,
+         _ExtensionRequest'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ExtensionRequest
+          -> Data.ProtoLens.Encoding.Bytes.Parser ExtensionRequest
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "containing_type"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"containingType") y x)
+                        16
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (Prelude.fmap
+                                          Prelude.fromIntegral
+                                          Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                       "extension_number"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"extensionNumber") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ExtensionRequest"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v
+                  = Lens.Family2.view
+                      (Data.ProtoLens.Field.field @"containingType") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (let
+                   _v
+                     = Lens.Family2.view
+                         (Data.ProtoLens.Field.field @"extensionNumber") _x
+                 in
+                   if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                         ((Prelude..)
+                            Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral _v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ExtensionRequest where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ExtensionRequest'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ExtensionRequest'containingType x__)
+                (Control.DeepSeq.deepseq
+                   (_ExtensionRequest'extensionNumber x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.fileDescriptorProto' @:: Lens' FileDescriptorResponse [Data.ByteString.ByteString]@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.vec'fileDescriptorProto' @:: Lens' FileDescriptorResponse (Data.Vector.Vector Data.ByteString.ByteString)@ -}
+data FileDescriptorResponse
+  = FileDescriptorResponse'_constructor {_FileDescriptorResponse'fileDescriptorProto :: !(Data.Vector.Vector Data.ByteString.ByteString),
+                                         _FileDescriptorResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FileDescriptorResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField FileDescriptorResponse "fileDescriptorProto" [Data.ByteString.ByteString] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FileDescriptorResponse'fileDescriptorProto
+           (\ x__ y__
+              -> x__ {_FileDescriptorResponse'fileDescriptorProto = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField FileDescriptorResponse "vec'fileDescriptorProto" (Data.Vector.Vector Data.ByteString.ByteString) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FileDescriptorResponse'fileDescriptorProto
+           (\ x__ y__
+              -> x__ {_FileDescriptorResponse'fileDescriptorProto = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message FileDescriptorResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.FileDescriptorResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\SYNFileDescriptorResponse\DC22\n\
+      \\NAKfile_descriptor_proto\CAN\SOH \ETX(\fR\DC3fileDescriptorProto"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        fileDescriptorProto__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_descriptor_proto"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.BytesField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.ByteString.ByteString)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Unpacked
+                 (Data.ProtoLens.Field.field @"fileDescriptorProto")) ::
+              Data.ProtoLens.FieldDescriptor FileDescriptorResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, fileDescriptorProto__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _FileDescriptorResponse'_unknownFields
+        (\ x__ y__ -> x__ {_FileDescriptorResponse'_unknownFields = y__})
+  defMessage
+    = FileDescriptorResponse'_constructor
+        {_FileDescriptorResponse'fileDescriptorProto = Data.Vector.Generic.empty,
+         _FileDescriptorResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          FileDescriptorResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector Data.ProtoLens.Encoding.Growing.RealWorld Data.ByteString.ByteString
+             -> Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorResponse
+        loop x mutable'fileDescriptorProto
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'fileDescriptorProto <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                      (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                         mutable'fileDescriptorProto)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'fileDescriptorProto")
+                              frozen'fileDescriptorProto x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                            Data.ProtoLens.Encoding.Bytes.getBytes
+                                              (Prelude.fromIntegral len))
+                                        "file_descriptor_proto"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append
+                                          mutable'fileDescriptorProto y)
+                                loop x v
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'fileDescriptorProto
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'fileDescriptorProto <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                               Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'fileDescriptorProto)
+          "FileDescriptorResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                (\ _v
+                   -> (Data.Monoid.<>)
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                        ((\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           _v))
+                (Lens.Family2.view
+                   (Data.ProtoLens.Field.field @"vec'fileDescriptorProto") _x))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData FileDescriptorResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_FileDescriptorResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_FileDescriptorResponse'fileDescriptorProto x__) ())
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.service' @:: Lens' ListServiceResponse [ServiceResponse]@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.vec'service' @:: Lens' ListServiceResponse (Data.Vector.Vector ServiceResponse)@ -}
+data ListServiceResponse
+  = ListServiceResponse'_constructor {_ListServiceResponse'service :: !(Data.Vector.Vector ServiceResponse),
+                                      _ListServiceResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ListServiceResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ListServiceResponse "service" [ServiceResponse] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ListServiceResponse'service
+           (\ x__ y__ -> x__ {_ListServiceResponse'service = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField ListServiceResponse "vec'service" (Data.Vector.Vector ServiceResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ListServiceResponse'service
+           (\ x__ y__ -> x__ {_ListServiceResponse'service = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ListServiceResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.ListServiceResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\DC3ListServiceResponse\DC2=\n\
+      \\aservice\CAN\SOH \ETX(\v2#.grpc.reflection.v1.ServiceResponseR\aservice"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        service__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "service"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ServiceResponse)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Unpacked (Data.ProtoLens.Field.field @"service")) ::
+              Data.ProtoLens.FieldDescriptor ListServiceResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, service__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ListServiceResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ListServiceResponse'_unknownFields = y__})
+  defMessage
+    = ListServiceResponse'_constructor
+        {_ListServiceResponse'service = Data.Vector.Generic.empty,
+         _ListServiceResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ListServiceResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector Data.ProtoLens.Encoding.Growing.RealWorld ServiceResponse
+             -> Data.ProtoLens.Encoding.Bytes.Parser ListServiceResponse
+        loop x mutable'service
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                          (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                             mutable'service)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'service") frozen'service x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                            Data.ProtoLens.Encoding.Bytes.isolate
+                                              (Prelude.fromIntegral len)
+                                              Data.ProtoLens.parseMessage)
+                                        "service"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append mutable'service y)
+                                loop x v
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'service
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                   Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'service)
+          "ListServiceResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                (\ _v
+                   -> (Data.Monoid.<>)
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                        ((Prelude..)
+                           (\ bs
+                              -> (Data.Monoid.<>)
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Data.ProtoLens.encodeMessage _v))
+                (Lens.Family2.view (Data.ProtoLens.Field.field @"vec'service") _x))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData ListServiceResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ListServiceResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq (_ListServiceResponse'service x__) ())
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.host' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'messageRequest' @:: Lens' ServerReflectionRequest (Prelude.Maybe ServerReflectionRequest'MessageRequest)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'fileByFilename' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.fileByFilename' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'fileContainingSymbol' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.fileContainingSymbol' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'fileContainingExtension' @:: Lens' ServerReflectionRequest (Prelude.Maybe ExtensionRequest)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.fileContainingExtension' @:: Lens' ServerReflectionRequest ExtensionRequest@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'allExtensionNumbersOfType' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.allExtensionNumbersOfType' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'listServices' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.listServices' @:: Lens' ServerReflectionRequest Data.Text.Text@ -}
+data ServerReflectionRequest
+  = ServerReflectionRequest'_constructor {_ServerReflectionRequest'host :: !Data.Text.Text,
+                                          _ServerReflectionRequest'messageRequest :: !(Prelude.Maybe ServerReflectionRequest'MessageRequest),
+                                          _ServerReflectionRequest'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServerReflectionRequest where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+data ServerReflectionRequest'MessageRequest
+  = ServerReflectionRequest'FileByFilename !Data.Text.Text |
+    ServerReflectionRequest'FileContainingSymbol !Data.Text.Text |
+    ServerReflectionRequest'FileContainingExtension !ExtensionRequest |
+    ServerReflectionRequest'AllExtensionNumbersOfType !Data.Text.Text |
+    ServerReflectionRequest'ListServices !Data.Text.Text
+  deriving stock (Prelude.Show, Prelude.Eq, Prelude.Ord)
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "host" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'host
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'host = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'messageRequest" (Prelude.Maybe ServerReflectionRequest'MessageRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileByFilename" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileByFilename x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionRequest'FileByFilename y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileByFilename" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileByFilename x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionRequest'FileByFilename y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileContainingSymbol" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileContainingSymbol x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionRequest'FileContainingSymbol y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileContainingSymbol" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileContainingSymbol x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionRequest'FileContainingSymbol y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileContainingExtension" (Prelude.Maybe ExtensionRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileContainingExtension x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionRequest'FileContainingExtension y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileContainingExtension" ExtensionRequest where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileContainingExtension x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionRequest'FileContainingExtension y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'allExtensionNumbersOfType" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionRequest'AllExtensionNumbersOfType y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "allExtensionNumbersOfType" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionRequest'AllExtensionNumbersOfType y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'listServices" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'ListServices x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__ -> Prelude.fmap ServerReflectionRequest'ListServices y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "listServices" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'ListServices x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__ -> Prelude.fmap ServerReflectionRequest'ListServices y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Message ServerReflectionRequest where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.ServerReflectionRequest"
+  packedMessageDescriptor _
+    = "\n\
+      \\ETBServerReflectionRequest\DC2\DC2\n\
+      \\EOThost\CAN\SOH \SOH(\tR\EOThost\DC2*\n\
+      \\DLEfile_by_filename\CAN\ETX \SOH(\tH\NULR\SOfileByFilename\DC26\n\
+      \\SYNfile_containing_symbol\CAN\EOT \SOH(\tH\NULR\DC4fileContainingSymbol\DC2b\n\
+      \\EMfile_containing_extension\CAN\ENQ \SOH(\v2$.grpc.reflection.v1.ExtensionRequestH\NULR\ETBfileContainingExtension\DC2B\n\
+      \\GSall_extension_numbers_of_type\CAN\ACK \SOH(\tH\NULR\EMallExtensionNumbersOfType\DC2%\n\
+      \\rlist_services\CAN\a \SOH(\tH\NULR\flistServicesB\DC1\n\
+      \\SImessage_request"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        host__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "host"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"host")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileByFilename__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_by_filename"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileByFilename")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileContainingSymbol__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_containing_symbol"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileContainingSymbol")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileContainingExtension__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_containing_extension"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ExtensionRequest)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileContainingExtension")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        allExtensionNumbersOfType__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "all_extension_numbers_of_type"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'allExtensionNumbersOfType")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        listServices__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "list_services"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'listServices")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, host__field_descriptor),
+           (Data.ProtoLens.Tag 3, fileByFilename__field_descriptor),
+           (Data.ProtoLens.Tag 4, fileContainingSymbol__field_descriptor),
+           (Data.ProtoLens.Tag 5, fileContainingExtension__field_descriptor),
+           (Data.ProtoLens.Tag 6, 
+            allExtensionNumbersOfType__field_descriptor),
+           (Data.ProtoLens.Tag 7, listServices__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServerReflectionRequest'_unknownFields
+        (\ x__ y__ -> x__ {_ServerReflectionRequest'_unknownFields = y__})
+  defMessage
+    = ServerReflectionRequest'_constructor
+        {_ServerReflectionRequest'host = Data.ProtoLens.fieldDefault,
+         _ServerReflectionRequest'messageRequest = Prelude.Nothing,
+         _ServerReflectionRequest'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServerReflectionRequest
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServerReflectionRequest
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "host"
+                                loop (Lens.Family2.set (Data.ProtoLens.Field.field @"host") y x)
+                        26
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "file_by_filename"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileByFilename") y x)
+                        34
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "file_containing_symbol"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileContainingSymbol") y x)
+                        42
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "file_containing_extension"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileContainingExtension") y x)
+                        50
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "all_extension_numbers_of_type"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"allExtensionNumbersOfType") y x)
+                        58
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "list_services"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"listServices") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServerReflectionRequest"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let _v = Lens.Family2.view (Data.ProtoLens.Field.field @"host") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (case
+                     Lens.Family2.view
+                       (Data.ProtoLens.Field.field @"maybe'messageRequest") _x
+                 of
+                   Prelude.Nothing -> Data.Monoid.mempty
+                   (Prelude.Just (ServerReflectionRequest'FileByFilename v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'FileContainingSymbol v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'FileContainingExtension v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 42)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.ProtoLens.encodeMessage v)
+                   (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'ListServices v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ServerReflectionRequest where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServerReflectionRequest'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ServerReflectionRequest'host x__)
+                (Control.DeepSeq.deepseq
+                   (_ServerReflectionRequest'messageRequest x__) ()))
+instance Control.DeepSeq.NFData ServerReflectionRequest'MessageRequest where
+  rnf (ServerReflectionRequest'FileByFilename x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'FileContainingSymbol x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'FileContainingExtension x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'AllExtensionNumbersOfType x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'ListServices x__)
+    = Control.DeepSeq.rnf x__
+_ServerReflectionRequest'FileByFilename ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'FileByFilename
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileByFilename
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileByFilename p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'FileContainingSymbol ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'FileContainingSymbol
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileContainingSymbol
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileContainingSymbol p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'FileContainingExtension ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest ExtensionRequest
+_ServerReflectionRequest'FileContainingExtension
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileContainingExtension
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileContainingExtension p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'AllExtensionNumbersOfType ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'AllExtensionNumbersOfType
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'AllExtensionNumbersOfType
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'AllExtensionNumbersOfType p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'ListServices ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'ListServices
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'ListServices
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'ListServices p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.validHost' @:: Lens' ServerReflectionResponse Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.originalRequest' @:: Lens' ServerReflectionResponse ServerReflectionRequest@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'originalRequest' @:: Lens' ServerReflectionResponse (Prelude.Maybe ServerReflectionRequest)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'messageResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ServerReflectionResponse'MessageResponse)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'fileDescriptorResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe FileDescriptorResponse)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.fileDescriptorResponse' @:: Lens' ServerReflectionResponse FileDescriptorResponse@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'allExtensionNumbersResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ExtensionNumberResponse)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.allExtensionNumbersResponse' @:: Lens' ServerReflectionResponse ExtensionNumberResponse@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'listServicesResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ListServiceResponse)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.listServicesResponse' @:: Lens' ServerReflectionResponse ListServiceResponse@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.maybe'errorResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ErrorResponse)@
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.errorResponse' @:: Lens' ServerReflectionResponse ErrorResponse@ -}
+data ServerReflectionResponse
+  = ServerReflectionResponse'_constructor {_ServerReflectionResponse'validHost :: !Data.Text.Text,
+                                           _ServerReflectionResponse'originalRequest :: !(Prelude.Maybe ServerReflectionRequest),
+                                           _ServerReflectionResponse'messageResponse :: !(Prelude.Maybe ServerReflectionResponse'MessageResponse),
+                                           _ServerReflectionResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServerReflectionResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+data ServerReflectionResponse'MessageResponse
+  = ServerReflectionResponse'FileDescriptorResponse !FileDescriptorResponse |
+    ServerReflectionResponse'AllExtensionNumbersResponse !ExtensionNumberResponse |
+    ServerReflectionResponse'ListServicesResponse !ListServiceResponse |
+    ServerReflectionResponse'ErrorResponse !ErrorResponse
+  deriving stock (Prelude.Show, Prelude.Eq, Prelude.Ord)
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "validHost" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'validHost
+           (\ x__ y__ -> x__ {_ServerReflectionResponse'validHost = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "originalRequest" ServerReflectionRequest where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'originalRequest
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'originalRequest = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'originalRequest" (Prelude.Maybe ServerReflectionRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'originalRequest
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'originalRequest = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'messageResponse" (Prelude.Maybe ServerReflectionResponse'MessageResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'fileDescriptorResponse" (Prelude.Maybe FileDescriptorResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionResponse'FileDescriptorResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "fileDescriptorResponse" FileDescriptorResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionResponse'FileDescriptorResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'allExtensionNumbersResponse" (Prelude.Maybe ExtensionNumberResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionResponse'AllExtensionNumbersResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "allExtensionNumbersResponse" ExtensionNumberResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionResponse'AllExtensionNumbersResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'listServicesResponse" (Prelude.Maybe ListServiceResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'ListServicesResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionResponse'ListServicesResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "listServicesResponse" ListServiceResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'ListServicesResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionResponse'ListServicesResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'errorResponse" (Prelude.Maybe ErrorResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'ErrorResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionResponse'ErrorResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "errorResponse" ErrorResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'ErrorResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionResponse'ErrorResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Message ServerReflectionResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1.ServerReflectionResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\CANServerReflectionResponse\DC2\GS\n\
+      \\n\
+      \valid_host\CAN\SOH \SOH(\tR\tvalidHost\DC2V\n\
+      \\DLEoriginal_request\CAN\STX \SOH(\v2+.grpc.reflection.v1.ServerReflectionRequestR\SIoriginalRequest\DC2f\n\
+      \\CANfile_descriptor_response\CAN\EOT \SOH(\v2*.grpc.reflection.v1.FileDescriptorResponseH\NULR\SYNfileDescriptorResponse\DC2r\n\
+      \\RSall_extension_numbers_response\CAN\ENQ \SOH(\v2+.grpc.reflection.v1.ExtensionNumberResponseH\NULR\ESCallExtensionNumbersResponse\DC2_\n\
+      \\SYNlist_services_response\CAN\ACK \SOH(\v2'.grpc.reflection.v1.ListServiceResponseH\NULR\DC4listServicesResponse\DC2J\n\
+      \\SOerror_response\CAN\a \SOH(\v2!.grpc.reflection.v1.ErrorResponseH\NULR\rerrorResponseB\DC2\n\
+      \\DLEmessage_response"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        validHost__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "valid_host"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"validHost")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        originalRequest__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "original_request"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ServerReflectionRequest)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'originalRequest")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        fileDescriptorResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_descriptor_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor FileDescriptorResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileDescriptorResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        allExtensionNumbersResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "all_extension_numbers_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ExtensionNumberResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field
+                    @"maybe'allExtensionNumbersResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        listServicesResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "list_services_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ListServiceResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'listServicesResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        errorResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ErrorResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'errorResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, validHost__field_descriptor),
+           (Data.ProtoLens.Tag 2, originalRequest__field_descriptor),
+           (Data.ProtoLens.Tag 4, fileDescriptorResponse__field_descriptor),
+           (Data.ProtoLens.Tag 5, 
+            allExtensionNumbersResponse__field_descriptor),
+           (Data.ProtoLens.Tag 6, listServicesResponse__field_descriptor),
+           (Data.ProtoLens.Tag 7, errorResponse__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServerReflectionResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ServerReflectionResponse'_unknownFields = y__})
+  defMessage
+    = ServerReflectionResponse'_constructor
+        {_ServerReflectionResponse'validHost = Data.ProtoLens.fieldDefault,
+         _ServerReflectionResponse'originalRequest = Prelude.Nothing,
+         _ServerReflectionResponse'messageResponse = Prelude.Nothing,
+         _ServerReflectionResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServerReflectionResponse
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServerReflectionResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "valid_host"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"validHost") y x)
+                        18
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "original_request"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"originalRequest") y x)
+                        34
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "file_descriptor_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileDescriptorResponse") y x)
+                        42
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "all_extension_numbers_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"allExtensionNumbersResponse") y
+                                     x)
+                        50
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "list_services_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"listServicesResponse") y x)
+                        58
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "error_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"errorResponse") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServerReflectionResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v = Lens.Family2.view (Data.ProtoLens.Field.field @"validHost") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (case
+                     Lens.Family2.view
+                       (Data.ProtoLens.Field.field @"maybe'originalRequest") _x
+                 of
+                   Prelude.Nothing -> Data.Monoid.mempty
+                   (Prelude.Just _v)
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.ProtoLens.encodeMessage _v))
+                ((Data.Monoid.<>)
+                   (case
+                        Lens.Family2.view
+                          (Data.ProtoLens.Field.field @"maybe'messageResponse") _x
+                    of
+                      Prelude.Nothing -> Data.Monoid.mempty
+                      (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 42)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'ListServicesResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'ErrorResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v))
+                   (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))))
+instance Control.DeepSeq.NFData ServerReflectionResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServerReflectionResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ServerReflectionResponse'validHost x__)
+                (Control.DeepSeq.deepseq
+                   (_ServerReflectionResponse'originalRequest x__)
+                   (Control.DeepSeq.deepseq
+                      (_ServerReflectionResponse'messageResponse x__) ())))
+instance Control.DeepSeq.NFData ServerReflectionResponse'MessageResponse where
+  rnf (ServerReflectionResponse'FileDescriptorResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'AllExtensionNumbersResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'ListServicesResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'ErrorResponse x__)
+    = Control.DeepSeq.rnf x__
+_ServerReflectionResponse'FileDescriptorResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse FileDescriptorResponse
+_ServerReflectionResponse'FileDescriptorResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'FileDescriptorResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'FileDescriptorResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'AllExtensionNumbersResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ExtensionNumberResponse
+_ServerReflectionResponse'AllExtensionNumbersResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'AllExtensionNumbersResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'AllExtensionNumbersResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'ListServicesResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ListServiceResponse
+_ServerReflectionResponse'ListServicesResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'ListServicesResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'ListServicesResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'ErrorResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ErrorResponse
+_ServerReflectionResponse'ErrorResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'ErrorResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'ErrorResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1.Reflection_Fields.name' @:: Lens' ServiceResponse Data.Text.Text@ -}
+data ServiceResponse
+  = ServiceResponse'_constructor {_ServiceResponse'name :: !Data.Text.Text,
+                                  _ServiceResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServiceResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ServiceResponse "name" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServiceResponse'name
+           (\ x__ y__ -> x__ {_ServiceResponse'name = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ServiceResponse where
+  messageName _ = Data.Text.pack "grpc.reflection.v1.ServiceResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\SIServiceResponse\DC2\DC2\n\
+      \\EOTname\CAN\SOH \SOH(\tR\EOTname"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        name__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "name"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"name")) ::
+              Data.ProtoLens.FieldDescriptor ServiceResponse
+      in
+        Data.Map.fromList [(Data.ProtoLens.Tag 1, name__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServiceResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ServiceResponse'_unknownFields = y__})
+  defMessage
+    = ServiceResponse'_constructor
+        {_ServiceResponse'name = Data.ProtoLens.fieldDefault,
+         _ServiceResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServiceResponse
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServiceResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "name"
+                                loop (Lens.Family2.set (Data.ProtoLens.Field.field @"name") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServiceResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let _v = Lens.Family2.view (Data.ProtoLens.Field.field @"name") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData ServiceResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServiceResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq (_ServiceResponse'name x__) ())
+data ServerReflection = ServerReflection {}
+instance Data.ProtoLens.Service.Types.Service ServerReflection where
+  type ServiceName ServerReflection = "ServerReflection"
+  type ServicePackage ServerReflection = "grpc.reflection.v1"
+  type ServiceMethods ServerReflection = '["serverReflectionInfo"]
+  packedServiceDescriptor _
+    = "\n\
+      \\DLEServerReflection\DC2u\n\
+      \\DC4ServerReflectionInfo\DC2+.grpc.reflection.v1.ServerReflectionRequest\SUB,.grpc.reflection.v1.ServerReflectionResponse(\SOH0\SOH"
+instance Data.ProtoLens.Service.Types.HasMethodImpl ServerReflection "serverReflectionInfo" where
+  type MethodName ServerReflection "serverReflectionInfo" = "ServerReflectionInfo"
+  type MethodInput ServerReflection "serverReflectionInfo" = ServerReflectionRequest
+  type MethodOutput ServerReflection "serverReflectionInfo" = ServerReflectionResponse
+  type MethodStreamingType ServerReflection "serverReflectionInfo" = 'Data.ProtoLens.Service.Types.BiDiStreaming
+packedFileDescriptor :: Data.ByteString.ByteString
+packedFileDescriptor
+  = "\n\
+    \#grpc/reflection/v1/reflection.proto\DC2\DC2grpc.reflection.v1\"\243\STX\n\
+    \\ETBServerReflectionRequest\DC2\DC2\n\
+    \\EOThost\CAN\SOH \SOH(\tR\EOThost\DC2*\n\
+    \\DLEfile_by_filename\CAN\ETX \SOH(\tH\NULR\SOfileByFilename\DC26\n\
+    \\SYNfile_containing_symbol\CAN\EOT \SOH(\tH\NULR\DC4fileContainingSymbol\DC2b\n\
+    \\EMfile_containing_extension\CAN\ENQ \SOH(\v2$.grpc.reflection.v1.ExtensionRequestH\NULR\ETBfileContainingExtension\DC2B\n\
+    \\GSall_extension_numbers_of_type\CAN\ACK \SOH(\tH\NULR\EMallExtensionNumbersOfType\DC2%\n\
+    \\rlist_services\CAN\a \SOH(\tH\NULR\flistServicesB\DC1\n\
+    \\SImessage_request\"f\n\
+    \\DLEExtensionRequest\DC2'\n\
+    \\SIcontaining_type\CAN\SOH \SOH(\tR\SOcontainingType\DC2)\n\
+    \\DLEextension_number\CAN\STX \SOH(\ENQR\SIextensionNumber\"\174\EOT\n\
+    \\CANServerReflectionResponse\DC2\GS\n\
+    \\n\
+    \valid_host\CAN\SOH \SOH(\tR\tvalidHost\DC2V\n\
+    \\DLEoriginal_request\CAN\STX \SOH(\v2+.grpc.reflection.v1.ServerReflectionRequestR\SIoriginalRequest\DC2f\n\
+    \\CANfile_descriptor_response\CAN\EOT \SOH(\v2*.grpc.reflection.v1.FileDescriptorResponseH\NULR\SYNfileDescriptorResponse\DC2r\n\
+    \\RSall_extension_numbers_response\CAN\ENQ \SOH(\v2+.grpc.reflection.v1.ExtensionNumberResponseH\NULR\ESCallExtensionNumbersResponse\DC2_\n\
+    \\SYNlist_services_response\CAN\ACK \SOH(\v2'.grpc.reflection.v1.ListServiceResponseH\NULR\DC4listServicesResponse\DC2J\n\
+    \\SOerror_response\CAN\a \SOH(\v2!.grpc.reflection.v1.ErrorResponseH\NULR\rerrorResponseB\DC2\n\
+    \\DLEmessage_response\"L\n\
+    \\SYNFileDescriptorResponse\DC22\n\
+    \\NAKfile_descriptor_proto\CAN\SOH \ETX(\fR\DC3fileDescriptorProto\"j\n\
+    \\ETBExtensionNumberResponse\DC2$\n\
+    \\SObase_type_name\CAN\SOH \SOH(\tR\fbaseTypeName\DC2)\n\
+    \\DLEextension_number\CAN\STX \ETX(\ENQR\SIextensionNumber\"T\n\
+    \\DC3ListServiceResponse\DC2=\n\
+    \\aservice\CAN\SOH \ETX(\v2#.grpc.reflection.v1.ServiceResponseR\aservice\"%\n\
+    \\SIServiceResponse\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\"S\n\
+    \\rErrorResponse\DC2\GS\n\
+    \\n\
+    \error_code\CAN\SOH \SOH(\ENQR\terrorCode\DC2#\n\
+    \\rerror_message\CAN\STX \SOH(\tR\ferrorMessage2\137\SOH\n\
+    \\DLEServerReflection\DC2u\n\
+    \\DC4ServerReflectionInfo\DC2+.grpc.reflection.v1.ServerReflectionRequest\SUB,.grpc.reflection.v1.ServerReflectionResponse(\SOH0\SOHB\201\SOH\n\
+    \\SYNcom.grpc.reflection.v1B\SIReflectionProtoP\SOHZ4google.golang.org/grpc/reflection/grpc_reflection_v1\162\STX\ETXGRX\170\STX\DC2Grpc.Reflection.V1\202\STX\DC2Grpc\\Reflection\\V1\226\STX\RSGrpc\\Reflection\\V1\\GPBMetadata\234\STX\DC4Grpc::Reflection::V1J\231-\n\
+    \\a\DC2\ENQ\NAK\NUL\145\SOH\SOH\n\
+    \\135\a\n\
+    \\SOH\f\DC2\ETX\NAK\NUL\DC22\183\EOT Copyright 2016 The gRPC Authors\n\
+    \\n\
+    \ Licensed under the Apache License, Version 2.0 (the \"License\");\n\
+    \ you may not use this file except in compliance with the License.\n\
+    \ You may obtain a copy of the License at\n\
+    \\n\
+    \     http://www.apache.org/licenses/LICENSE-2.0\n\
+    \\n\
+    \ Unless required by applicable law or agreed to in writing, software\n\
+    \ distributed under the License is distributed on an \"AS IS\" BASIS,\n\
+    \ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+    \ See the License for the specific language governing permissions and\n\
+    \ limitations under the License.\n\
+    \2\194\STX Service exported by server reflection.  A more complete description of how\n\
+    \ server reflection works can be found at\n\
+    \ https://github.com/grpc/grpc/blob/master/doc/server-reflection.md\n\
+    \\n\
+    \ The canonical version of this proto can be found at\n\
+    \ https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto\n\
+    \\n\
+    \\b\n\
+    \\SOH\STX\DC2\ETX\ETB\NUL\ESC\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX\EM\NULK\n\
+    \\t\n\
+    \\STX\b\v\DC2\ETX\EM\NULK\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX\SUB\NUL\"\n\
+    \\t\n\
+    \\STX\b\n\
+    \\DC2\ETX\SUB\NUL\"\n\
+    \\n\
+    \\n\
+    \\STX\ACK\NUL\DC2\EOT\RS\NUL#\SOH\n\
+    \\n\
+    \\n\
+    \\ETX\ACK\NUL\SOH\DC2\ETX\RS\b\CAN\n\
+    \\133\SOH\n\
+    \\EOT\ACK\NUL\STX\NUL\DC2\EOT!\STX\"0\SUBw The reflection service is structured as a bidirectional stream, ensuring\n\
+    \ all related requests go to a single server.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\SOH\DC2\ETX!\ACK\SUB\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ENQ\DC2\ETX!\ESC!\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\STX\DC2\ETX!\"9\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ACK\DC2\ETX\"\SI\NAK\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ETX\DC2\ETX\"\SYN.\n\
+    \V\n\
+    \\STX\EOT\NUL\DC2\EOT&\NULF\SOH\SUBJ The message sent by the client when calling ServerReflectionInfo method.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX&\b\US\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX'\STX\DC2\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ENQ\DC2\ETX'\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX'\t\r\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX'\DLE\DC1\n\
+    \\223\SOH\n\
+    \\EOT\EOT\NUL\b\NUL\DC2\EOT+\STXE\ETX\SUB\208\SOH To use reflection service, the client should set one of the following\n\
+    \ fields in message_request. The server distinguishes requests by their\n\
+    \ defined field and then handles them using corresponding methods.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\b\NUL\SOH\DC2\ETX+\b\ETB\n\
+    \2\n\
+    \\EOT\EOT\NUL\STX\SOH\DC2\ETX-\EOT \SUB% Find a proto file by the file name.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ENQ\DC2\ETX-\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\SOH\DC2\ETX-\v\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ETX\DC2\ETX-\RS\US\n\
+    \\200\SOH\n\
+    \\EOT\EOT\NUL\STX\STX\DC2\ETX2\EOT&\SUB\186\SOH Find the proto file that declares the given fully-qualified symbol name.\n\
+    \ This field should be a fully-qualified symbol name\n\
+    \ (e.g. <package>.<service>[.<method>] or <package>.<type>).\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ENQ\DC2\ETX2\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\SOH\DC2\ETX2\v!\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ETX\DC2\ETX2$%\n\
+    \|\n\
+    \\EOT\EOT\NUL\STX\ETX\DC2\ETX6\EOT3\SUBo Find the proto file which defines an extension extending the given\n\
+    \ message type with the given field number.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ACK\DC2\ETX6\EOT\DC4\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\SOH\DC2\ETX6\NAK.\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ETX\DC2\ETX612\n\
+    \\238\ETX\n\
+    \\EOT\EOT\NUL\STX\EOT\DC2\ETX@\EOT-\SUB\224\ETX Finds the tag numbers used by all known extensions of the given message\n\
+    \ type, and appends them to ExtensionNumberResponse in an undefined order.\n\
+    \ Its corresponding method is best-effort: it's not guaranteed that the\n\
+    \ reflection service will implement this method, and it's not guaranteed\n\
+    \ that this method will provide all extensions. Returns\n\
+    \ StatusCode::UNIMPLEMENTED if it's not implemented.\n\
+    \ This field should be a fully-qualified type name. The format is\n\
+    \ <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\ENQ\DC2\ETX@\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\SOH\DC2\ETX@\v(\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\ETX\DC2\ETX@+,\n\
+    \\\\n\
+    \\EOT\EOT\NUL\STX\ENQ\DC2\ETXD\EOT\GS\SUBO List the full names of registered services. The content will not be\n\
+    \ checked.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\ENQ\DC2\ETXD\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\SOH\DC2\ETXD\v\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\ETX\DC2\ETXD\ESC\FS\n\
+    \o\n\
+    \\STX\EOT\SOH\DC2\EOTJ\NULN\SOH\SUBc The type name and extension number sent by the client when requesting\n\
+    \ file_containing_extension.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETXJ\b\CAN\n\
+    \O\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETXL\STX\GS\SUBB Fully-qualified type name. The format should be <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETXL\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETXL\t\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETXL\ESC\FS\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETXM\STX\GS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETXM\STX\a\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETXM\b\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETXM\ESC\FS\n\
+    \S\n\
+    \\STX\EOT\STX\DC2\EOTQ\NULh\SOH\SUBG The message sent by the server to answer ServerReflectionInfo method.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\STX\SOH\DC2\ETXQ\b \n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETXR\STX\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETXR\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETXR\t\DC3\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETXR\SYN\ETB\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\ETXS\STX/\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\ETXS\STX\EM\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETXS\SUB*\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETXS-.\n\
+    \m\n\
+    \\EOT\EOT\STX\b\NUL\DC2\EOTV\STXg\ETX\SUB_ The server sets one of the following fields according to the message_request\n\
+    \ in the request.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\b\NUL\SOH\DC2\ETXV\b\CAN\n\
+    \\177\ETX\n\
+    \\EOT\EOT\STX\STX\STX\DC2\ETX]\EOT8\SUB\163\ETX This message is used to answer file_by_filename, file_containing_symbol,\n\
+    \ file_containing_extension requests with transitive dependencies.\n\
+    \ As the repeated label is not allowed in oneof fields, we use a\n\
+    \ FileDescriptorResponse message to encapsulate the repeated fields.\n\
+    \ The reflection service is allowed to avoid sending FileDescriptorProtos\n\
+    \ that were previously sent in response to earlier requests in the stream.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ACK\DC2\ETX]\EOT\SUB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\SOH\DC2\ETX]\ESC3\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETX]67\n\
+    \U\n\
+    \\EOT\EOT\STX\STX\ETX\DC2\ETX`\EOT?\SUBH This message is used to answer all_extension_numbers_of_type requests.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ACK\DC2\ETX`\EOT\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\SOH\DC2\ETX`\FS:\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ETX\DC2\ETX`=>\n\
+    \E\n\
+    \\EOT\EOT\STX\STX\EOT\DC2\ETXc\EOT3\SUB8 This message is used to answer list_services requests.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ACK\DC2\ETXc\EOT\ETB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\SOH\DC2\ETXc\CAN.\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ETX\DC2\ETXc12\n\
+    \9\n\
+    \\EOT\EOT\STX\STX\ENQ\DC2\ETXf\EOT%\SUB, This message is used when an error occurs.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ACK\DC2\ETXf\EOT\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\SOH\DC2\ETXf\DC2 \n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ETX\DC2\ETXf#$\n\
+    \\167\SOH\n\
+    \\STX\EOT\ETX\DC2\EOTm\NULr\SOH\SUB\154\SOH Serialized FileDescriptorProto messages sent by the server answering\n\
+    \ a file_by_filename, file_containing_symbol, or file_containing_extension\n\
+    \ request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ETX\SOH\DC2\ETXm\b\RS\n\
+    \\178\SOH\n\
+    \\EOT\EOT\ETX\STX\NUL\DC2\ETXq\STX+\SUB\164\SOH Serialized FileDescriptorProto messages. We avoid taking a dependency on\n\
+    \ descriptor.proto, which uses proto2 only features, by making them opaque\n\
+    \ bytes instead.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\EOT\DC2\ETXq\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\ENQ\DC2\ETXq\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\SOH\DC2\ETXq\DC1&\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\ETX\DC2\ETXq)*\n\
+    \n\n\
+    \\STX\EOT\EOT\DC2\EOTv\NUL{\SOH\SUBb A list of extension numbers sent by the server answering\n\
+    \ all_extension_numbers_of_type request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\EOT\SOH\DC2\ETXv\b\US\n\
+    \f\n\
+    \\EOT\EOT\EOT\STX\NUL\DC2\ETXy\STX\FS\SUBY Full name of the base type, including the package name. The format\n\
+    \ is <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\ETXy\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\ETXy\t\ETB\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\ETXy\SUB\ESC\n\
+    \\v\n\
+    \\EOT\EOT\EOT\STX\SOH\DC2\ETXz\STX&\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\EOT\DC2\ETXz\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\ENQ\DC2\ETXz\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\ETXz\DC1!\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\ETXz$%\n\
+    \\\\n\
+    \\STX\EOT\ENQ\DC2\ENQ~\NUL\130\SOH\SOH\SUBO A list of ServiceResponse sent by the server answering list_services request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ENQ\SOH\DC2\ETX~\b\ESC\n\
+    \\132\SOH\n\
+    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\129\SOH\STX'\SUBv The information of each service may be expanded in the future, so we use\n\
+    \ ServiceResponse message to encapsulate it.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\EOT\DC2\EOT\129\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ACK\DC2\EOT\129\SOH\v\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\129\SOH\ESC\"\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\129\SOH%&\n\
+    \q\n\
+    \\STX\EOT\ACK\DC2\ACK\134\SOH\NUL\138\SOH\SOH\SUBc The information of a single service used by ListServiceResponse to answer\n\
+    \ list_services request.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\ACK\SOH\DC2\EOT\134\SOH\b\ETB\n\
+    \q\n\
+    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\137\SOH\STX\DC2\SUBc Full name of a registered service, including its package name. The format\n\
+    \ is <package>.<service>\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\137\SOH\STX\b\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\137\SOH\t\r\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\137\SOH\DLE\DC1\n\
+    \Y\n\
+    \\STX\EOT\a\DC2\ACK\141\SOH\NUL\145\SOH\SOH\SUBK The error code and error message sent by the server when an error occurs.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\a\SOH\DC2\EOT\141\SOH\b\NAK\n\
+    \L\n\
+    \\EOT\EOT\a\STX\NUL\DC2\EOT\143\SOH\STX\ETB\SUB> This field uses the error codes defined in grpc::StatusCode.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\143\SOH\STX\a\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\143\SOH\b\DC2\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\143\SOH\NAK\SYN\n\
+    \\f\n\
+    \\EOT\EOT\a\STX\SOH\DC2\EOT\144\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\144\SOH\STX\b\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\144\SOH\t\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\144\SOH\EM\SUBb\ACKproto3"

--- a/cardano-rpc/gen/Proto/Grpc/Reflection/V1/Reflection_Fields.hs
+++ b/cardano-rpc/gen/Proto/Grpc/Reflection/V1/Reflection_Fields.hs
@@ -1,0 +1,257 @@
+{- This file was auto-generated from grpc/reflection/v1/reflection.proto by the proto-lens-protoc program. -}
+{-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
+{-# OPTIONS_GHC -Wno-unused-imports#-}
+{-# OPTIONS_GHC -Wno-duplicate-exports#-}
+{-# OPTIONS_GHC -Wno-dodgy-exports#-}
+module Proto.Grpc.Reflection.V1.Reflection_Fields where
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
+allExtensionNumbersOfType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "allExtensionNumbersOfType" a) =>
+  Lens.Family2.LensLike' f s a
+allExtensionNumbersOfType
+  = Data.ProtoLens.Field.field @"allExtensionNumbersOfType"
+allExtensionNumbersResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "allExtensionNumbersResponse" a) =>
+  Lens.Family2.LensLike' f s a
+allExtensionNumbersResponse
+  = Data.ProtoLens.Field.field @"allExtensionNumbersResponse"
+baseTypeName ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "baseTypeName" a) =>
+  Lens.Family2.LensLike' f s a
+baseTypeName = Data.ProtoLens.Field.field @"baseTypeName"
+containingType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "containingType" a) =>
+  Lens.Family2.LensLike' f s a
+containingType = Data.ProtoLens.Field.field @"containingType"
+errorCode ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorCode" a) =>
+  Lens.Family2.LensLike' f s a
+errorCode = Data.ProtoLens.Field.field @"errorCode"
+errorMessage ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorMessage" a) =>
+  Lens.Family2.LensLike' f s a
+errorMessage = Data.ProtoLens.Field.field @"errorMessage"
+errorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+errorResponse = Data.ProtoLens.Field.field @"errorResponse"
+extensionNumber ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "extensionNumber" a) =>
+  Lens.Family2.LensLike' f s a
+extensionNumber = Data.ProtoLens.Field.field @"extensionNumber"
+fileByFilename ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileByFilename" a) =>
+  Lens.Family2.LensLike' f s a
+fileByFilename = Data.ProtoLens.Field.field @"fileByFilename"
+fileContainingExtension ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileContainingExtension" a) =>
+  Lens.Family2.LensLike' f s a
+fileContainingExtension
+  = Data.ProtoLens.Field.field @"fileContainingExtension"
+fileContainingSymbol ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileContainingSymbol" a) =>
+  Lens.Family2.LensLike' f s a
+fileContainingSymbol
+  = Data.ProtoLens.Field.field @"fileContainingSymbol"
+fileDescriptorProto ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileDescriptorProto" a) =>
+  Lens.Family2.LensLike' f s a
+fileDescriptorProto
+  = Data.ProtoLens.Field.field @"fileDescriptorProto"
+fileDescriptorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileDescriptorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+fileDescriptorResponse
+  = Data.ProtoLens.Field.field @"fileDescriptorResponse"
+host ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "host" a) =>
+  Lens.Family2.LensLike' f s a
+host = Data.ProtoLens.Field.field @"host"
+listServices ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "listServices" a) =>
+  Lens.Family2.LensLike' f s a
+listServices = Data.ProtoLens.Field.field @"listServices"
+listServicesResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "listServicesResponse" a) =>
+  Lens.Family2.LensLike' f s a
+listServicesResponse
+  = Data.ProtoLens.Field.field @"listServicesResponse"
+maybe'allExtensionNumbersOfType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'allExtensionNumbersOfType" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'allExtensionNumbersOfType
+  = Data.ProtoLens.Field.field @"maybe'allExtensionNumbersOfType"
+maybe'allExtensionNumbersResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'allExtensionNumbersResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'allExtensionNumbersResponse
+  = Data.ProtoLens.Field.field @"maybe'allExtensionNumbersResponse"
+maybe'errorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'errorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'errorResponse
+  = Data.ProtoLens.Field.field @"maybe'errorResponse"
+maybe'fileByFilename ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileByFilename" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileByFilename
+  = Data.ProtoLens.Field.field @"maybe'fileByFilename"
+maybe'fileContainingExtension ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileContainingExtension" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileContainingExtension
+  = Data.ProtoLens.Field.field @"maybe'fileContainingExtension"
+maybe'fileContainingSymbol ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileContainingSymbol" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileContainingSymbol
+  = Data.ProtoLens.Field.field @"maybe'fileContainingSymbol"
+maybe'fileDescriptorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileDescriptorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileDescriptorResponse
+  = Data.ProtoLens.Field.field @"maybe'fileDescriptorResponse"
+maybe'listServices ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'listServices" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'listServices
+  = Data.ProtoLens.Field.field @"maybe'listServices"
+maybe'listServicesResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'listServicesResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'listServicesResponse
+  = Data.ProtoLens.Field.field @"maybe'listServicesResponse"
+maybe'messageRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'messageRequest" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'messageRequest
+  = Data.ProtoLens.Field.field @"maybe'messageRequest"
+maybe'messageResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'messageResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'messageResponse
+  = Data.ProtoLens.Field.field @"maybe'messageResponse"
+maybe'originalRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'originalRequest" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'originalRequest
+  = Data.ProtoLens.Field.field @"maybe'originalRequest"
+name ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "name" a) =>
+  Lens.Family2.LensLike' f s a
+name = Data.ProtoLens.Field.field @"name"
+originalRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "originalRequest" a) =>
+  Lens.Family2.LensLike' f s a
+originalRequest = Data.ProtoLens.Field.field @"originalRequest"
+service ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "service" a) =>
+  Lens.Family2.LensLike' f s a
+service = Data.ProtoLens.Field.field @"service"
+validHost ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "validHost" a) =>
+  Lens.Family2.LensLike' f s a
+validHost = Data.ProtoLens.Field.field @"validHost"
+vec'extensionNumber ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'extensionNumber" a) =>
+  Lens.Family2.LensLike' f s a
+vec'extensionNumber
+  = Data.ProtoLens.Field.field @"vec'extensionNumber"
+vec'fileDescriptorProto ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'fileDescriptorProto" a) =>
+  Lens.Family2.LensLike' f s a
+vec'fileDescriptorProto
+  = Data.ProtoLens.Field.field @"vec'fileDescriptorProto"
+vec'service ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'service" a) =>
+  Lens.Family2.LensLike' f s a
+vec'service = Data.ProtoLens.Field.field @"vec'service"

--- a/cardano-rpc/gen/Proto/Grpc/Reflection/V1alpha/Reflection.hs
+++ b/cardano-rpc/gen/Proto/Grpc/Reflection/V1alpha/Reflection.hs
@@ -1,0 +1,2366 @@
+{- This file was auto-generated from grpc/reflection/v1alpha/reflection.proto by the proto-lens-protoc program. -}
+{-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
+{-# OPTIONS_GHC -Wno-unused-imports#-}
+{-# OPTIONS_GHC -Wno-duplicate-exports#-}
+{-# OPTIONS_GHC -Wno-dodgy-exports#-}
+module Proto.Grpc.Reflection.V1alpha.Reflection (
+        ServerReflection(..), ErrorResponse(), ExtensionNumberResponse(),
+        ExtensionRequest(), FileDescriptorResponse(),
+        ListServiceResponse(), ServerReflectionRequest(),
+        ServerReflectionRequest'MessageRequest(..),
+        _ServerReflectionRequest'FileByFilename,
+        _ServerReflectionRequest'FileContainingSymbol,
+        _ServerReflectionRequest'FileContainingExtension,
+        _ServerReflectionRequest'AllExtensionNumbersOfType,
+        _ServerReflectionRequest'ListServices, ServerReflectionResponse(),
+        ServerReflectionResponse'MessageResponse(..),
+        _ServerReflectionResponse'FileDescriptorResponse,
+        _ServerReflectionResponse'AllExtensionNumbersResponse,
+        _ServerReflectionResponse'ListServicesResponse,
+        _ServerReflectionResponse'ErrorResponse, ServiceResponse()
+    ) where
+import qualified Data.ProtoLens.Runtime.Control.DeepSeq as Control.DeepSeq
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Prism as Data.ProtoLens.Prism
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.errorCode' @:: Lens' ErrorResponse Data.Int.Int32@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.errorMessage' @:: Lens' ErrorResponse Data.Text.Text@ -}
+data ErrorResponse
+  = ErrorResponse'_constructor {_ErrorResponse'errorCode :: !Data.Int.Int32,
+                                _ErrorResponse'errorMessage :: !Data.Text.Text,
+                                _ErrorResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ErrorResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ErrorResponse "errorCode" Data.Int.Int32 where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ErrorResponse'errorCode
+           (\ x__ y__ -> x__ {_ErrorResponse'errorCode = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ErrorResponse "errorMessage" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ErrorResponse'errorMessage
+           (\ x__ y__ -> x__ {_ErrorResponse'errorMessage = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ErrorResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ErrorResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\rErrorResponse\DC2\GS\n\
+      \\n\
+      \error_code\CAN\SOH \SOH(\ENQR\terrorCode\DC2#\n\
+      \\rerror_message\CAN\STX \SOH(\tR\ferrorMessage"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        errorCode__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_code"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"errorCode")) ::
+              Data.ProtoLens.FieldDescriptor ErrorResponse
+        errorMessage__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_message"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"errorMessage")) ::
+              Data.ProtoLens.FieldDescriptor ErrorResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, errorCode__field_descriptor),
+           (Data.ProtoLens.Tag 2, errorMessage__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ErrorResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ErrorResponse'_unknownFields = y__})
+  defMessage
+    = ErrorResponse'_constructor
+        {_ErrorResponse'errorCode = Data.ProtoLens.fieldDefault,
+         _ErrorResponse'errorMessage = Data.ProtoLens.fieldDefault,
+         _ErrorResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ErrorResponse -> Data.ProtoLens.Encoding.Bytes.Parser ErrorResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        8 -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (Prelude.fmap
+                                          Prelude.fromIntegral
+                                          Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                       "error_code"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"errorCode") y x)
+                        18
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "error_message"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"errorMessage") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ErrorResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v = Lens.Family2.view (Data.ProtoLens.Field.field @"errorCode") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                      ((Prelude..)
+                         Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral _v))
+             ((Data.Monoid.<>)
+                (let
+                   _v
+                     = Lens.Family2.view (Data.ProtoLens.Field.field @"errorMessage") _x
+                 in
+                   if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                         ((Prelude..)
+                            (\ bs
+                               -> (Data.Monoid.<>)
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                    (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Data.Text.Encoding.encodeUtf8 _v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ErrorResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ErrorResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ErrorResponse'errorCode x__)
+                (Control.DeepSeq.deepseq (_ErrorResponse'errorMessage x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.baseTypeName' @:: Lens' ExtensionNumberResponse Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.extensionNumber' @:: Lens' ExtensionNumberResponse [Data.Int.Int32]@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.vec'extensionNumber' @:: Lens' ExtensionNumberResponse (Data.Vector.Unboxed.Vector Data.Int.Int32)@ -}
+data ExtensionNumberResponse
+  = ExtensionNumberResponse'_constructor {_ExtensionNumberResponse'baseTypeName :: !Data.Text.Text,
+                                          _ExtensionNumberResponse'extensionNumber :: !(Data.Vector.Unboxed.Vector Data.Int.Int32),
+                                          _ExtensionNumberResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ExtensionNumberResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "baseTypeName" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'baseTypeName
+           (\ x__ y__ -> x__ {_ExtensionNumberResponse'baseTypeName = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "extensionNumber" [Data.Int.Int32] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'extensionNumber
+           (\ x__ y__
+              -> x__ {_ExtensionNumberResponse'extensionNumber = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField ExtensionNumberResponse "vec'extensionNumber" (Data.Vector.Unboxed.Vector Data.Int.Int32) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionNumberResponse'extensionNumber
+           (\ x__ y__
+              -> x__ {_ExtensionNumberResponse'extensionNumber = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ExtensionNumberResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ExtensionNumberResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\ETBExtensionNumberResponse\DC2$\n\
+      \\SObase_type_name\CAN\SOH \SOH(\tR\fbaseTypeName\DC2)\n\
+      \\DLEextension_number\CAN\STX \ETX(\ENQR\SIextensionNumber"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        baseTypeName__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "base_type_name"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"baseTypeName")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionNumberResponse
+        extensionNumber__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "extension_number"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Packed
+                 (Data.ProtoLens.Field.field @"extensionNumber")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionNumberResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, baseTypeName__field_descriptor),
+           (Data.ProtoLens.Tag 2, extensionNumber__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ExtensionNumberResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ExtensionNumberResponse'_unknownFields = y__})
+  defMessage
+    = ExtensionNumberResponse'_constructor
+        {_ExtensionNumberResponse'baseTypeName = Data.ProtoLens.fieldDefault,
+         _ExtensionNumberResponse'extensionNumber = Data.Vector.Generic.empty,
+         _ExtensionNumberResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ExtensionNumberResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector Data.ProtoLens.Encoding.Growing.RealWorld Data.Int.Int32
+             -> Data.ProtoLens.Encoding.Bytes.Parser ExtensionNumberResponse
+        loop x mutable'extensionNumber
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'extensionNumber <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'extensionNumber)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'extensionNumber")
+                              frozen'extensionNumber x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "base_type_name"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"baseTypeName") y x)
+                                  mutable'extensionNumber
+                        16
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (Prelude.fmap
+                                           Prelude.fromIntegral
+                                           Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                        "extension_number"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append
+                                          mutable'extensionNumber y)
+                                loop x v
+                        18
+                          -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        Data.ProtoLens.Encoding.Bytes.isolate
+                                          (Prelude.fromIntegral len)
+                                          ((let
+                                              ploop qs
+                                                = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                     if packedEnd then
+                                                         Prelude.return qs
+                                                     else
+                                                         do !q <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                                                    (Prelude.fmap
+                                                                       Prelude.fromIntegral
+                                                                       Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                    "extension_number"
+                                                            qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                     (Data.ProtoLens.Encoding.Growing.append
+                                                                        qs q)
+                                                            ploop qs'
+                                            in ploop)
+                                             mutable'extensionNumber)
+                                loop x y
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'extensionNumber
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'extensionNumber <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                           Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'extensionNumber)
+          "ExtensionNumberResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v
+                  = Lens.Family2.view (Data.ProtoLens.Field.field @"baseTypeName") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (let
+                   p = Lens.Family2.view
+                         (Data.ProtoLens.Field.field @"vec'extensionNumber") _x
+                 in
+                   if Data.Vector.Generic.null p then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                         ((\ bs
+                             -> (Data.Monoid.<>)
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                     (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            (Data.ProtoLens.Encoding.Bytes.runBuilder
+                               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                  ((Prelude..)
+                                     Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral)
+                                  p))))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ExtensionNumberResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ExtensionNumberResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ExtensionNumberResponse'baseTypeName x__)
+                (Control.DeepSeq.deepseq
+                   (_ExtensionNumberResponse'extensionNumber x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.containingType' @:: Lens' ExtensionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.extensionNumber' @:: Lens' ExtensionRequest Data.Int.Int32@ -}
+data ExtensionRequest
+  = ExtensionRequest'_constructor {_ExtensionRequest'containingType :: !Data.Text.Text,
+                                   _ExtensionRequest'extensionNumber :: !Data.Int.Int32,
+                                   _ExtensionRequest'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ExtensionRequest where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ExtensionRequest "containingType" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionRequest'containingType
+           (\ x__ y__ -> x__ {_ExtensionRequest'containingType = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ExtensionRequest "extensionNumber" Data.Int.Int32 where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ExtensionRequest'extensionNumber
+           (\ x__ y__ -> x__ {_ExtensionRequest'extensionNumber = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ExtensionRequest where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ExtensionRequest"
+  packedMessageDescriptor _
+    = "\n\
+      \\DLEExtensionRequest\DC2'\n\
+      \\SIcontaining_type\CAN\SOH \SOH(\tR\SOcontainingType\DC2)\n\
+      \\DLEextension_number\CAN\STX \SOH(\ENQR\SIextensionNumber"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        containingType__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "containing_type"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"containingType")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionRequest
+        extensionNumber__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "extension_number"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"extensionNumber")) ::
+              Data.ProtoLens.FieldDescriptor ExtensionRequest
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, containingType__field_descriptor),
+           (Data.ProtoLens.Tag 2, extensionNumber__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ExtensionRequest'_unknownFields
+        (\ x__ y__ -> x__ {_ExtensionRequest'_unknownFields = y__})
+  defMessage
+    = ExtensionRequest'_constructor
+        {_ExtensionRequest'containingType = Data.ProtoLens.fieldDefault,
+         _ExtensionRequest'extensionNumber = Data.ProtoLens.fieldDefault,
+         _ExtensionRequest'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ExtensionRequest
+          -> Data.ProtoLens.Encoding.Bytes.Parser ExtensionRequest
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "containing_type"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"containingType") y x)
+                        16
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (Prelude.fmap
+                                          Prelude.fromIntegral
+                                          Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                       "extension_number"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"extensionNumber") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ExtensionRequest"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v
+                  = Lens.Family2.view
+                      (Data.ProtoLens.Field.field @"containingType") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (let
+                   _v
+                     = Lens.Family2.view
+                         (Data.ProtoLens.Field.field @"extensionNumber") _x
+                 in
+                   if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                       Data.Monoid.mempty
+                   else
+                       (Data.Monoid.<>)
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                         ((Prelude..)
+                            Data.ProtoLens.Encoding.Bytes.putVarInt Prelude.fromIntegral _v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ExtensionRequest where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ExtensionRequest'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ExtensionRequest'containingType x__)
+                (Control.DeepSeq.deepseq
+                   (_ExtensionRequest'extensionNumber x__) ()))
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.fileDescriptorProto' @:: Lens' FileDescriptorResponse [Data.ByteString.ByteString]@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.vec'fileDescriptorProto' @:: Lens' FileDescriptorResponse (Data.Vector.Vector Data.ByteString.ByteString)@ -}
+data FileDescriptorResponse
+  = FileDescriptorResponse'_constructor {_FileDescriptorResponse'fileDescriptorProto :: !(Data.Vector.Vector Data.ByteString.ByteString),
+                                         _FileDescriptorResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FileDescriptorResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField FileDescriptorResponse "fileDescriptorProto" [Data.ByteString.ByteString] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FileDescriptorResponse'fileDescriptorProto
+           (\ x__ y__
+              -> x__ {_FileDescriptorResponse'fileDescriptorProto = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField FileDescriptorResponse "vec'fileDescriptorProto" (Data.Vector.Vector Data.ByteString.ByteString) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FileDescriptorResponse'fileDescriptorProto
+           (\ x__ y__
+              -> x__ {_FileDescriptorResponse'fileDescriptorProto = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message FileDescriptorResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.FileDescriptorResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\SYNFileDescriptorResponse\DC22\n\
+      \\NAKfile_descriptor_proto\CAN\SOH \ETX(\fR\DC3fileDescriptorProto"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        fileDescriptorProto__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_descriptor_proto"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.BytesField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.ByteString.ByteString)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Unpacked
+                 (Data.ProtoLens.Field.field @"fileDescriptorProto")) ::
+              Data.ProtoLens.FieldDescriptor FileDescriptorResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, fileDescriptorProto__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _FileDescriptorResponse'_unknownFields
+        (\ x__ y__ -> x__ {_FileDescriptorResponse'_unknownFields = y__})
+  defMessage
+    = FileDescriptorResponse'_constructor
+        {_FileDescriptorResponse'fileDescriptorProto = Data.Vector.Generic.empty,
+         _FileDescriptorResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          FileDescriptorResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector Data.ProtoLens.Encoding.Growing.RealWorld Data.ByteString.ByteString
+             -> Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorResponse
+        loop x mutable'fileDescriptorProto
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'fileDescriptorProto <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                      (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                         mutable'fileDescriptorProto)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'fileDescriptorProto")
+                              frozen'fileDescriptorProto x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                            Data.ProtoLens.Encoding.Bytes.getBytes
+                                              (Prelude.fromIntegral len))
+                                        "file_descriptor_proto"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append
+                                          mutable'fileDescriptorProto y)
+                                loop x v
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'fileDescriptorProto
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'fileDescriptorProto <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                               Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'fileDescriptorProto)
+          "FileDescriptorResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                (\ _v
+                   -> (Data.Monoid.<>)
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                        ((\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           _v))
+                (Lens.Family2.view
+                   (Data.ProtoLens.Field.field @"vec'fileDescriptorProto") _x))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData FileDescriptorResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_FileDescriptorResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_FileDescriptorResponse'fileDescriptorProto x__) ())
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.service' @:: Lens' ListServiceResponse [ServiceResponse]@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.vec'service' @:: Lens' ListServiceResponse (Data.Vector.Vector ServiceResponse)@ -}
+data ListServiceResponse
+  = ListServiceResponse'_constructor {_ListServiceResponse'service :: !(Data.Vector.Vector ServiceResponse),
+                                      _ListServiceResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ListServiceResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ListServiceResponse "service" [ServiceResponse] where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ListServiceResponse'service
+           (\ x__ y__ -> x__ {_ListServiceResponse'service = y__}))
+        (Lens.Family2.Unchecked.lens
+           Data.Vector.Generic.toList
+           (\ _ y__ -> Data.Vector.Generic.fromList y__))
+instance Data.ProtoLens.Field.HasField ListServiceResponse "vec'service" (Data.Vector.Vector ServiceResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ListServiceResponse'service
+           (\ x__ y__ -> x__ {_ListServiceResponse'service = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ListServiceResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ListServiceResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\DC3ListServiceResponse\DC2B\n\
+      \\aservice\CAN\SOH \ETX(\v2(.grpc.reflection.v1alpha.ServiceResponseR\aservice"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        service__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "service"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ServiceResponse)
+              (Data.ProtoLens.RepeatedField
+                 Data.ProtoLens.Unpacked (Data.ProtoLens.Field.field @"service")) ::
+              Data.ProtoLens.FieldDescriptor ListServiceResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, service__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ListServiceResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ListServiceResponse'_unknownFields = y__})
+  defMessage
+    = ListServiceResponse'_constructor
+        {_ListServiceResponse'service = Data.Vector.Generic.empty,
+         _ListServiceResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ListServiceResponse
+          -> Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector Data.ProtoLens.Encoding.Growing.RealWorld ServiceResponse
+             -> Data.ProtoLens.Encoding.Bytes.Parser ListServiceResponse
+        loop x mutable'service
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do frozen'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                          (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                             mutable'service)
+                      (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t)
+                           (Lens.Family2.set
+                              (Data.ProtoLens.Field.field @"vec'service") frozen'service x))
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                        (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                            Data.ProtoLens.Encoding.Bytes.isolate
+                                              (Prelude.fromIntegral len)
+                                              Data.ProtoLens.parseMessage)
+                                        "service"
+                                v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       (Data.ProtoLens.Encoding.Growing.append mutable'service y)
+                                loop x v
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+                                  mutable'service
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do mutable'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                   Data.ProtoLens.Encoding.Growing.new
+              loop Data.ProtoLens.defMessage mutable'service)
+          "ListServiceResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                (\ _v
+                   -> (Data.Monoid.<>)
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                        ((Prelude..)
+                           (\ bs
+                              -> (Data.Monoid.<>)
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Data.ProtoLens.encodeMessage _v))
+                (Lens.Family2.view (Data.ProtoLens.Field.field @"vec'service") _x))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData ListServiceResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ListServiceResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq (_ListServiceResponse'service x__) ())
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.host' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'messageRequest' @:: Lens' ServerReflectionRequest (Prelude.Maybe ServerReflectionRequest'MessageRequest)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'fileByFilename' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.fileByFilename' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'fileContainingSymbol' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.fileContainingSymbol' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'fileContainingExtension' @:: Lens' ServerReflectionRequest (Prelude.Maybe ExtensionRequest)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.fileContainingExtension' @:: Lens' ServerReflectionRequest ExtensionRequest@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'allExtensionNumbersOfType' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.allExtensionNumbersOfType' @:: Lens' ServerReflectionRequest Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'listServices' @:: Lens' ServerReflectionRequest (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.listServices' @:: Lens' ServerReflectionRequest Data.Text.Text@ -}
+data ServerReflectionRequest
+  = ServerReflectionRequest'_constructor {_ServerReflectionRequest'host :: !Data.Text.Text,
+                                          _ServerReflectionRequest'messageRequest :: !(Prelude.Maybe ServerReflectionRequest'MessageRequest),
+                                          _ServerReflectionRequest'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServerReflectionRequest where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+data ServerReflectionRequest'MessageRequest
+  = ServerReflectionRequest'FileByFilename !Data.Text.Text |
+    ServerReflectionRequest'FileContainingSymbol !Data.Text.Text |
+    ServerReflectionRequest'FileContainingExtension !ExtensionRequest |
+    ServerReflectionRequest'AllExtensionNumbersOfType !Data.Text.Text |
+    ServerReflectionRequest'ListServices !Data.Text.Text
+  deriving stock (Prelude.Show, Prelude.Eq, Prelude.Ord)
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "host" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'host
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'host = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'messageRequest" (Prelude.Maybe ServerReflectionRequest'MessageRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileByFilename" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileByFilename x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionRequest'FileByFilename y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileByFilename" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileByFilename x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionRequest'FileByFilename y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileContainingSymbol" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileContainingSymbol x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionRequest'FileContainingSymbol y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileContainingSymbol" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileContainingSymbol x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionRequest'FileContainingSymbol y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'fileContainingExtension" (Prelude.Maybe ExtensionRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'FileContainingExtension x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionRequest'FileContainingExtension y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "fileContainingExtension" ExtensionRequest where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'FileContainingExtension x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionRequest'FileContainingExtension y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'allExtensionNumbersOfType" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionRequest'AllExtensionNumbersOfType y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "allExtensionNumbersOfType" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionRequest'AllExtensionNumbersOfType y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "maybe'listServices" (Prelude.Maybe Data.Text.Text) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionRequest'ListServices x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__ -> Prelude.fmap ServerReflectionRequest'ListServices y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionRequest "listServices" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionRequest'messageRequest
+           (\ x__ y__ -> x__ {_ServerReflectionRequest'messageRequest = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionRequest'ListServices x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__ -> Prelude.fmap ServerReflectionRequest'ListServices y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault))
+instance Data.ProtoLens.Message ServerReflectionRequest where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ServerReflectionRequest"
+  packedMessageDescriptor _
+    = "\n\
+      \\ETBServerReflectionRequest\DC2\DC2\n\
+      \\EOThost\CAN\SOH \SOH(\tR\EOThost\DC2*\n\
+      \\DLEfile_by_filename\CAN\ETX \SOH(\tH\NULR\SOfileByFilename\DC26\n\
+      \\SYNfile_containing_symbol\CAN\EOT \SOH(\tH\NULR\DC4fileContainingSymbol\DC2g\n\
+      \\EMfile_containing_extension\CAN\ENQ \SOH(\v2).grpc.reflection.v1alpha.ExtensionRequestH\NULR\ETBfileContainingExtension\DC2B\n\
+      \\GSall_extension_numbers_of_type\CAN\ACK \SOH(\tH\NULR\EMallExtensionNumbersOfType\DC2%\n\
+      \\rlist_services\CAN\a \SOH(\tH\NULR\flistServicesB\DC1\n\
+      \\SImessage_request"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        host__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "host"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"host")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileByFilename__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_by_filename"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileByFilename")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileContainingSymbol__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_containing_symbol"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileContainingSymbol")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        fileContainingExtension__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_containing_extension"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ExtensionRequest)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileContainingExtension")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        allExtensionNumbersOfType__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "all_extension_numbers_of_type"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'allExtensionNumbersOfType")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+        listServices__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "list_services"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'listServices")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionRequest
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, host__field_descriptor),
+           (Data.ProtoLens.Tag 3, fileByFilename__field_descriptor),
+           (Data.ProtoLens.Tag 4, fileContainingSymbol__field_descriptor),
+           (Data.ProtoLens.Tag 5, fileContainingExtension__field_descriptor),
+           (Data.ProtoLens.Tag 6, 
+            allExtensionNumbersOfType__field_descriptor),
+           (Data.ProtoLens.Tag 7, listServices__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServerReflectionRequest'_unknownFields
+        (\ x__ y__ -> x__ {_ServerReflectionRequest'_unknownFields = y__})
+  defMessage
+    = ServerReflectionRequest'_constructor
+        {_ServerReflectionRequest'host = Data.ProtoLens.fieldDefault,
+         _ServerReflectionRequest'messageRequest = Prelude.Nothing,
+         _ServerReflectionRequest'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServerReflectionRequest
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServerReflectionRequest
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "host"
+                                loop (Lens.Family2.set (Data.ProtoLens.Field.field @"host") y x)
+                        26
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "file_by_filename"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileByFilename") y x)
+                        34
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "file_containing_symbol"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileContainingSymbol") y x)
+                        42
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "file_containing_extension"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileContainingExtension") y x)
+                        50
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "all_extension_numbers_of_type"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"allExtensionNumbersOfType") y x)
+                        58
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "list_services"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"listServices") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServerReflectionRequest"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let _v = Lens.Family2.view (Data.ProtoLens.Field.field @"host") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (case
+                     Lens.Family2.view
+                       (Data.ProtoLens.Field.field @"maybe'messageRequest") _x
+                 of
+                   Prelude.Nothing -> Data.Monoid.mempty
+                   (Prelude.Just (ServerReflectionRequest'FileByFilename v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'FileContainingSymbol v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'FileContainingExtension v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 42)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.ProtoLens.encodeMessage v)
+                   (Prelude.Just (ServerReflectionRequest'AllExtensionNumbersOfType v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v)
+                   (Prelude.Just (ServerReflectionRequest'ListServices v))
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.Text.Encoding.encodeUtf8 v))
+                (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+instance Control.DeepSeq.NFData ServerReflectionRequest where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServerReflectionRequest'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ServerReflectionRequest'host x__)
+                (Control.DeepSeq.deepseq
+                   (_ServerReflectionRequest'messageRequest x__) ()))
+instance Control.DeepSeq.NFData ServerReflectionRequest'MessageRequest where
+  rnf (ServerReflectionRequest'FileByFilename x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'FileContainingSymbol x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'FileContainingExtension x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'AllExtensionNumbersOfType x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionRequest'ListServices x__)
+    = Control.DeepSeq.rnf x__
+_ServerReflectionRequest'FileByFilename ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'FileByFilename
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileByFilename
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileByFilename p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'FileContainingSymbol ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'FileContainingSymbol
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileContainingSymbol
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileContainingSymbol p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'FileContainingExtension ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest ExtensionRequest
+_ServerReflectionRequest'FileContainingExtension
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'FileContainingExtension
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'FileContainingExtension p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'AllExtensionNumbersOfType ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'AllExtensionNumbersOfType
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'AllExtensionNumbersOfType
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'AllExtensionNumbersOfType p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionRequest'ListServices ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionRequest'MessageRequest Data.Text.Text
+_ServerReflectionRequest'ListServices
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionRequest'ListServices
+      (\ p__
+         -> case p__ of
+              (ServerReflectionRequest'ListServices p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.validHost' @:: Lens' ServerReflectionResponse Data.Text.Text@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.originalRequest' @:: Lens' ServerReflectionResponse ServerReflectionRequest@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'originalRequest' @:: Lens' ServerReflectionResponse (Prelude.Maybe ServerReflectionRequest)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'messageResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ServerReflectionResponse'MessageResponse)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'fileDescriptorResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe FileDescriptorResponse)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.fileDescriptorResponse' @:: Lens' ServerReflectionResponse FileDescriptorResponse@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'allExtensionNumbersResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ExtensionNumberResponse)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.allExtensionNumbersResponse' @:: Lens' ServerReflectionResponse ExtensionNumberResponse@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'listServicesResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ListServiceResponse)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.listServicesResponse' @:: Lens' ServerReflectionResponse ListServiceResponse@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.maybe'errorResponse' @:: Lens' ServerReflectionResponse (Prelude.Maybe ErrorResponse)@
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.errorResponse' @:: Lens' ServerReflectionResponse ErrorResponse@ -}
+data ServerReflectionResponse
+  = ServerReflectionResponse'_constructor {_ServerReflectionResponse'validHost :: !Data.Text.Text,
+                                           _ServerReflectionResponse'originalRequest :: !(Prelude.Maybe ServerReflectionRequest),
+                                           _ServerReflectionResponse'messageResponse :: !(Prelude.Maybe ServerReflectionResponse'MessageResponse),
+                                           _ServerReflectionResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServerReflectionResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+data ServerReflectionResponse'MessageResponse
+  = ServerReflectionResponse'FileDescriptorResponse !FileDescriptorResponse |
+    ServerReflectionResponse'AllExtensionNumbersResponse !ExtensionNumberResponse |
+    ServerReflectionResponse'ListServicesResponse !ListServiceResponse |
+    ServerReflectionResponse'ErrorResponse !ErrorResponse
+  deriving stock (Prelude.Show, Prelude.Eq, Prelude.Ord)
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "validHost" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'validHost
+           (\ x__ y__ -> x__ {_ServerReflectionResponse'validHost = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "originalRequest" ServerReflectionRequest where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'originalRequest
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'originalRequest = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'originalRequest" (Prelude.Maybe ServerReflectionRequest) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'originalRequest
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'originalRequest = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'messageResponse" (Prelude.Maybe ServerReflectionResponse'MessageResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        Prelude.id
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'fileDescriptorResponse" (Prelude.Maybe FileDescriptorResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionResponse'FileDescriptorResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "fileDescriptorResponse" FileDescriptorResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionResponse'FileDescriptorResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'allExtensionNumbersResponse" (Prelude.Maybe ExtensionNumberResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap
+                   ServerReflectionResponse'AllExtensionNumbersResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "allExtensionNumbersResponse" ExtensionNumberResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap
+                      ServerReflectionResponse'AllExtensionNumbersResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'listServicesResponse" (Prelude.Maybe ListServiceResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'ListServicesResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionResponse'ListServicesResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "listServicesResponse" ListServiceResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'ListServicesResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionResponse'ListServicesResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "maybe'errorResponse" (Prelude.Maybe ErrorResponse) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        (Lens.Family2.Unchecked.lens
+           (\ x__
+              -> case x__ of
+                   (Prelude.Just (ServerReflectionResponse'ErrorResponse x__val))
+                     -> Prelude.Just x__val
+                   _otherwise -> Prelude.Nothing)
+           (\ _ y__
+              -> Prelude.fmap ServerReflectionResponse'ErrorResponse y__))
+instance Data.ProtoLens.Field.HasField ServerReflectionResponse "errorResponse" ErrorResponse where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServerReflectionResponse'messageResponse
+           (\ x__ y__
+              -> x__ {_ServerReflectionResponse'messageResponse = y__}))
+        ((Prelude..)
+           (Lens.Family2.Unchecked.lens
+              (\ x__
+                 -> case x__ of
+                      (Prelude.Just (ServerReflectionResponse'ErrorResponse x__val))
+                        -> Prelude.Just x__val
+                      _otherwise -> Prelude.Nothing)
+              (\ _ y__
+                 -> Prelude.fmap ServerReflectionResponse'ErrorResponse y__))
+           (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage))
+instance Data.ProtoLens.Message ServerReflectionResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ServerReflectionResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\CANServerReflectionResponse\DC2\GS\n\
+      \\n\
+      \valid_host\CAN\SOH \SOH(\tR\tvalidHost\DC2[\n\
+      \\DLEoriginal_request\CAN\STX \SOH(\v20.grpc.reflection.v1alpha.ServerReflectionRequestR\SIoriginalRequest\DC2k\n\
+      \\CANfile_descriptor_response\CAN\EOT \SOH(\v2/.grpc.reflection.v1alpha.FileDescriptorResponseH\NULR\SYNfileDescriptorResponse\DC2w\n\
+      \\RSall_extension_numbers_response\CAN\ENQ \SOH(\v20.grpc.reflection.v1alpha.ExtensionNumberResponseH\NULR\ESCallExtensionNumbersResponse\DC2d\n\
+      \\SYNlist_services_response\CAN\ACK \SOH(\v2,.grpc.reflection.v1alpha.ListServiceResponseH\NULR\DC4listServicesResponse\DC2O\n\
+      \\SOerror_response\CAN\a \SOH(\v2&.grpc.reflection.v1alpha.ErrorResponseH\NULR\rerrorResponseB\DC2\n\
+      \\DLEmessage_response"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        validHost__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "valid_host"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional
+                 (Data.ProtoLens.Field.field @"validHost")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        originalRequest__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "original_request"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ServerReflectionRequest)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'originalRequest")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        fileDescriptorResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "file_descriptor_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor FileDescriptorResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'fileDescriptorResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        allExtensionNumbersResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "all_extension_numbers_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ExtensionNumberResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field
+                    @"maybe'allExtensionNumbersResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        listServicesResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "list_services_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ListServiceResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'listServicesResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+        errorResponse__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "error_response"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor ErrorResponse)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'errorResponse")) ::
+              Data.ProtoLens.FieldDescriptor ServerReflectionResponse
+      in
+        Data.Map.fromList
+          [(Data.ProtoLens.Tag 1, validHost__field_descriptor),
+           (Data.ProtoLens.Tag 2, originalRequest__field_descriptor),
+           (Data.ProtoLens.Tag 4, fileDescriptorResponse__field_descriptor),
+           (Data.ProtoLens.Tag 5, 
+            allExtensionNumbersResponse__field_descriptor),
+           (Data.ProtoLens.Tag 6, listServicesResponse__field_descriptor),
+           (Data.ProtoLens.Tag 7, errorResponse__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServerReflectionResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ServerReflectionResponse'_unknownFields = y__})
+  defMessage
+    = ServerReflectionResponse'_constructor
+        {_ServerReflectionResponse'validHost = Data.ProtoLens.fieldDefault,
+         _ServerReflectionResponse'originalRequest = Prelude.Nothing,
+         _ServerReflectionResponse'messageResponse = Prelude.Nothing,
+         _ServerReflectionResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServerReflectionResponse
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServerReflectionResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "valid_host"
+                                loop
+                                  (Lens.Family2.set (Data.ProtoLens.Field.field @"validHost") y x)
+                        18
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "original_request"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"originalRequest") y x)
+                        34
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "file_descriptor_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"fileDescriptorResponse") y x)
+                        42
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "all_extension_numbers_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"allExtensionNumbersResponse") y
+                                     x)
+                        50
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "list_services_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"listServicesResponse") y x)
+                        58
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "error_response"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"errorResponse") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServerReflectionResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let
+                _v = Lens.Family2.view (Data.ProtoLens.Field.field @"validHost") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             ((Data.Monoid.<>)
+                (case
+                     Lens.Family2.view
+                       (Data.ProtoLens.Field.field @"maybe'originalRequest") _x
+                 of
+                   Prelude.Nothing -> Data.Monoid.mempty
+                   (Prelude.Just _v)
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                          ((Prelude..)
+                             (\ bs
+                                -> (Data.Monoid.<>)
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Data.ProtoLens.encodeMessage _v))
+                ((Data.Monoid.<>)
+                   (case
+                        Lens.Family2.view
+                          (Data.ProtoLens.Field.field @"maybe'messageResponse") _x
+                    of
+                      Prelude.Nothing -> Data.Monoid.mempty
+                      (Prelude.Just (ServerReflectionResponse'FileDescriptorResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'AllExtensionNumbersResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 42)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'ListServicesResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v)
+                      (Prelude.Just (ServerReflectionResponse'ErrorResponse v))
+                        -> (Data.Monoid.<>)
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                             ((Prelude..)
+                                (\ bs
+                                   -> (Data.Monoid.<>)
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Data.ProtoLens.encodeMessage v))
+                   (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))))
+instance Control.DeepSeq.NFData ServerReflectionResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServerReflectionResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq
+                (_ServerReflectionResponse'validHost x__)
+                (Control.DeepSeq.deepseq
+                   (_ServerReflectionResponse'originalRequest x__)
+                   (Control.DeepSeq.deepseq
+                      (_ServerReflectionResponse'messageResponse x__) ())))
+instance Control.DeepSeq.NFData ServerReflectionResponse'MessageResponse where
+  rnf (ServerReflectionResponse'FileDescriptorResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'AllExtensionNumbersResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'ListServicesResponse x__)
+    = Control.DeepSeq.rnf x__
+  rnf (ServerReflectionResponse'ErrorResponse x__)
+    = Control.DeepSeq.rnf x__
+_ServerReflectionResponse'FileDescriptorResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse FileDescriptorResponse
+_ServerReflectionResponse'FileDescriptorResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'FileDescriptorResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'FileDescriptorResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'AllExtensionNumbersResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ExtensionNumberResponse
+_ServerReflectionResponse'AllExtensionNumbersResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'AllExtensionNumbersResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'AllExtensionNumbersResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'ListServicesResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ListServiceResponse
+_ServerReflectionResponse'ListServicesResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'ListServicesResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'ListServicesResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+_ServerReflectionResponse'ErrorResponse ::
+  Data.ProtoLens.Prism.Prism' ServerReflectionResponse'MessageResponse ErrorResponse
+_ServerReflectionResponse'ErrorResponse
+  = Data.ProtoLens.Prism.prism'
+      ServerReflectionResponse'ErrorResponse
+      (\ p__
+         -> case p__ of
+              (ServerReflectionResponse'ErrorResponse p__val)
+                -> Prelude.Just p__val
+              _otherwise -> Prelude.Nothing)
+{- | Fields :
+     
+         * 'Proto.Grpc.Reflection.V1alpha.Reflection_Fields.name' @:: Lens' ServiceResponse Data.Text.Text@ -}
+data ServiceResponse
+  = ServiceResponse'_constructor {_ServiceResponse'name :: !Data.Text.Text,
+                                  _ServiceResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
+  deriving stock (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServiceResponse where
+  showsPrec _ __x __s
+    = Prelude.showChar
+        '{'
+        (Prelude.showString
+           (Data.ProtoLens.showMessageShort __x) (Prelude.showChar '}' __s))
+instance Data.ProtoLens.Field.HasField ServiceResponse "name" Data.Text.Text where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _ServiceResponse'name
+           (\ x__ y__ -> x__ {_ServiceResponse'name = y__}))
+        Prelude.id
+instance Data.ProtoLens.Message ServiceResponse where
+  messageName _
+    = Data.Text.pack "grpc.reflection.v1alpha.ServiceResponse"
+  packedMessageDescriptor _
+    = "\n\
+      \\SIServiceResponse\DC2\DC2\n\
+      \\EOTname\CAN\SOH \SOH(\tR\EOTname"
+  packedFileDescriptor _ = packedFileDescriptor
+  fieldsByTag
+    = let
+        name__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "name"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
+              (Data.ProtoLens.PlainField
+                 Data.ProtoLens.Optional (Data.ProtoLens.Field.field @"name")) ::
+              Data.ProtoLens.FieldDescriptor ServiceResponse
+      in
+        Data.Map.fromList [(Data.ProtoLens.Tag 1, name__field_descriptor)]
+  unknownFields
+    = Lens.Family2.Unchecked.lens
+        _ServiceResponse'_unknownFields
+        (\ x__ y__ -> x__ {_ServiceResponse'_unknownFields = y__})
+  defMessage
+    = ServiceResponse'_constructor
+        {_ServiceResponse'name = Data.ProtoLens.fieldDefault,
+         _ServiceResponse'_unknownFields = []}
+  parseMessage
+    = let
+        loop ::
+          ServiceResponse
+          -> Data.ProtoLens.Encoding.Bytes.Parser ServiceResponse
+        loop x
+          = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+               if end then
+                   do (let missing = []
+                       in
+                         if Prelude.null missing then
+                             Prelude.return ()
+                         else
+                             Prelude.fail
+                               ((Prelude.++)
+                                  "Missing required fields: "
+                                  (Prelude.show (missing :: [Prelude.String]))))
+                      Prelude.return
+                        (Lens.Family2.over
+                           Data.ProtoLens.unknownFields (\ !t -> Prelude.reverse t) x)
+               else
+                   do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                      case tag of
+                        10
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.getText
+                                             (Prelude.fromIntegral len))
+                                       "name"
+                                loop (Lens.Family2.set (Data.ProtoLens.Field.field @"name") y x)
+                        wire
+                          -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
+                                        wire
+                                loop
+                                  (Lens.Family2.over
+                                     Data.ProtoLens.unknownFields (\ !t -> (:) y t) x)
+      in
+        (Data.ProtoLens.Encoding.Bytes.<?>)
+          (do loop Data.ProtoLens.defMessage) "ServiceResponse"
+  buildMessage
+    = \ _x
+        -> (Data.Monoid.<>)
+             (let _v = Lens.Family2.view (Data.ProtoLens.Field.field @"name") _x
+              in
+                if (Prelude.==) _v Data.ProtoLens.fieldDefault then
+                    Data.Monoid.mempty
+                else
+                    (Data.Monoid.<>)
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                      ((Prelude..)
+                         (\ bs
+                            -> (Data.Monoid.<>)
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                         Data.Text.Encoding.encodeUtf8 _v))
+             (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
+instance Control.DeepSeq.NFData ServiceResponse where
+  rnf
+    = \ x__
+        -> Control.DeepSeq.deepseq
+             (_ServiceResponse'_unknownFields x__)
+             (Control.DeepSeq.deepseq (_ServiceResponse'name x__) ())
+data ServerReflection = ServerReflection {}
+instance Data.ProtoLens.Service.Types.Service ServerReflection where
+  type ServiceName ServerReflection = "ServerReflection"
+  type ServicePackage ServerReflection = "grpc.reflection.v1alpha"
+  type ServiceMethods ServerReflection = '["serverReflectionInfo"]
+  packedServiceDescriptor _
+    = "\n\
+      \\DLEServerReflection\DC2\DEL\n\
+      \\DC4ServerReflectionInfo\DC20.grpc.reflection.v1alpha.ServerReflectionRequest\SUB1.grpc.reflection.v1alpha.ServerReflectionResponse(\SOH0\SOH"
+instance Data.ProtoLens.Service.Types.HasMethodImpl ServerReflection "serverReflectionInfo" where
+  type MethodName ServerReflection "serverReflectionInfo" = "ServerReflectionInfo"
+  type MethodInput ServerReflection "serverReflectionInfo" = ServerReflectionRequest
+  type MethodOutput ServerReflection "serverReflectionInfo" = ServerReflectionResponse
+  type MethodStreamingType ServerReflection "serverReflectionInfo" = 'Data.ProtoLens.Service.Types.BiDiStreaming
+packedFileDescriptor :: Data.ByteString.ByteString
+packedFileDescriptor
+  = "\n\
+    \(grpc/reflection/v1alpha/reflection.proto\DC2\ETBgrpc.reflection.v1alpha\"\248\STX\n\
+    \\ETBServerReflectionRequest\DC2\DC2\n\
+    \\EOThost\CAN\SOH \SOH(\tR\EOThost\DC2*\n\
+    \\DLEfile_by_filename\CAN\ETX \SOH(\tH\NULR\SOfileByFilename\DC26\n\
+    \\SYNfile_containing_symbol\CAN\EOT \SOH(\tH\NULR\DC4fileContainingSymbol\DC2g\n\
+    \\EMfile_containing_extension\CAN\ENQ \SOH(\v2).grpc.reflection.v1alpha.ExtensionRequestH\NULR\ETBfileContainingExtension\DC2B\n\
+    \\GSall_extension_numbers_of_type\CAN\ACK \SOH(\tH\NULR\EMallExtensionNumbersOfType\DC2%\n\
+    \\rlist_services\CAN\a \SOH(\tH\NULR\flistServicesB\DC1\n\
+    \\SImessage_request\"f\n\
+    \\DLEExtensionRequest\DC2'\n\
+    \\SIcontaining_type\CAN\SOH \SOH(\tR\SOcontainingType\DC2)\n\
+    \\DLEextension_number\CAN\STX \SOH(\ENQR\SIextensionNumber\"\199\EOT\n\
+    \\CANServerReflectionResponse\DC2\GS\n\
+    \\n\
+    \valid_host\CAN\SOH \SOH(\tR\tvalidHost\DC2[\n\
+    \\DLEoriginal_request\CAN\STX \SOH(\v20.grpc.reflection.v1alpha.ServerReflectionRequestR\SIoriginalRequest\DC2k\n\
+    \\CANfile_descriptor_response\CAN\EOT \SOH(\v2/.grpc.reflection.v1alpha.FileDescriptorResponseH\NULR\SYNfileDescriptorResponse\DC2w\n\
+    \\RSall_extension_numbers_response\CAN\ENQ \SOH(\v20.grpc.reflection.v1alpha.ExtensionNumberResponseH\NULR\ESCallExtensionNumbersResponse\DC2d\n\
+    \\SYNlist_services_response\CAN\ACK \SOH(\v2,.grpc.reflection.v1alpha.ListServiceResponseH\NULR\DC4listServicesResponse\DC2O\n\
+    \\SOerror_response\CAN\a \SOH(\v2&.grpc.reflection.v1alpha.ErrorResponseH\NULR\rerrorResponseB\DC2\n\
+    \\DLEmessage_response\"L\n\
+    \\SYNFileDescriptorResponse\DC22\n\
+    \\NAKfile_descriptor_proto\CAN\SOH \ETX(\fR\DC3fileDescriptorProto\"j\n\
+    \\ETBExtensionNumberResponse\DC2$\n\
+    \\SObase_type_name\CAN\SOH \SOH(\tR\fbaseTypeName\DC2)\n\
+    \\DLEextension_number\CAN\STX \ETX(\ENQR\SIextensionNumber\"Y\n\
+    \\DC3ListServiceResponse\DC2B\n\
+    \\aservice\CAN\SOH \ETX(\v2(.grpc.reflection.v1alpha.ServiceResponseR\aservice\"%\n\
+    \\SIServiceResponse\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\"S\n\
+    \\rErrorResponse\DC2\GS\n\
+    \\n\
+    \error_code\CAN\SOH \SOH(\ENQR\terrorCode\DC2#\n\
+    \\rerror_message\CAN\STX \SOH(\tR\ferrorMessage2\147\SOH\n\
+    \\DLEServerReflection\DC2\DEL\n\
+    \\DC4ServerReflectionInfo\DC20.grpc.reflection.v1alpha.ServerReflectionRequest\SUB1.grpc.reflection.v1alpha.ServerReflectionResponse(\SOH0\SOHB\172\SOH\n\
+    \\ESCcom.grpc.reflection.v1alphaB\SIReflectionProtoP\SOH\162\STX\ETXGRX\170\STX\ETBGrpc.Reflection.V1alpha\202\STX\ETBGrpc\\Reflection\\V1alpha\226\STX#Grpc\\Reflection\\V1alpha\\GPBMetadata\234\STX\EMGrpc::Reflection::V1alphaJ\142+\n\
+    \\a\DC2\ENQ\DLE\NUL\135\SOH\SOH\n\
+    \\232\EOT\n\
+    \\SOH\f\DC2\ETX\DLE\NUL\DC22\180\EOT Copyright 2016 gRPC authors.\n\
+    \\n\
+    \ Licensed under the Apache License, Version 2.0 (the \"License\");\n\
+    \ you may not use this file except in compliance with the License.\n\
+    \ You may obtain a copy of the License at\n\
+    \\n\
+    \     http://www.apache.org/licenses/LICENSE-2.0\n\
+    \\n\
+    \ Unless required by applicable law or agreed to in writing, software\n\
+    \ distributed under the License is distributed on an \"AS IS\" BASIS,\n\
+    \ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+    \ See the License for the specific language governing permissions and\n\
+    \ limitations under the License.\n\
+    \2' Service exported by server reflection\n\
+    \\n\
+    \\b\n\
+    \\SOH\STX\DC2\ETX\DC2\NUL \n\
+    \\n\
+    \\n\
+    \\STX\ACK\NUL\DC2\EOT\DC4\NUL\EM\SOH\n\
+    \\n\
+    \\n\
+    \\ETX\ACK\NUL\SOH\DC2\ETX\DC4\b\CAN\n\
+    \\133\SOH\n\
+    \\EOT\ACK\NUL\STX\NUL\DC2\EOT\ETB\STX\CAN0\SUBw The reflection service is structured as a bidirectional stream, ensuring\n\
+    \ all related requests go to a single server.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\SOH\DC2\ETX\ETB\ACK\SUB\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ENQ\DC2\ETX\ETB\ESC!\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\STX\DC2\ETX\ETB\"9\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ACK\DC2\ETX\CAN\SI\NAK\n\
+    \\f\n\
+    \\ENQ\ACK\NUL\STX\NUL\ETX\DC2\ETX\CAN\SYN.\n\
+    \V\n\
+    \\STX\EOT\NUL\DC2\EOT\FS\NUL<\SOH\SUBJ The message sent by the client when calling ServerReflectionInfo method.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX\FS\b\US\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX\GS\STX\DC2\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ENQ\DC2\ETX\GS\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX\GS\t\r\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX\GS\DLE\DC1\n\
+    \\223\SOH\n\
+    \\EOT\EOT\NUL\b\NUL\DC2\EOT!\STX;\ETX\SUB\208\SOH To use reflection service, the client should set one of the following\n\
+    \ fields in message_request. The server distinguishes requests by their\n\
+    \ defined field and then handles them using corresponding methods.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\b\NUL\SOH\DC2\ETX!\b\ETB\n\
+    \2\n\
+    \\EOT\EOT\NUL\STX\SOH\DC2\ETX#\EOT \SUB% Find a proto file by the file name.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ENQ\DC2\ETX#\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\SOH\DC2\ETX#\v\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ETX\DC2\ETX#\RS\US\n\
+    \\200\SOH\n\
+    \\EOT\EOT\NUL\STX\STX\DC2\ETX(\EOT&\SUB\186\SOH Find the proto file that declares the given fully-qualified symbol name.\n\
+    \ This field should be a fully-qualified symbol name\n\
+    \ (e.g. <package>.<service>[.<method>] or <package>.<type>).\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ENQ\DC2\ETX(\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\SOH\DC2\ETX(\v!\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ETX\DC2\ETX($%\n\
+    \|\n\
+    \\EOT\EOT\NUL\STX\ETX\DC2\ETX,\EOT3\SUBo Find the proto file which defines an extension extending the given\n\
+    \ message type with the given field number.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ACK\DC2\ETX,\EOT\DC4\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\SOH\DC2\ETX,\NAK.\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ETX\DC2\ETX,12\n\
+    \\238\ETX\n\
+    \\EOT\EOT\NUL\STX\EOT\DC2\ETX6\EOT-\SUB\224\ETX Finds the tag numbers used by all known extensions of the given message\n\
+    \ type, and appends them to ExtensionNumberResponse in an undefined order.\n\
+    \ Its corresponding method is best-effort: it's not guaranteed that the\n\
+    \ reflection service will implement this method, and it's not guaranteed\n\
+    \ that this method will provide all extensions. Returns\n\
+    \ StatusCode::UNIMPLEMENTED if it's not implemented.\n\
+    \ This field should be a fully-qualified type name. The format is\n\
+    \ <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\ENQ\DC2\ETX6\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\SOH\DC2\ETX6\v(\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\EOT\ETX\DC2\ETX6+,\n\
+    \\\\n\
+    \\EOT\EOT\NUL\STX\ENQ\DC2\ETX:\EOT\GS\SUBO List the full names of registered services. The content will not be\n\
+    \ checked.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\ENQ\DC2\ETX:\EOT\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\SOH\DC2\ETX:\v\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ENQ\ETX\DC2\ETX:\ESC\FS\n\
+    \o\n\
+    \\STX\EOT\SOH\DC2\EOT@\NULD\SOH\SUBc The type name and extension number sent by the client when requesting\n\
+    \ file_containing_extension.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETX@\b\CAN\n\
+    \O\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETXB\STX\GS\SUBB Fully-qualified type name. The format should be <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETXB\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETXB\t\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETXB\ESC\FS\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETXC\STX\GS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETXC\STX\a\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETXC\b\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETXC\ESC\FS\n\
+    \S\n\
+    \\STX\EOT\STX\DC2\EOTG\NUL^\SOH\SUBG The message sent by the server to answer ServerReflectionInfo method.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\STX\SOH\DC2\ETXG\b \n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETXH\STX\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETXH\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETXH\t\DC3\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETXH\SYN\ETB\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\ETXI\STX/\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\ETXI\STX\EM\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETXI\SUB*\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETXI-.\n\
+    \l\n\
+    \\EOT\EOT\STX\b\NUL\DC2\EOTL\STX]\ETX\SUB^ The server set one of the following fields accroding to the message_request\n\
+    \ in the request.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\b\NUL\SOH\DC2\ETXL\b\CAN\n\
+    \\177\ETX\n\
+    \\EOT\EOT\STX\STX\STX\DC2\ETXS\EOT8\SUB\163\ETX This message is used to answer file_by_filename, file_containing_symbol,\n\
+    \ file_containing_extension requests with transitive dependencies. As\n\
+    \ the repeated label is not allowed in oneof fields, we use a\n\
+    \ FileDescriptorResponse message to encapsulate the repeated fields.\n\
+    \ The reflection service is allowed to avoid sending FileDescriptorProtos\n\
+    \ that were previously sent in response to earlier requests in the stream.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ACK\DC2\ETXS\EOT\SUB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\SOH\DC2\ETXS\ESC3\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETXS67\n\
+    \S\n\
+    \\EOT\EOT\STX\STX\ETX\DC2\ETXV\EOT?\SUBF This message is used to answer all_extension_numbers_of_type requst.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ACK\DC2\ETXV\EOT\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\SOH\DC2\ETXV\FS:\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ETX\DC2\ETXV=>\n\
+    \D\n\
+    \\EOT\EOT\STX\STX\EOT\DC2\ETXY\EOT3\SUB7 This message is used to answer list_services request.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ACK\DC2\ETXY\EOT\ETB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\SOH\DC2\ETXY\CAN.\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ETX\DC2\ETXY12\n\
+    \9\n\
+    \\EOT\EOT\STX\STX\ENQ\DC2\ETX\\\EOT%\SUB, This message is used when an error occurs.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ACK\DC2\ETX\\\EOT\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\SOH\DC2\ETX\\\DC2 \n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ETX\DC2\ETX\\#$\n\
+    \\167\SOH\n\
+    \\STX\EOT\ETX\DC2\EOTc\NULh\SOH\SUB\154\SOH Serialized FileDescriptorProto messages sent by the server answering\n\
+    \ a file_by_filename, file_containing_symbol, or file_containing_extension\n\
+    \ request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ETX\SOH\DC2\ETXc\b\RS\n\
+    \\178\SOH\n\
+    \\EOT\EOT\ETX\STX\NUL\DC2\ETXg\STX+\SUB\164\SOH Serialized FileDescriptorProto messages. We avoid taking a dependency on\n\
+    \ descriptor.proto, which uses proto2 only features, by making them opaque\n\
+    \ bytes instead.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\EOT\DC2\ETXg\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\ENQ\DC2\ETXg\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\SOH\DC2\ETXg\DC1&\n\
+    \\f\n\
+    \\ENQ\EOT\ETX\STX\NUL\ETX\DC2\ETXg)*\n\
+    \n\n\
+    \\STX\EOT\EOT\DC2\EOTl\NULq\SOH\SUBb A list of extension numbers sent by the server answering\n\
+    \ all_extension_numbers_of_type request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\EOT\SOH\DC2\ETXl\b\US\n\
+    \f\n\
+    \\EOT\EOT\EOT\STX\NUL\DC2\ETXo\STX\FS\SUBY Full name of the base type, including the package name. The format\n\
+    \ is <package>.<type>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\ETXo\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\ETXo\t\ETB\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\ETXo\SUB\ESC\n\
+    \\v\n\
+    \\EOT\EOT\EOT\STX\SOH\DC2\ETXp\STX&\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\EOT\DC2\ETXp\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\ENQ\DC2\ETXp\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\ETXp\DC1!\n\
+    \\f\n\
+    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\ETXp$%\n\
+    \[\n\
+    \\STX\EOT\ENQ\DC2\EOTt\NULx\SOH\SUBO A list of ServiceResponse sent by the server answering list_services request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ENQ\SOH\DC2\ETXt\b\ESC\n\
+    \\131\SOH\n\
+    \\EOT\EOT\ENQ\STX\NUL\DC2\ETXw\STX'\SUBv The information of each service may be expanded in the future, so we use\n\
+    \ ServiceResponse message to encapsulate it.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ENQ\STX\NUL\EOT\DC2\ETXw\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ACK\DC2\ETXw\v\SUB\n\
+    \\f\n\
+    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\ETXw\ESC\"\n\
+    \\f\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\ETXw%&\n\
+    \p\n\
+    \\STX\EOT\ACK\DC2\ENQ|\NUL\128\SOH\SOH\SUBc The information of a single service used by ListServiceResponse to answer\n\
+    \ list_services request.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ACK\SOH\DC2\ETX|\b\ETB\n\
+    \p\n\
+    \\EOT\EOT\ACK\STX\NUL\DC2\ETX\DEL\STX\DC2\SUBc Full name of a registered service, including its package name. The format\n\
+    \ is <package>.<service>\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\ETX\DEL\STX\b\n\
+    \\f\n\
+    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\ETX\DEL\t\r\n\
+    \\f\n\
+    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\ETX\DEL\DLE\DC1\n\
+    \Y\n\
+    \\STX\EOT\a\DC2\ACK\131\SOH\NUL\135\SOH\SOH\SUBK The error code and error message sent by the server when an error occurs.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\a\SOH\DC2\EOT\131\SOH\b\NAK\n\
+    \L\n\
+    \\EOT\EOT\a\STX\NUL\DC2\EOT\133\SOH\STX\ETB\SUB> This field uses the error codes defined in grpc::StatusCode.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\133\SOH\STX\a\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\133\SOH\b\DC2\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\133\SOH\NAK\SYN\n\
+    \\f\n\
+    \\EOT\EOT\a\STX\SOH\DC2\EOT\134\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\134\SOH\STX\b\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\134\SOH\t\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\134\SOH\EM\SUBb\ACKproto3"

--- a/cardano-rpc/gen/Proto/Grpc/Reflection/V1alpha/Reflection_Fields.hs
+++ b/cardano-rpc/gen/Proto/Grpc/Reflection/V1alpha/Reflection_Fields.hs
@@ -1,0 +1,257 @@
+{- This file was auto-generated from grpc/reflection/v1alpha/reflection.proto by the proto-lens-protoc program. -}
+{-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies, UndecidableInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleContexts, FlexibleInstances, PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds, BangPatterns, TypeApplications, OverloadedStrings, DerivingStrategies#-}
+{-# OPTIONS_GHC -Wno-unused-imports#-}
+{-# OPTIONS_GHC -Wno-duplicate-exports#-}
+{-# OPTIONS_GHC -Wno-dodgy-exports#-}
+module Proto.Grpc.Reflection.V1alpha.Reflection_Fields where
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
+allExtensionNumbersOfType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "allExtensionNumbersOfType" a) =>
+  Lens.Family2.LensLike' f s a
+allExtensionNumbersOfType
+  = Data.ProtoLens.Field.field @"allExtensionNumbersOfType"
+allExtensionNumbersResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "allExtensionNumbersResponse" a) =>
+  Lens.Family2.LensLike' f s a
+allExtensionNumbersResponse
+  = Data.ProtoLens.Field.field @"allExtensionNumbersResponse"
+baseTypeName ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "baseTypeName" a) =>
+  Lens.Family2.LensLike' f s a
+baseTypeName = Data.ProtoLens.Field.field @"baseTypeName"
+containingType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "containingType" a) =>
+  Lens.Family2.LensLike' f s a
+containingType = Data.ProtoLens.Field.field @"containingType"
+errorCode ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorCode" a) =>
+  Lens.Family2.LensLike' f s a
+errorCode = Data.ProtoLens.Field.field @"errorCode"
+errorMessage ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorMessage" a) =>
+  Lens.Family2.LensLike' f s a
+errorMessage = Data.ProtoLens.Field.field @"errorMessage"
+errorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "errorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+errorResponse = Data.ProtoLens.Field.field @"errorResponse"
+extensionNumber ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "extensionNumber" a) =>
+  Lens.Family2.LensLike' f s a
+extensionNumber = Data.ProtoLens.Field.field @"extensionNumber"
+fileByFilename ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileByFilename" a) =>
+  Lens.Family2.LensLike' f s a
+fileByFilename = Data.ProtoLens.Field.field @"fileByFilename"
+fileContainingExtension ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileContainingExtension" a) =>
+  Lens.Family2.LensLike' f s a
+fileContainingExtension
+  = Data.ProtoLens.Field.field @"fileContainingExtension"
+fileContainingSymbol ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileContainingSymbol" a) =>
+  Lens.Family2.LensLike' f s a
+fileContainingSymbol
+  = Data.ProtoLens.Field.field @"fileContainingSymbol"
+fileDescriptorProto ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileDescriptorProto" a) =>
+  Lens.Family2.LensLike' f s a
+fileDescriptorProto
+  = Data.ProtoLens.Field.field @"fileDescriptorProto"
+fileDescriptorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "fileDescriptorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+fileDescriptorResponse
+  = Data.ProtoLens.Field.field @"fileDescriptorResponse"
+host ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "host" a) =>
+  Lens.Family2.LensLike' f s a
+host = Data.ProtoLens.Field.field @"host"
+listServices ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "listServices" a) =>
+  Lens.Family2.LensLike' f s a
+listServices = Data.ProtoLens.Field.field @"listServices"
+listServicesResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "listServicesResponse" a) =>
+  Lens.Family2.LensLike' f s a
+listServicesResponse
+  = Data.ProtoLens.Field.field @"listServicesResponse"
+maybe'allExtensionNumbersOfType ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'allExtensionNumbersOfType" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'allExtensionNumbersOfType
+  = Data.ProtoLens.Field.field @"maybe'allExtensionNumbersOfType"
+maybe'allExtensionNumbersResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'allExtensionNumbersResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'allExtensionNumbersResponse
+  = Data.ProtoLens.Field.field @"maybe'allExtensionNumbersResponse"
+maybe'errorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'errorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'errorResponse
+  = Data.ProtoLens.Field.field @"maybe'errorResponse"
+maybe'fileByFilename ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileByFilename" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileByFilename
+  = Data.ProtoLens.Field.field @"maybe'fileByFilename"
+maybe'fileContainingExtension ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileContainingExtension" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileContainingExtension
+  = Data.ProtoLens.Field.field @"maybe'fileContainingExtension"
+maybe'fileContainingSymbol ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileContainingSymbol" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileContainingSymbol
+  = Data.ProtoLens.Field.field @"maybe'fileContainingSymbol"
+maybe'fileDescriptorResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'fileDescriptorResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'fileDescriptorResponse
+  = Data.ProtoLens.Field.field @"maybe'fileDescriptorResponse"
+maybe'listServices ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'listServices" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'listServices
+  = Data.ProtoLens.Field.field @"maybe'listServices"
+maybe'listServicesResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'listServicesResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'listServicesResponse
+  = Data.ProtoLens.Field.field @"maybe'listServicesResponse"
+maybe'messageRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'messageRequest" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'messageRequest
+  = Data.ProtoLens.Field.field @"maybe'messageRequest"
+maybe'messageResponse ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'messageResponse" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'messageResponse
+  = Data.ProtoLens.Field.field @"maybe'messageResponse"
+maybe'originalRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'originalRequest" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'originalRequest
+  = Data.ProtoLens.Field.field @"maybe'originalRequest"
+name ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "name" a) =>
+  Lens.Family2.LensLike' f s a
+name = Data.ProtoLens.Field.field @"name"
+originalRequest ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "originalRequest" a) =>
+  Lens.Family2.LensLike' f s a
+originalRequest = Data.ProtoLens.Field.field @"originalRequest"
+service ::
+  forall f s a.
+  (Prelude.Functor f, Data.ProtoLens.Field.HasField s "service" a) =>
+  Lens.Family2.LensLike' f s a
+service = Data.ProtoLens.Field.field @"service"
+validHost ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "validHost" a) =>
+  Lens.Family2.LensLike' f s a
+validHost = Data.ProtoLens.Field.field @"validHost"
+vec'extensionNumber ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'extensionNumber" a) =>
+  Lens.Family2.LensLike' f s a
+vec'extensionNumber
+  = Data.ProtoLens.Field.field @"vec'extensionNumber"
+vec'fileDescriptorProto ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'fileDescriptorProto" a) =>
+  Lens.Family2.LensLike' f s a
+vec'fileDescriptorProto
+  = Data.ProtoLens.Field.field @"vec'fileDescriptorProto"
+vec'service ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "vec'service" a) =>
+  Lens.Family2.LensLike' f s a
+vec'service = Data.ProtoLens.Field.field @"vec'service"

--- a/cardano-rpc/proto/grpc/reflection/v1/reflection.proto
+++ b/cardano-rpc/proto/grpc/reflection/v1/reflection.proto
@@ -1,0 +1,147 @@
+// Copyright 2016 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Service exported by server reflection.  A more complete description of how
+// server reflection works can be found at
+// https://github.com/grpc/grpc/blob/master/doc/server-reflection.md
+//
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/reflection/v1/reflection.proto
+
+syntax = "proto3";
+
+package grpc.reflection.v1;
+
+option go_package = "google.golang.org/grpc/reflection/grpc_reflection_v1";
+option java_multiple_files = true;
+option java_package = "io.grpc.reflection.v1";
+option java_outer_classname = "ServerReflectionProto";
+
+service ServerReflection {
+  // The reflection service is structured as a bidirectional stream, ensuring
+  // all related requests go to a single server.
+  rpc ServerReflectionInfo(stream ServerReflectionRequest)
+      returns (stream ServerReflectionResponse);
+}
+
+// The message sent by the client when calling ServerReflectionInfo method.
+message ServerReflectionRequest {
+  string host = 1;
+  // To use reflection service, the client should set one of the following
+  // fields in message_request. The server distinguishes requests by their
+  // defined field and then handles them using corresponding methods.
+  oneof message_request {
+    // Find a proto file by the file name.
+    string file_by_filename = 3;
+
+    // Find the proto file that declares the given fully-qualified symbol name.
+    // This field should be a fully-qualified symbol name
+    // (e.g. <package>.<service>[.<method>] or <package>.<type>).
+    string file_containing_symbol = 4;
+
+    // Find the proto file which defines an extension extending the given
+    // message type with the given field number.
+    ExtensionRequest file_containing_extension = 5;
+
+    // Finds the tag numbers used by all known extensions of the given message
+    // type, and appends them to ExtensionNumberResponse in an undefined order.
+    // Its corresponding method is best-effort: it's not guaranteed that the
+    // reflection service will implement this method, and it's not guaranteed
+    // that this method will provide all extensions. Returns
+    // StatusCode::UNIMPLEMENTED if it's not implemented.
+    // This field should be a fully-qualified type name. The format is
+    // <package>.<type>
+    string all_extension_numbers_of_type = 6;
+
+    // List the full names of registered services. The content will not be
+    // checked.
+    string list_services = 7;
+  }
+}
+
+// The type name and extension number sent by the client when requesting
+// file_containing_extension.
+message ExtensionRequest {
+  // Fully-qualified type name. The format should be <package>.<type>
+  string containing_type = 1;
+  int32 extension_number = 2;
+}
+
+// The message sent by the server to answer ServerReflectionInfo method.
+message ServerReflectionResponse {
+  string valid_host = 1;
+  ServerReflectionRequest original_request = 2;
+  // The server sets one of the following fields according to the message_request
+  // in the request.
+  oneof message_response {
+    // This message is used to answer file_by_filename, file_containing_symbol,
+    // file_containing_extension requests with transitive dependencies.
+    // As the repeated label is not allowed in oneof fields, we use a
+    // FileDescriptorResponse message to encapsulate the repeated fields.
+    // The reflection service is allowed to avoid sending FileDescriptorProtos
+    // that were previously sent in response to earlier requests in the stream.
+    FileDescriptorResponse file_descriptor_response = 4;
+
+    // This message is used to answer all_extension_numbers_of_type requests.
+    ExtensionNumberResponse all_extension_numbers_response = 5;
+
+    // This message is used to answer list_services requests.
+    ListServiceResponse list_services_response = 6;
+
+    // This message is used when an error occurs.
+    ErrorResponse error_response = 7;
+  }
+}
+
+// Serialized FileDescriptorProto messages sent by the server answering
+// a file_by_filename, file_containing_symbol, or file_containing_extension
+// request.
+message FileDescriptorResponse {
+  // Serialized FileDescriptorProto messages. We avoid taking a dependency on
+  // descriptor.proto, which uses proto2 only features, by making them opaque
+  // bytes instead.
+  repeated bytes file_descriptor_proto = 1;
+}
+
+// A list of extension numbers sent by the server answering
+// all_extension_numbers_of_type request.
+message ExtensionNumberResponse {
+  // Full name of the base type, including the package name. The format
+  // is <package>.<type>
+  string base_type_name = 1;
+  repeated int32 extension_number = 2;
+}
+
+// A list of ServiceResponse sent by the server answering list_services request.
+message ListServiceResponse {
+  // The information of each service may be expanded in the future, so we use
+  // ServiceResponse message to encapsulate it.
+  repeated ServiceResponse service = 1;
+}
+
+// The information of a single service used by ListServiceResponse to answer
+// list_services request.
+message ServiceResponse {
+  // Full name of a registered service, including its package name. The format
+  // is <package>.<service>
+  string name = 1;
+}
+
+// The error code and error message sent by the server when an error occurs.
+message ErrorResponse {
+  // This field uses the error codes defined in grpc::StatusCode.
+  int32 error_code = 1;
+  string error_message = 2;
+}
+

--- a/cardano-rpc/proto/grpc/reflection/v1alpha/reflection.proto
+++ b/cardano-rpc/proto/grpc/reflection/v1alpha/reflection.proto
@@ -1,0 +1,136 @@
+// Copyright 2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Service exported by server reflection
+
+syntax = "proto3";
+
+package grpc.reflection.v1alpha;
+
+service ServerReflection {
+  // The reflection service is structured as a bidirectional stream, ensuring
+  // all related requests go to a single server.
+  rpc ServerReflectionInfo(stream ServerReflectionRequest)
+      returns (stream ServerReflectionResponse);
+}
+
+// The message sent by the client when calling ServerReflectionInfo method.
+message ServerReflectionRequest {
+  string host = 1;
+  // To use reflection service, the client should set one of the following
+  // fields in message_request. The server distinguishes requests by their
+  // defined field and then handles them using corresponding methods.
+  oneof message_request {
+    // Find a proto file by the file name.
+    string file_by_filename = 3;
+
+    // Find the proto file that declares the given fully-qualified symbol name.
+    // This field should be a fully-qualified symbol name
+    // (e.g. <package>.<service>[.<method>] or <package>.<type>).
+    string file_containing_symbol = 4;
+
+    // Find the proto file which defines an extension extending the given
+    // message type with the given field number.
+    ExtensionRequest file_containing_extension = 5;
+
+    // Finds the tag numbers used by all known extensions of the given message
+    // type, and appends them to ExtensionNumberResponse in an undefined order.
+    // Its corresponding method is best-effort: it's not guaranteed that the
+    // reflection service will implement this method, and it's not guaranteed
+    // that this method will provide all extensions. Returns
+    // StatusCode::UNIMPLEMENTED if it's not implemented.
+    // This field should be a fully-qualified type name. The format is
+    // <package>.<type>
+    string all_extension_numbers_of_type = 6;
+
+    // List the full names of registered services. The content will not be
+    // checked.
+    string list_services = 7;
+  }
+}
+
+// The type name and extension number sent by the client when requesting
+// file_containing_extension.
+message ExtensionRequest {
+  // Fully-qualified type name. The format should be <package>.<type>
+  string containing_type = 1;
+  int32 extension_number = 2;
+}
+
+// The message sent by the server to answer ServerReflectionInfo method.
+message ServerReflectionResponse {
+  string valid_host = 1;
+  ServerReflectionRequest original_request = 2;
+  // The server set one of the following fields accroding to the message_request
+  // in the request.
+  oneof message_response {
+    // This message is used to answer file_by_filename, file_containing_symbol,
+    // file_containing_extension requests with transitive dependencies. As
+    // the repeated label is not allowed in oneof fields, we use a
+    // FileDescriptorResponse message to encapsulate the repeated fields.
+    // The reflection service is allowed to avoid sending FileDescriptorProtos
+    // that were previously sent in response to earlier requests in the stream.
+    FileDescriptorResponse file_descriptor_response = 4;
+
+    // This message is used to answer all_extension_numbers_of_type requst.
+    ExtensionNumberResponse all_extension_numbers_response = 5;
+
+    // This message is used to answer list_services request.
+    ListServiceResponse list_services_response = 6;
+
+    // This message is used when an error occurs.
+    ErrorResponse error_response = 7;
+  }
+}
+
+// Serialized FileDescriptorProto messages sent by the server answering
+// a file_by_filename, file_containing_symbol, or file_containing_extension
+// request.
+message FileDescriptorResponse {
+  // Serialized FileDescriptorProto messages. We avoid taking a dependency on
+  // descriptor.proto, which uses proto2 only features, by making them opaque
+  // bytes instead.
+  repeated bytes file_descriptor_proto = 1;
+}
+
+// A list of extension numbers sent by the server answering
+// all_extension_numbers_of_type request.
+message ExtensionNumberResponse {
+  // Full name of the base type, including the package name. The format
+  // is <package>.<type>
+  string base_type_name = 1;
+  repeated int32 extension_number = 2;
+}
+
+// A list of ServiceResponse sent by the server answering list_services request.
+message ListServiceResponse {
+  // The information of each service may be expanded in the future, so we use
+  // ServiceResponse message to encapsulate it.
+  repeated ServiceResponse service = 1;
+}
+
+// The information of a single service used by ListServiceResponse to answer
+// list_services request.
+message ServiceResponse {
+  // Full name of a registered service, including its package name. The format
+  // is <package>.<service>
+  string name = 1;
+}
+
+// The error code and error message sent by the server when an error occurs.
+message ErrorResponse {
+  // This field uses the error codes defined in grpc::StatusCode.
+  int32 error_code = 1;
+  string error_message = 2;
+}

--- a/cardano-rpc/src/Cardano/Rpc/Proto/Api/Reflection/V1.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Proto/Api/Reflection/V1.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Rpc.Proto.Api.Reflection.V1
+  ( module Proto.Grpc.Reflection.V1.Reflection
+  , module Proto.Grpc.Reflection.V1.Reflection_Fields
+  )
+where
+
+import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
+
+import Proto.Grpc.Reflection.V1.Reflection
+import Proto.Grpc.Reflection.V1.Reflection_Fields
+
+type instance RequestMetadata (Protobuf ServerReflection meth) = NoMetadata
+
+type instance ResponseInitialMetadata (Protobuf ServerReflection meth) = NoMetadata
+
+type instance ResponseTrailingMetadata (Protobuf ServerReflection meth) = NoMetadata

--- a/cardano-rpc/src/Cardano/Rpc/Proto/Api/Reflection/V1alpha.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Proto/Api/Reflection/V1alpha.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Rpc.Proto.Api.Reflection.V1alpha
+  ( module Proto.Grpc.Reflection.V1alpha.Reflection
+  , module Proto.Grpc.Reflection.V1alpha.Reflection_Fields
+  )
+where
+
+import Network.GRPC.Common
+import Network.GRPC.Common.Protobuf
+
+import Proto.Grpc.Reflection.V1alpha.Reflection
+import Proto.Grpc.Reflection.V1alpha.Reflection_Fields
+
+type instance RequestMetadata (Protobuf ServerReflection meth) = NoMetadata
+
+type instance ResponseInitialMetadata (Protobuf ServerReflection meth) = NoMetadata
+
+type instance ResponseTrailingMetadata (Protobuf ServerReflection meth) = NoMetadata

--- a/cardano-rpc/src/Cardano/Rpc/Server.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server.hs
@@ -7,11 +7,13 @@
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.Rpc.Server
   ( runRpcServer
   , NodeKernelAccess
   , mkNodeKernelAccess
+  , registeredServiceNames
 
     -- * Traces
   , TraceRpc (..)
@@ -25,6 +27,8 @@ where
 
 import Cardano.Api
 import Cardano.Rpc.Proto.Api.Node qualified as Rpc
+import Cardano.Rpc.Proto.Api.Reflection.V1 qualified as ReflectionV1
+import Cardano.Rpc.Proto.Api.Reflection.V1alpha qualified as ReflectionV1alpha
 import Cardano.Rpc.Proto.Api.UtxoRpc.Query qualified as UtxoRpc
 import Cardano.Rpc.Proto.Api.UtxoRpc.Submit qualified as UtxoRpc
 import Cardano.Rpc.Proto.Api.UtxoRpc.Sync qualified as UtxoRpc
@@ -34,6 +38,11 @@ import Cardano.Rpc.Server.Internal.Error (renderRpcExceptionForClient)
 import Cardano.Rpc.Server.Internal.Monad
 import Cardano.Rpc.Server.Internal.Node
 import Cardano.Rpc.Server.Internal.Orphans ()
+import Cardano.Rpc.Server.Internal.Reflection
+  ( qualifiedServiceName
+  , serverReflectionInfoMethodV1
+  , serverReflectionInfoMethodV1alpha
+  )
 import Cardano.Rpc.Server.Internal.Tracing
 import Cardano.Rpc.Server.Internal.UtxoRpc.Eval
 import Cardano.Rpc.Server.Internal.UtxoRpc.Query
@@ -107,6 +116,42 @@ methodsSyncRpc =
     . Method (mkNonStreaming $ wrapInSpan TraceRpcReadTipSpan . readTipMethod)
     $ NoMoreMethods
 
+-- | gRPC method table for the Server Reflection API's @v1@ service.
+methodsReflectionV1
+  :: MonadIO m
+  => Methods m (ProtobufMethodsOf ReflectionV1.ServerReflection)
+methodsReflectionV1 =
+  Method (mkBiDiStreaming $ serverReflectionInfoMethodV1 registeredServiceNames) $
+    NoMoreMethods
+
+-- | gRPC method table for the Server Reflection API's legacy @v1alpha@ service.
+methodsReflectionV1alpha
+  :: MonadIO m
+  => Methods m (ProtobufMethodsOf ReflectionV1alpha.ServerReflection)
+methodsReflectionV1alpha =
+  Method (mkBiDiStreaming $ serverReflectionInfoMethodV1alpha registeredServiceNames) $
+    NoMoreMethods
+
+-- | Every service this server registers, paired with its handler methods
+-- in one list, so the name registered with grapesy and the name advertised
+-- by the Server Reflection API's @list_services@ ('registeredServiceNames')
+-- can never drift apart - unlike two hand-maintained lists, this cannot go
+-- out of sync by construction.
+registeredServices :: [(Text, [SomeRpcHandler (RIO RpcEnv)])]
+registeredServices =
+  [ (qualifiedServiceName @Rpc.Node, fromMethods methodsNodeRpc)
+  , (qualifiedServiceName @UtxoRpc.QueryService, fromMethods methodsUtxoRpc)
+  , (qualifiedServiceName @UtxoRpc.SubmitService, fromMethods methodsUtxoRpcSubmit)
+  , (qualifiedServiceName @UtxoRpc.SyncService, fromMethods methodsSyncRpc)
+  , (qualifiedServiceName @ReflectionV1.ServerReflection, fromMethods methodsReflectionV1)
+  , (qualifiedServiceName @ReflectionV1alpha.ServerReflection, fromMethods methodsReflectionV1alpha)
+  ]
+
+-- | Fully qualified names of every service this server registers, for the
+-- Server Reflection API's @list_services@.
+registeredServiceNames :: [Text]
+registeredServiceNames = map fst registeredServices
+
 -- | Start the gRPC server, registering all RPC service handlers.
 -- Does nothing when the RPC server is disabled in configuration.
 runRpcServer
@@ -169,12 +214,7 @@ runRpcServer tracer rpcConfig networkMagic nodeKernelAccessRef = handleFatalExce
     runRIO rpcEnv $
       withRunInIO $ \runInIO ->
         runServer http2Settings config <=< mkGrpcServer serverParams . fmap (hoistSomeRpcHandler runInIO) $
-          mconcat
-            [ fromMethods methodsNodeRpc
-            , fromMethods methodsUtxoRpc
-            , fromMethods methodsUtxoRpcSubmit
-            , fromMethods methodsSyncRpc
-            ]
+          mconcat (map snd registeredServices)
  where
   serverParams :: ServerParams
   serverParams =

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Reflection.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Reflection.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Handler for the gRPC Server Reflection API
+-- (<https://github.com/grpc/grpc/blob/master/doc/server-reflection.md>),
+-- @grpc.reflection.v1@ and the older @grpc.reflection.v1alpha@. This lets
+-- generic clients (e.g. @grpcurl@) discover and decode this server's proto
+-- services without a local copy of the @.proto@ files.
+module Cardano.Rpc.Server.Internal.Reflection
+  ( serverReflectionInfoMethodV1
+  , serverReflectionInfoMethodV1alpha
+  , answerReflectionRequest
+  , qualifiedServiceName
+  )
+where
+
+import Cardano.Rpc.Proto.Api.Reflection.V1 qualified as V1
+import Cardano.Rpc.Proto.Api.Reflection.V1alpha qualified as V1alpha
+import Cardano.Rpc.Server.Internal.Error (throwGrpcErrorWithMessage)
+import Cardano.Rpc.Server.Internal.Reflection.DescriptorTable
+
+import RIO
+
+import Data.ProtoLens (Message, decodeMessage, defMessage, encodeMessage)
+import Data.ProtoLens.Service.Types (Service, ServiceName, ServicePackage)
+import Data.Text qualified as Text
+import GHC.TypeLits (symbolVal)
+import Network.GRPC.Spec
+  ( GrpcError (GrpcInternal, GrpcInvalidArgument, GrpcNotFound)
+  , NextElem (NextElem, NoNextElem)
+  , Proto (Proto)
+  , fromGrpcError
+  )
+
+-- | Handle the @ServerReflectionInfo@ bidirectional stream for
+-- @grpc.reflection.v1@: answer every request on the incoming stream in
+-- turn, then forward the client's own terminal marker. A bidi handler that
+-- returns without sending 'NoNextElem' itself has its stream cancelled
+-- instead of closed with trailers, the same requirement as for
+-- server-streaming handlers (both go through grapesy's identical
+-- @sendOutput call . fromNextElem call@ path).
+serverReflectionInfoMethodV1
+  :: MonadIO m
+  => [Text]
+  -- ^ Fully qualified names of every service registered with this server,
+  -- answered verbatim for @list_services@
+  -> IO (NextElem (Proto V1.ServerReflectionRequest))
+  -> (NextElem (Proto V1.ServerReflectionResponse) -> IO ())
+  -> m ()
+serverReflectionInfoMethodV1 serviceNames recv send = liftIO loop
+ where
+  loop =
+    recv >>= \case
+      NoNextElem -> send NoNextElem
+      NextElem request -> do
+        send . NextElem $ answerReflectionRequest descriptorTable serviceNames request
+        loop
+
+-- | Handle the same stream for the legacy @grpc.reflection.v1alpha@, by
+-- bridging each message to and from @v1@ and answering with the one core
+-- 'answerReflectionRequest'.
+serverReflectionInfoMethodV1alpha
+  :: MonadIO m
+  => [Text]
+  -- ^ Fully qualified names of every service registered with this server,
+  -- answered verbatim for @list_services@
+  -> IO (NextElem (Proto V1alpha.ServerReflectionRequest))
+  -> (NextElem (Proto V1alpha.ServerReflectionResponse) -> IO ())
+  -> m ()
+serverReflectionInfoMethodV1alpha serviceNames recv send = liftIO loop
+ where
+  loop =
+    recv >>= \case
+      NoNextElem -> send NoNextElem
+      NextElem request -> do
+        v1Request <- bridgeMessage request
+        v1alphaResponse <- bridgeMessage (answerReflectionRequest descriptorTable serviceNames v1Request)
+        send $ NextElem v1alphaResponse
+        loop
+
+-- | Answer one @ServerReflectionRequest@, dispatching on its
+-- @message_request@ oneof.
+--
+-- Lookup failures ('V1.FileByFilename', 'V1.FileContainingSymbol') are
+-- reported in-stream as an @ErrorResponse@ with @NOT_FOUND@, never as a
+-- gRPC error: the RPC itself stays OK for the life of the stream.
+-- No proto file served here declares proto2 extensions, so
+-- @file_containing_extension@ always answers @NOT_FOUND@, while
+-- @all_extension_numbers_of_type@ answers an empty @ExtensionNumberResponse@
+-- for a type the server knows and @NOT_FOUND@ for one it does not.
+answerReflectionRequest
+  :: DescriptorTable
+  -> [Text]
+  -> Proto V1.ServerReflectionRequest
+  -> Proto V1.ServerReflectionResponse
+answerReflectionRequest table serviceNames request =
+  defMessage
+    & V1.validHost .~ (request ^. V1.host)
+    & V1.originalRequest .~ request
+    & answer
+ where
+  answer :: Proto V1.ServerReflectionResponse -> Proto V1.ServerReflectionResponse
+  answer = case request ^. V1.maybe'messageRequest of
+    -- proto3 leaves message_request entirely unset when malformed by the
+    -- client; there is no lookup to fail here, so this is INVALID_ARGUMENT
+    -- rather than NOT_FOUND. Answering in-stream here matches grpc's
+    -- canonical C++ implementation; Go instead terminates the RPC.
+    Nothing ->
+      V1.errorResponse .~ mkErrorResponse GrpcInvalidArgument "no message_request set"
+    Just (Proto messageRequest) -> case messageRequest of
+      V1.ServerReflectionRequest'FileByFilename fileName ->
+        fileDescriptorAnswer fileName
+      V1.ServerReflectionRequest'FileContainingSymbol symbolName ->
+        case lookupSymbol table symbolName of
+          Nothing -> V1.errorResponse .~ mkErrorResponse GrpcNotFound ("symbol not found: " <> symbolName)
+          Just fileName -> fileDescriptorAnswer fileName
+      V1.ServerReflectionRequest'FileContainingExtension extensionRequest ->
+        V1.errorResponse
+          .~ mkErrorResponse
+            GrpcNotFound
+            ( "no extensions are declared by this server (requested for type: "
+                <> (Proto extensionRequest ^. V1.containingType)
+                <> ")"
+            )
+      V1.ServerReflectionRequest'AllExtensionNumbersOfType typeName ->
+        case lookupSymbol table typeName of
+          Nothing -> V1.errorResponse .~ mkErrorResponse GrpcNotFound ("type not found: " <> typeName)
+          Just _ -> V1.allExtensionNumbersResponse .~ (defMessage & V1.baseTypeName .~ typeName)
+      V1.ServerReflectionRequest'ListServices _ ->
+        V1.listServicesResponse
+          .~ (defMessage & V1.service .~ map (\serviceName -> defMessage & V1.name .~ serviceName) serviceNames)
+
+  fileDescriptorAnswer
+    :: Text -> Proto V1.ServerReflectionResponse -> Proto V1.ServerReflectionResponse
+  fileDescriptorAnswer fileName = case transitiveClosure table fileName of
+    Nothing -> V1.errorResponse .~ mkErrorResponse GrpcNotFound ("file not found: " <> fileName)
+    Just entries ->
+      V1.fileDescriptorResponse .~ (defMessage & V1.fileDescriptorProto .~ map fileEntryBytes entries)
+
+  mkErrorResponse :: GrpcError -> Text -> Proto V1.ErrorResponse
+  mkErrorResponse grpcError message =
+    defMessage
+      & V1.errorCode .~ fromIntegral (fromGrpcError grpcError)
+      & V1.errorMessage .~ message
+
+-- | Re-encode a message as a wire-compatible message with different
+-- generated Haskell types. Safe between schemas that agree on every field
+-- number and wire type, which @v1@ and @v1alpha@ of the reflection protos
+-- do (@v1alpha@ is @v1@ under its original package name); a future schema
+-- divergence is reported as an @INTERNAL@ gRPC error rather than a panic.
+bridgeMessage :: (Message a, Message b, MonadIO m) => Proto a -> m (Proto b)
+bridgeMessage message =
+  either (throwGrpcErrorWithMessage GrpcInternal . ("bridgeMessage: " <>) . Text.pack) pure $
+    decodeMessage (encodeMessage message)
+
+-- | The fully qualified name of a proto service, @\<package\>.\<Service\>@,
+-- read off its own compiled-in descriptor via proto-lens's 'Service' class.
+-- Deriving it this way, rather than writing out the string, means the name
+-- paired with each service's handler in "Cardano.Rpc.Server" and the name
+-- 'answerReflectionRequest' (above) advertises for @list_services@ can
+-- never drift apart.
+qualifiedServiceName :: forall s. Service s => Text
+qualifiedServiceName =
+  Text.pack (symbolVal (Proxy @(ServicePackage s)))
+    <> "."
+    <> Text.pack (symbolVal (Proxy @(ServiceName s)))

--- a/cardano-rpc/src/Cardano/Rpc/Server/Internal/Reflection/DescriptorTable.hs
+++ b/cardano-rpc/src/Cardano/Rpc/Server/Internal/Reflection/DescriptorTable.hs
@@ -1,0 +1,181 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | The proto file descriptors served by the gRPC Server Reflection API,
+-- compiled into this binary, plus a package-qualified symbol index over
+-- their contents (services, methods, messages, fields, oneofs, enums and
+-- enum values).
+--
+-- Every proto file cardano-rpc serves is represented here by one
+-- 'FileEntry', keyed by the file name embedded in its own descriptor (e.g.
+-- @"cardano/rpc/node.proto"@), which is also how dependent files refer to
+-- it in their own @dependency@ list.
+module Cardano.Rpc.Server.Internal.Reflection.DescriptorTable
+  ( FileEntry (..)
+  , DescriptorTable
+  , descriptorTable
+  , fileNames
+  , lookupFile
+  , lookupSymbol
+  , transitiveClosure
+  , fileSymbolNames
+  )
+where
+
+import RIO
+
+import Data.Map.Strict qualified as Map
+import Data.ProtoLens (Message, packedFileDescriptor)
+import Data.ProtoLens.Descriptor (fileDescriptor)
+import Data.Set qualified as Set
+import Data.Text qualified as Text
+
+import Proto.Cardano.Rpc.Node (CurrentEra)
+import Proto.Google.Protobuf.Descriptor
+import Proto.Google.Protobuf.Descriptor_Fields qualified as Descriptor
+import Proto.Google.Protobuf.Empty (Empty)
+import Proto.Google.Protobuf.FieldMask (FieldMask)
+import Proto.Grpc.Reflection.V1.Reflection qualified as ReflectionV1
+import Proto.Grpc.Reflection.V1alpha.Reflection qualified as ReflectionV1alpha
+import Proto.Utxorpc.V1beta.Cardano.Cardano (TxInput)
+import Proto.Utxorpc.V1beta.Query.Query (ReadParamsRequest)
+import Proto.Utxorpc.V1beta.Submit.Submit (SubmitTxRequest)
+import Proto.Utxorpc.V1beta.Sync.Sync (FollowTipRequest)
+
+-- | The descriptor table for every proto file this server's gRPC API is
+-- built from: the six services it registers, plus the well-known
+-- @google.protobuf@ types and the reflection protos themselves.
+descriptorTable :: DescriptorTable
+descriptorTable =
+  DescriptorTable
+    { descriptorTableFileIndex =
+        Map.fromList [(fileEntryDescriptor entry ^. Descriptor.name, entry) | entry <- entries]
+    , descriptorTableSymbolIndex =
+        Map.fromList
+          [ (symbolName, fileEntryDescriptor entry ^. Descriptor.name)
+          | entry <- entries
+          , symbolName <- fileSymbolNames (fileEntryDescriptor entry)
+          ]
+    }
+ where
+  entries =
+    [ mkFileEntry @CurrentEra
+    , mkFileEntry @TxInput
+    , mkFileEntry @ReadParamsRequest
+    , mkFileEntry @SubmitTxRequest
+    , mkFileEntry @FollowTipRequest
+    , mkFileEntry @Empty
+    , mkFileEntry @FieldMask
+    , mkFileEntry @ReflectionV1.ServerReflectionRequest
+    , mkFileEntry @ReflectionV1alpha.ServerReflectionRequest
+    ]
+
+-- | Resolve a fully qualified symbol - a service, method, message, nested
+-- message, field, oneof, enum, or enum value name - to the file that
+-- declares it.
+lookupSymbol :: DescriptorTable -> Text -> Maybe Text
+lookupSymbol table symbolName = Map.lookup symbolName (descriptorTableSymbolIndex table)
+
+-- | The named file, plus every file it transitively depends on, in
+-- traversal order with the file itself first, deduplicated. 'Nothing' if
+-- the file itself is not in the table; a dependency that is missing from
+-- the table (which should not happen - see the table's closure invariant)
+-- is silently skipped rather than failing the whole lookup.
+transitiveClosure :: DescriptorTable -> Text -> Maybe [FileEntry]
+transitiveClosure table rootName = do
+  rootEntry <- lookupFile table rootName
+  pure $
+    rootEntry : go (Set.singleton rootName) (fileEntryDescriptor rootEntry ^. Descriptor.dependency)
+ where
+  go _ [] = []
+  go seen (depName : rest)
+    | depName `Set.member` seen = go seen rest
+    | otherwise = case lookupFile table depName of
+        Nothing -> go (Set.insert depName seen) rest
+        Just depEntry ->
+          depEntry
+            : go (Set.insert depName seen) (rest <> fileEntryDescriptor depEntry ^. Descriptor.dependency)
+
+-- | Look up a file by name (e.g. @"cardano/rpc/node.proto"@).
+lookupFile :: DescriptorTable -> Text -> Maybe FileEntry
+lookupFile table fileName = Map.lookup fileName (descriptorTableFileIndex table)
+
+-- | The name of every served proto file.
+fileNames :: DescriptorTable -> [Text]
+fileNames = Map.keys . descriptorTableFileIndex
+
+-- | Build the 'FileEntry' for the proto file containing @msg@, using one
+-- representative message type per file (any message declared in the file
+-- works - 'packedFileDescriptor'\/'fileDescriptor' both resolve to the whole
+-- containing file, not just @msg@ itself).
+mkFileEntry :: forall msg. Message msg => FileEntry
+mkFileEntry =
+  FileEntry
+    { fileEntryDescriptor = fileDescriptor @msg
+    , fileEntryBytes = packedFileDescriptor (Proxy @msg)
+    }
+
+-- | Every package-qualified symbol a file declares: its services (and their
+-- methods), top-level and nested messages (and their fields and oneofs),
+-- and top-level and nested enums (and their values).
+fileSymbolNames :: FileDescriptorProto -> [Text]
+fileSymbolNames descriptor =
+  concatMap (serviceSymbolNames packageName) (descriptor ^. Descriptor.service)
+    <> concatMap (messageSymbolNames packageName) (descriptor ^. Descriptor.messageType)
+    <> concatMap (enumSymbolNames packageName) (descriptor ^. Descriptor.enumType)
+ where
+  packageName = descriptor ^. Descriptor.package
+
+-- | A service's own symbol, plus one per method it declares.
+serviceSymbolNames :: Text -> ServiceDescriptorProto -> [Text]
+serviceSymbolNames packageName service =
+  serviceName : map (qualify serviceName . (^. Descriptor.name)) (service ^. Descriptor.method)
+ where
+  serviceName = qualify packageName (service ^. Descriptor.name)
+
+-- | A message's own symbol, plus every symbol nested inside it, recursively:
+-- its fields and oneof declarations (both scoped to the message itself,
+-- like enum values are), its nested messages, and its nested enums.
+messageSymbolNames :: Text -> DescriptorProto -> [Text]
+messageSymbolNames enclosingName message =
+  messageName
+    : concatMap (messageSymbolNames messageName) (message ^. Descriptor.nestedType)
+      <> concatMap (enumSymbolNames messageName) (message ^. Descriptor.enumType)
+      <> map (qualify messageName . (^. Descriptor.name)) (message ^. Descriptor.field)
+      <> map (qualify messageName . (^. Descriptor.name)) (message ^. Descriptor.oneofDecl)
+ where
+  messageName = qualify enclosingName (message ^. Descriptor.name)
+
+-- | An enum's own symbol, plus one per value it declares. Protobuf scopes
+-- an enum VALUE's fully qualified name to the enum's own enclosing scope
+-- (the package, or the containing message), not to the enum type itself,
+-- so a value's symbol is a SIBLING of its enum's symbol, not nested under
+-- it - e.g. @cardano.rpc.conway@, not @cardano.rpc.Era.conway@.
+enumSymbolNames :: Text -> EnumDescriptorProto -> [Text]
+enumSymbolNames enclosingName enum =
+  qualify enclosingName (enum ^. Descriptor.name)
+    : map (qualify enclosingName . (^. Descriptor.name)) (enum ^. Descriptor.value)
+
+-- | Join a package\/enclosing-message prefix and a name with a dot, or just
+-- the name if the prefix is empty (a file with no @package@ declaration).
+qualify :: Text -> Text -> Text
+qualify prefix name
+  | Text.null prefix = name
+  | otherwise = prefix <> "." <> name
+
+-- | One served proto file: its decoded descriptor, used to walk dependencies
+-- and resolve symbols, and the packed bytes of that same descriptor, sent
+-- verbatim in a @FileDescriptorResponse@.
+data FileEntry = FileEntry
+  { fileEntryDescriptor :: FileDescriptorProto
+  , fileEntryBytes :: ByteString
+  }
+  deriving (Eq, Show)
+
+data DescriptorTable = DescriptorTable
+  { descriptorTableFileIndex :: Map Text FileEntry
+  , descriptorTableSymbolIndex :: Map Text Text
+  -- ^ Fully qualified symbol (service, method, message, field, oneof, enum,
+  -- or enum value name) to the file name that declares it.
+  }

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/Reflection.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/Reflection.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE LambdaCase #-}
+
+-- | Unit coverage for the gRPC Server Reflection handler
+-- ('Cardano.Rpc.Server.Internal.Reflection'): request dispatch via
+-- 'answerReflectionRequest', and the bidirectional stream's termination
+-- behaviour and @v1@\/@v1alpha@ bridging.
+module Test.Cardano.Rpc.Reflection where
+
+import Cardano.Rpc.Proto.Api.Reflection.V1 qualified as V1
+import Cardano.Rpc.Proto.Api.Reflection.V1alpha qualified as V1alpha
+import Cardano.Rpc.Server (registeredServiceNames)
+import Cardano.Rpc.Server.Internal.Reflection
+import Cardano.Rpc.Server.Internal.Reflection.DescriptorTable
+  ( descriptorTable
+  , fileEntryBytes
+  , lookupSymbol
+  , transitiveClosure
+  )
+
+import RIO
+
+import Data.ProtoLens (defMessage)
+import Data.Text qualified as Text
+import Network.GRPC.Spec (NextElem (NextElem, NoNextElem))
+
+import Hedgehog as H
+import Hedgehog.Extras qualified as H
+
+-- | The server registers exactly six services, under exactly these names.
+-- "Cardano.Rpc.Server" derives 'registeredServiceNames' from the same list
+-- that supplies the registered handlers, so the two cannot drift apart by
+-- construction; this pins the list's actual contents instead. Every name
+-- must also resolve via the descriptor table, since @list_services@
+-- answering a name whose file was never registered there would make the
+-- reflection API self-inconsistent.
+hprop_registered_service_names :: Property
+hprop_registered_service_names = H.propertyOnce $ do
+  registeredServiceNames
+    === [ "cardano.rpc.Node"
+        , "utxorpc.v1beta.query.QueryService"
+        , "utxorpc.v1beta.submit.SubmitService"
+        , "utxorpc.v1beta.sync.SyncService"
+        , "grpc.reflection.v1.ServerReflection"
+        , "grpc.reflection.v1alpha.ServerReflection"
+        ]
+  forM_ registeredServiceNames $ \serviceName ->
+    H.assertWith serviceName (isJust . lookupSymbol descriptorTable)
+
+-- | @list_services@ answers with exactly the given names, regardless of the
+-- request's (unchecked, per spec) payload string.
+hprop_list_services_returns_given_names :: Property
+hprop_list_services_returns_given_names = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.listServices .~ "ignored"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  map (^. V1.name) (response ^. V1.listServicesResponse . V1.service) === testServiceNames
+  response ^. V1.originalRequest === request
+  response ^. V1.validHost === "localhost"
+
+-- | @file_by_filename@ for a known file answers with its full transitive
+-- dependency closure, file first.
+hprop_file_by_filename_returns_full_closure :: Property
+hprop_file_by_filename_returns_full_closure = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.fileByFilename .~ "cardano/rpc/node.proto"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  expectedEntries <- H.nothingFail $ transitiveClosure descriptorTable "cardano/rpc/node.proto"
+  response ^. V1.fileDescriptorResponse . V1.fileDescriptorProto
+    === map fileEntryBytes expectedEntries
+
+-- | @file_by_filename@ for an unknown file answers in-stream with
+-- @NOT_FOUND@ (error code 5), never a gRPC error.
+hprop_file_by_filename_not_found :: Property
+hprop_file_by_filename_not_found = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.fileByFilename .~ "does/not/exist.proto"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.originalRequest === request
+  response ^. V1.errorResponse . V1.errorCode === 5
+  H.assertWith
+    (response ^. V1.errorResponse . V1.errorMessage)
+    ("does/not/exist.proto" `Text.isInfixOf`)
+
+-- | @file_containing_symbol@ for a known symbol answers with the closure of
+-- the file that declares it.
+hprop_file_containing_symbol_found :: Property
+hprop_file_containing_symbol_found = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.fileContainingSymbol .~ "cardano.rpc.Node"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  expectedEntries <- H.nothingFail $ transitiveClosure descriptorTable "cardano/rpc/node.proto"
+  response ^. V1.fileDescriptorResponse . V1.fileDescriptorProto
+    === map fileEntryBytes expectedEntries
+
+-- | @file_containing_symbol@ for an unknown symbol answers @NOT_FOUND@.
+hprop_file_containing_symbol_unknown :: Property
+hprop_file_containing_symbol_unknown = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.fileContainingSymbol .~ "no.such.Symbol"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.errorResponse . V1.errorCode === 5
+
+-- | @file_containing_extension@ always answers @NOT_FOUND@: none of the
+-- proto files served here declare proto2 extensions.
+hprop_file_containing_extension_is_not_found :: Property
+hprop_file_containing_extension_is_not_found = H.propertyOnce $ do
+  let extensionRequest = defMessage & V1.containingType .~ "some.Type" & V1.extensionNumber .~ 7
+      request = defMessage & V1.host .~ "localhost" & V1.fileContainingExtension .~ extensionRequest
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.errorResponse . V1.errorCode === 5
+
+-- | @all_extension_numbers_of_type@ answers @NOT_FOUND@ for a type this
+-- server does not declare.
+hprop_all_extension_numbers_of_unknown_type_is_not_found :: Property
+hprop_all_extension_numbers_of_unknown_type_is_not_found = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.allExtensionNumbersOfType .~ "some.Type"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.errorResponse . V1.errorCode === 5
+
+-- | For a type it does declare, the answer is an empty
+-- @ExtensionNumberResponse@ naming that type rather than an error: the
+-- lookup succeeded and found no extensions, every proto here being proto3.
+hprop_all_extension_numbers_of_known_type_is_empty :: Property
+hprop_all_extension_numbers_of_known_type_is_empty = H.propertyOnce $ do
+  let request =
+        defMessage
+          & V1.host .~ "localhost"
+          & V1.allExtensionNumbersOfType .~ "cardano.rpc.CurrentEra"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.maybe'errorResponse === Nothing
+  response ^. V1.allExtensionNumbersResponse . V1.baseTypeName === "cardano.rpc.CurrentEra"
+  response ^. V1.allExtensionNumbersResponse . V1.extensionNumber === []
+
+-- | A request with no @message_request@ set at all is a malformed request,
+-- not a failed lookup, so it answers @INVALID_ARGUMENT@ (error code 3)
+-- rather than @NOT_FOUND@.
+hprop_unset_message_request_is_invalid_argument :: Property
+hprop_unset_message_request_is_invalid_argument = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost"
+      response = answerReflectionRequest descriptorTable testServiceNames request
+  response ^. V1.errorResponse . V1.errorCode === 3
+
+-- | The @v1@ handler sends the client's own terminal marker after
+-- answering every request: one response per request, plus a final
+-- 'NoNextElem'. A handler that omitted this would have its stream
+-- cancelled instead of closed with trailers.
+hprop_server_reflection_info_v1_sends_terminal_marker :: Property
+hprop_server_reflection_info_v1_sends_terminal_marker = H.propertyOnce $ do
+  let request = defMessage & V1.host .~ "localhost" & V1.listServices .~ "x"
+  sent <- runScriptedBidi (serverReflectionInfoMethodV1 testServiceNames) [request]
+  H.annotateShow sent
+  length sent === 2
+  lastElement <- H.nothingFail $ listToMaybe (reverse sent)
+  lastElement === NoNextElem
+
+-- | The @v1alpha@ handler answers using the same registry and service
+-- names as @v1@, bridging each message across the wire-compatible schemas:
+-- a @list_services@ round trip through it returns the same names.
+hprop_server_reflection_info_v1alpha_bridges_to_v1 :: Property
+hprop_server_reflection_info_v1alpha_bridges_to_v1 = H.propertyOnce $ do
+  let request = defMessage & V1alpha.host .~ "localhost" & V1alpha.listServices .~ "x"
+  sent <- runScriptedBidi (serverReflectionInfoMethodV1alpha testServiceNames) [request]
+  response <- H.nothingFail $ listToMaybe [r | NextElem r <- sent]
+  map (^. V1alpha.name) (response ^. V1alpha.listServicesResponse . V1alpha.service)
+    === testServiceNames
+
+-- | Drive a bidi handler with a fixed list of requests followed by the
+-- client's own terminal marker, capturing every element it sends.
+runScriptedBidi
+  :: MonadIO m
+  => (IO (NextElem req) -> (NextElem resp -> IO ()) -> IO ())
+  -> [req]
+  -> m [NextElem resp]
+runScriptedBidi handler requests = liftIO $ do
+  pending <- newIORef (map NextElem requests <> [NoNextElem])
+  sentRef <- newIORef []
+  let recv =
+        readIORef pending >>= \case
+          [] -> pure NoNextElem
+          next : rest -> writeIORef pending rest $> next
+      send nextElem = modifyIORef' sentRef (nextElem :)
+  handler recv send
+  reverse <$> readIORef sentRef
+
+-- | A small, self-contained service list for tests that only care about
+-- @list_services@ echoing back whatever it is given, independent of the
+-- real production names asserted by 'hprop_registered_service_names'.
+testServiceNames :: [Text]
+testServiceNames = ["test.pkg.ServiceOne", "test.pkg.ServiceTwo"]

--- a/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/Reflection/DescriptorTable.hs
+++ b/cardano-rpc/test/cardano-rpc-test/Test/Cardano/Rpc/Reflection/DescriptorTable.hs
@@ -1,0 +1,152 @@
+-- | Unit coverage for 'Cardano.Rpc.Server.Internal.Reflection.DescriptorTable':
+-- the compiled-in proto descriptor table and its symbol index, which back
+-- the gRPC Server Reflection API.
+module Test.Cardano.Rpc.Reflection.DescriptorTable where
+
+import Cardano.Rpc.Server.Internal.Reflection.DescriptorTable
+
+import RIO
+
+import Data.ProtoLens (defMessage)
+import Data.Set qualified as Set
+
+import Hedgehog as H
+import Hedgehog.Extras qualified as H
+
+import Proto.Google.Protobuf.Descriptor
+import Proto.Google.Protobuf.Descriptor_Fields qualified as Descriptor
+
+-- | Every entry's own @dependency@ list only ever names other files in the
+-- same table: the tripwire for a future proto addition whose import was
+-- forgotten from the descriptor table's fixed entry list.
+hprop_descriptor_table_closed_under_dependency :: Property
+hprop_descriptor_table_closed_under_dependency = H.propertyOnce $ do
+  let knownFiles = Set.fromList $ fileNames descriptorTable
+  forM_ (fileNames descriptorTable) $ \fileName -> do
+    entry <- H.nothingFail $ lookupFile descriptorTable fileName
+    let dependencies = fileEntryDescriptor entry ^. Descriptor.dependency
+    H.annotateShow (fileName, dependencies)
+    H.assertWith dependencies (all (`Set.member` knownFiles))
+
+-- | @cardano/rpc/node.proto@ imports exactly @google/protobuf/empty.proto@,
+-- so its closure is itself plus that one file.
+hprop_transitive_closure_single_dependency :: Property
+hprop_transitive_closure_single_dependency = H.propertyOnce $ do
+  entries <- H.nothingFail $ transitiveClosure descriptorTable "cardano/rpc/node.proto"
+  map ((^. Descriptor.name) . fileEntryDescriptor) entries
+    === ["cardano/rpc/node.proto", "google/protobuf/empty.proto"]
+
+-- | @utxorpc/v1beta/query/query.proto@ imports both
+-- @google/protobuf/field_mask.proto@ and
+-- @utxorpc/v1beta/cardano/cardano.proto@; the closure is the file itself
+-- plus both, deduplicated, file first.
+hprop_transitive_closure_multiple_dependencies :: Property
+hprop_transitive_closure_multiple_dependencies = H.propertyOnce $ do
+  entries <- H.nothingFail $ transitiveClosure descriptorTable "utxorpc/v1beta/query/query.proto"
+  let names = map ((^. Descriptor.name) . fileEntryDescriptor) entries
+  H.annotateShow names
+  listToMaybe names === Just "utxorpc/v1beta/query/query.proto"
+  Set.fromList names
+    === Set.fromList
+      [ "utxorpc/v1beta/query/query.proto"
+      , "google/protobuf/field_mask.proto"
+      , "utxorpc/v1beta/cardano/cardano.proto"
+      ]
+
+-- | A file that is not in the table has no closure.
+hprop_transitive_closure_unknown_file_is_nothing :: Property
+hprop_transitive_closure_unknown_file_is_nothing = H.propertyOnce $ do
+  transitiveClosure descriptorTable "does/not/exist.proto" === Nothing
+
+-- | A service's own symbol resolves to the file that declares it.
+hprop_lookup_symbol_service :: Property
+hprop_lookup_symbol_service = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.Node" === Just "cardano/rpc/node.proto"
+
+-- | The reflection service can describe itself: its own symbol resolves to
+-- its own file, the same as any other registered service.
+hprop_lookup_symbol_reflection_service :: Property
+hprop_lookup_symbol_reflection_service = H.propertyOnce $ do
+  lookupSymbol descriptorTable "grpc.reflection.v1.ServerReflection"
+    === Just "grpc/reflection/v1/reflection.proto"
+
+-- | A method's symbol - @\<package\>.\<Service\>.\<Method\>@, using the
+-- method's exact proto name (@GetEra@, not the Haskell binding's
+-- @getEra@) - resolves to the same file as its service.
+hprop_lookup_symbol_method :: Property
+hprop_lookup_symbol_method = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.Node.GetEra" === Just "cardano/rpc/node.proto"
+
+-- | A top-level message symbol resolves to its file.
+hprop_lookup_symbol_message :: Property
+hprop_lookup_symbol_message = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.CurrentEra" === Just "cardano/rpc/node.proto"
+  lookupSymbol descriptorTable "grpc.reflection.v1.ServerReflectionRequest"
+    === Just "grpc/reflection/v1/reflection.proto"
+
+-- | A top-level enum symbol resolves to its file.
+hprop_lookup_symbol_enum :: Property
+hprop_lookup_symbol_enum = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.Era" === Just "cardano/rpc/node.proto"
+
+-- | An enum VALUE's symbol is scoped to the enum's own enclosing scope, not
+-- to the enum type: @conway@ resolves as @cardano.rpc.conway@, a sibling of
+-- @cardano.rpc.Era@, not @cardano.rpc.Era.conway@.
+hprop_lookup_symbol_enum_value :: Property
+hprop_lookup_symbol_enum_value = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.conway" === Just "cardano/rpc/node.proto"
+  lookupSymbol descriptorTable "cardano.rpc.Era.conway" === Nothing
+
+-- | A field's symbol is scoped to its message, using the field's exact
+-- proto name (@era@, snake_case as embedded in the descriptor).
+hprop_lookup_symbol_field :: Property
+hprop_lookup_symbol_field = H.propertyOnce $ do
+  lookupSymbol descriptorTable "cardano.rpc.CurrentEra.era" === Just "cardano/rpc/node.proto"
+
+-- | A oneof declaration's symbol is scoped to its message, same as a field.
+hprop_lookup_symbol_oneof :: Property
+hprop_lookup_symbol_oneof = H.propertyOnce $ do
+  lookupSymbol descriptorTable "utxorpc.v1beta.cardano.GovernanceAction.governance_action"
+    === Just "utxorpc/v1beta/cardano/cardano.proto"
+
+-- | An unrecognised symbol resolves to 'Nothing'.
+hprop_lookup_symbol_unknown_is_nothing :: Property
+hprop_lookup_symbol_unknown_is_nothing = H.propertyOnce $ do
+  lookupSymbol descriptorTable "no.such.Symbol" === Nothing
+
+-- | 'fileSymbolNames' recurses into nested messages, qualifying each level
+-- with a dot; into a nested enum's values, scoped to the CONTAINING MESSAGE
+-- rather than the enum type (@test.nested.Outer.RED@, not
+-- @test.nested.Outer.Color.RED@); and into a message's own fields and
+-- oneof declarations, scoped to the message itself the same way. None of
+-- the proto files actually served here declare a nested message or enum,
+-- so this is exercised against a small hand-built descriptor instead of a
+-- real compiled-in file.
+hprop_file_symbol_names_recurses_into_nested_messages :: Property
+hprop_file_symbol_names_recurses_into_nested_messages = H.propertyOnce $ do
+  fileSymbolNames nestedFixtureFile
+    === [ "test.nested.Outer"
+        , "test.nested.Outer.Inner"
+        , "test.nested.Outer.Color"
+        , "test.nested.Outer.RED"
+        , "test.nested.Outer.payload"
+        , "test.nested.Outer.kind"
+        ]
+ where
+  nestedFixtureFile :: FileDescriptorProto
+  nestedFixtureFile =
+    defMessage
+      & Descriptor.name .~ "test/nested.proto"
+      & Descriptor.package .~ "test.nested"
+      & Descriptor.messageType
+        .~ [ defMessage
+               & Descriptor.name .~ "Outer"
+               & Descriptor.nestedType .~ [defMessage & Descriptor.name .~ "Inner"]
+               & Descriptor.enumType
+                 .~ [ defMessage
+                        & Descriptor.name .~ "Color"
+                        & Descriptor.value .~ [defMessage & Descriptor.name .~ "RED"]
+                    ]
+               & Descriptor.field .~ [defMessage & Descriptor.name .~ "payload"]
+               & Descriptor.oneofDecl .~ [defMessage & Descriptor.name .~ "kind"]
+           ]


### PR DESCRIPTION
## Description

Implements the [gRPC Server Reflection Protocol](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) in cardano-rpc, so clients can discover the available services, methods and message schemas from a running node without local `.proto` files.

Closes #1295.

What this adds:

- Both `grpc.reflection.v1.ServerReflection` and the older `grpc.reflection.v1alpha.ServerReflection` are served, so current and legacy probes (grpcurl, Postman, buf, evans) both work.
- The protos are vendored from grpc v1.66.0 and generated through the existing `buf generate proto` pipeline.
- One handler core serves both versions: the two proto packages are structurally identical, so v1alpha requests and responses are bridged by transcoding across identical field numbers.
- A compiled-in descriptor table covers all nine proto files (the five cardano-rpc protos, two google well-known types, and the two reflection protos) and answers `file_by_filename` and `file_containing_symbol` with the full transitive dependency closure. A unit test asserts the table stays closed under the descriptors' `dependency` field, so adding a proto without updating the table fails the test suite.
- `list_services` derives its answer from the same service definitions that are registered in the server, so the advertised list cannot drift from what is actually served.
- The proto2 extension queries (`file_containing_extension`, `all_extension_numbers_of_type`) answer NOT_FOUND, since none of our protos use extensions.

Design note for reviewers: lookup failures are answered with an in-stream `ErrorResponse` and the RPC stays OK, as the protocol specifies. A request with an entirely unset `message_request` oneof is answered with an in-stream `INVALID_ARGUMENT` error response; Go's reference implementation terminates the RPC instead, so this is a deliberate, tested divergence.

Testing: the cardano-rpc unit test suite covers the descriptor closure, symbol lookup, error paths, the v1alpha bridge and the terminal stream element (all 123 tests pass under the repo's `-Werror` nix check). A wire-level integration test against a running node via cardano-testnet follows in a separate cardano-node PR, which will also add grpcurl to the devshell for manual probes.

---

<!--
Every PR needs a changelog fragment in `.changes/`.
Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
Run herald with nix: nix run github:input-output-hk/cardano-dev#herald

Interactive:
  herald new

Non-interactive:
  herald new -p cardano-api -k bugfix -d "Fix something" --pr 1234

See .herald.yml for full configuration.
-->

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff
- [ ] Changelog fragment added in `.changes/`

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
