### PR TITLE
Fix nix develop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -152,6 +152,8 @@
             # Packages in this repo
             p.cardano-api
             p.cardano-api-gen
+            p.cardano-rpc
+            p.cardano-wasm
             # Work around for issue created by our inability to register sublibs.
             # This package may need to be built and we need to make sure its dependencies
             # are included in `ghc-pkg list` (in particular `compact`)


### PR DESCRIPTION
Local packages were getting built when running `nix develop` (should not happen).

In haskell.nix's shellFor, the `packages` argument specifies which local packages are "being developed" and should not be pre-built. All other local packages in the project get pre-built and registered in ghc-pkg.

Since `cardano-wasm` and `cardano-rpc` were not specified in `shell.packages` in flake.nix, they were getting pre-built, which caused cardano-api to also get pre-built.